### PR TITLE
Fixed an issue where egg files were not copied to the variant directory.

### DIFF
--- a/bin/rez-egg-install_.py
+++ b/bin/rez-egg-install_.py
@@ -425,6 +425,7 @@ for egg_name, v in eggs.iteritems():
     distr, d = v
     egg_path = distr.location
     egg_dir = os.path.basename(egg_path)
+    egg_path = os.path.split(egg_path)[0]
     
     pkg_path = os.path.join(install_path, egg_name, d["version"])
     meta_path = os.path.join(pkg_path, ".metadata")    


### PR DESCRIPTION
Hi

I noticed this issue when I tried to install python-memcached with
rez-egg-install. The .egg, site.py and easy_install.pth files were not copied
to the package/variant directory.

It looks like the code copying the extracted package contents was using an
incorrect path.
