### PR TITLE
Removed argument from remove_least_suitable_variant call.

### DIFF
--- a/python/rez/rez_config.py
+++ b/python/rez/rez_config.py
@@ -1209,7 +1209,7 @@ class _Configuration:
 					elif (self.rctxt.verbosity == 2):
 						self.dump()
 
-				self.remove_least_suitable_variant(self.rctxt)
+				self.remove_least_suitable_variant()
 
 			else:
 


### PR DESCRIPTION
Looks like remove_least_suitable_variant does not take any arguments, but on this line one was passed in.
