### PR TITLE
Solver Max Fails

### DIFF
--- a/src/rez/cli/env.py
+++ b/src/rez/cli/env.py
@@ -38,6 +38,9 @@ def setup_parser(parser):
                         help="ignore packages released after the given time. "
                         "Supported formats are: epoch time (eg 1393014494), "
                         "or relative time (eg -10s, -5m, -0.5h, -10d)")
+    parser.add_argument("--max-fails", type=int, default=-1, dest="max_fails",
+                        help="Exit when the number of failed configuration "
+                        "attempts exceeds N.")
     parser.add_argument("-o", "--output", type=str, metavar="FILE",
                         help="store the context into an rxt file, instead of "
                         "starting an interactive shell. Note that this will "
@@ -79,7 +82,7 @@ def command(opts, parser):
                              package_paths=pkg_paths,
                              add_implicit_packages=(not opts.no_implicit),
                              add_bootstrap_path=(not opts.no_bootstrap),
-                             verbosity=opts.verbose)
+                             verbosity=opts.verbose, max_fails=opts.max_fails)
 
     success = (rc.status == "solved")
     if not success:

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -64,10 +64,23 @@ class _Printer(object):
 
 
 
+class SolverState(object):
+    """Represent the current state of the solver instance for use with a 
+    callback.
+    """
+    def __init__(self, num_solves, num_fails, phase):
+        self.num_solves = num_solves
+        self.num_fails = num_fails
+        self.phase = phase
+
+    def __str__(self):
+        return "solve #%d (%d fails so far): %s" \
+                    % (self.num_solves, self.num_fails, str(self.phase))
+
+
 class _Common(object):
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, str(self))
-
 
 
 class Reduction(_Common):
@@ -1518,8 +1531,7 @@ class Solver(_Common):
         if self.callback:
             phase = self._latest_unsolved_phase()
             if phase:
-                s = "solve #%d (%d fails so far): %s" \
-                    % (self.num_solves, self.num_fails, str(phase))
+                s = SolverState(self.num_solves, self.num_fails, phase)
                 keep_going = self.callback(s)
                 if not keep_going:
                     self.pr("solve stopped by user")


### PR DESCRIPTION
Implement a resolved context callback and `rez env` command line option to limit the resolution algorithm based on the number of failures.

This reimplements a useful feature that has been lost during the rez 2.0 effort.

Although on the mailing list we discussed the option of a 'max time' option, I think a maximum number of fails gives a more concrete and repeatable way of managing the resolve process.  A time sensitive process could make debugging harder, for example.

That said, this is not mutually exclusive - it would possible to implement a callback that support both max fails and max time if required.

This branch was taken from the 2.0 at the beginning of the week as it wasn't clear what the state of the other branches was.  I don't think it will introduce conflicts, but might require modifications with respect to the change from `settings` to `config`.
