### PR TITLE
Build Time Dirty Context

### DIFF
--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -291,6 +291,13 @@ class LocalSequentialBuildProcess(StandardBuildProcess):
     """A BuildProcess that sequentially builds the variants of the current
     package, on the local host.
     """
+
+    def _use_existing_context_file(self, rxt_file):
+        if os.path.exists(rxt_file):
+            if os.path.getmtime(self.package.metafile) < os.path.getmtime(rxt_file):
+                return True
+        return False
+
     def _build(self, install_path, build_path, clean=False, install=False):
         base_install_path = self._get_base_install_path(install_path)
         nvariants = max(self.package.num_variants, 1)
@@ -314,7 +321,8 @@ class LocalSequentialBuildProcess(StandardBuildProcess):
 
             # resolve build environment and save to file
             rxt_path = os.path.join(build_subdir, "build.rxt")
-            if os.path.exists(rxt_path):
+
+            if self._use_existing_context_file(rxt_path):
                 self._pr("Loading existing environment context...")
                 r = ResolvedContext.load(rxt_path)
             else:


### PR DESCRIPTION
Reusing the resolved context when building a package is a nice feature and something the developers here have asked for.  

However, it doesn't detect changes to the package.yaml file.  So you can change the requires and rebuild without picking up the changes.  This has caught me out a few times and lost a fair bit of time....

This small change checks the modified time of the package.yaml file and compares it with the resolved context modified time.  If the package.yaml file is newer than the resolved context file then we re-resolve the environment.

This will pick up a few false positives (changes to the description for example which don't affect the build time environment) but I believe it is worth it for the time lost due to mis-building.

BTW: I've noticed a few method and variable names that are quite short, for example `_pr`, `_prd` and `_hdr`.  Is there some legend you are using to know what these mean; can I rename them to something sensible?  It makes the code much harder to read.

I understand it might be for brevity, but they can still be aliased locally, for example:

```
def _a_longer_method_name(self):
    pass

def build(self):
    _pr = self._a_longer_method_name
    ...
```
