### PR TITLE
Add Build Target to CMake Plugin

### DIFF
--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -31,8 +31,11 @@ class CMakeBuildSystem(BuildSystem):
                      'make':        "Unix Makefiles",
                      'xcode':       "Xcode"}
 
+    build_targets = ["Debug", "Release", "RelWithDebInfo"]
+
     schema_dict = {
         "build_system":     Or(*build_systems.keys()),
+        "build_target":     Or(*build_targets),
         "cmake_args":       [basestring]}
 
     @classmethod
@@ -49,9 +52,8 @@ class CMakeBuildSystem(BuildSystem):
 
     @classmethod
     def bind_cli(cls, parser):
-        build_targets = ["Debug", "Release"]
         parser.add_argument("-b", "--build-target", dest="build_target",
-                            type=str, choices=build_targets, default="Release",
+                            type=str, choices=cls.build_targets, default="Release",
                             help="set the build target.")
         parser.add_argument("--bs", "--build-system", dest="build_system",
                             type=str, choices=cls.build_systems.keys(),
@@ -67,7 +69,8 @@ class CMakeBuildSystem(BuildSystem):
             build_args=build_args,
             child_build_args=child_build_args)
 
-        self.build_target = opts.build_target
+        self.build_target = opts.build_target \
+            or self.package.config.plugins.build_system.cmake.build_target
         self.cmake_build_system = opts.build_system \
             or self.package.config.plugins.build_system.cmake.build_system
         if self.cmake_build_system == 'xcode' \

--- a/src/rezplugins/build_system/rezconfig
+++ b/src/rezplugins/build_system/rezconfig
@@ -3,6 +3,10 @@ cmake:
     # eclipse, make, xcode and codeblocks.
     build_system: make
 
+    # The name of the CMake build target to use, valid options are Debug, 
+    # Release and RelWithDebInfo.
+    build_target: Release
+
     # A list of default arguments to be passed to the cmake binary.
     cmake_args:
     - '-DCMAKE_SKIP_RPATH=1'


### PR DESCRIPTION
Update the CMake build system to support the RelWithDebInfo build target.

This option is configurable via a rezconfig file or the command line.  

The current default in the config file is "Release".
