### PR TITLE
Extend the CMAKE_MODULE_PATH Special Case

### DIFF
--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -585,6 +585,8 @@ def convert_old_commands(commands, annotate=True):
             var, value = cmd.split(' ', 1)[1].split('=', 1)
             if value.startswith('"') and value.endswith('"'):
                 value = value[1:-1]
+            elif value.startswith("'") and value.endswith("'"):
+                value = value[1:-1]
 
             if var == "CMAKE_MODULE_PATH":
                 value = value.replace("';'", os.pathsep).replace(';', os.pathsep)


### PR DESCRIPTION
This change extends the logic  in `convert_old_commands` to improve backwards compatibility.

The `CMAKE_MODULE_PATH` variable is `;` separated, however as noted in the [comment in Rez 1](https://github.com/nerdvegas/rez/blob/master/python/rez/rez_config.py#L2056-L2062) it must be surrounded by quotes to make it through the bash commands.  

Although Rez 1 provided logic to translate `:` separated `CMAKE_MODULE_PATH` variables to be `;` separated, we did not (for some reason) use that, and I wonder if others are in the same position.  

As a result nearly all of our packages include:

```
- export CMAKE_MODULE_PATH=!ROOT!/cmake';'$CMAKE_MODULE_PATH
```

Therefore, I'd like to propose a small change to `convert_old_commands` that allows it to replace `';'` with `:` and improve backwards compatibilty.
