### PR TITLE
Fix Validate Config Bug

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -49,8 +49,8 @@ class Setting(object):
             return self.config.overrides[self.key]
         # next, env-var
         if not self.config.locked:
-            value = os.getenv(self._env_var_name)
-            if value is not None:
+            value = os.getenv(self._env_var_name, '')
+            if value.strip():
                 return self._parse_env_var(value)
         # next, data unchanged
         if data is not None:


### PR DESCRIPTION
The `_validate` method could fail if a matching environment variable is found, but the variable has no value.

This change ensures the environment variable has a non-empty-string value before continuing.
