### PR TITLE
First version of the variants sorting algorithm 

### DIFF
--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -82,21 +82,24 @@ class _Printer(object):
 
 class VariantSorter(object):
     """
-    Example of the variant sorting algorithm  see test cases for more
+    Example of the variant sorting algorithm see test cases in tests_solver for more
 
     #initial order
 
-    #0    [ foo-1 , bar-1 , zex-1, bah-1 ]
-    #1    [ foo-1 , eek-3 , zex-2, bah-2 ]
-    #2    [ foo-1 , bar-3 , zex-3, bah-3 ]
-    #3    [ foo-3 , eek-1 , zex-4, bah-4 ]
-    #4    [ foo-1 , bar-2 , zex-5, bah-5 ]
-    #5    [ foo-4 , bar-4 , zex-1, bah-6 ]
-    #6    [ foo-1 , eek-1 , zex-4, bah-4 ]
-    #7    [ bar-4 , bah-1 ]
-    #8    [ bar-2 , bah-2, foo-1 ]
-    #9    [ bar-4 , bah-1, foo-2 ]
-    #10   [ bar-4 , bah-2 ]
+    #0    [ foo-1, bar-1, zex-1, bah-1 ]
+    #1    [ foo-1, eek-3, zex-2, bah-2 ]
+    #2    [ foo-1, bar-3, zex-3, bah-3 ]
+    #3    [ foo-3, zex-4, bah-4, eek-4 ]
+    #4    [ foo-1, bar-2, zex-5, bah-5 ]
+    #5    [ foo-4, bar-4, zex-1, bah-6 ]
+    #6    [ foo-3, eek-1, zex-4, bah-4 ]
+    #7    [ bar-4, bah-1 ]
+    #8    [ bar-2, bah-2 foo-1 ]
+    #9    [ bar-4, bah-1, foo-2 ]
+    #10   [ bar-4, bah-2 ]
+    #11   [ foo-3, zex-4, bah-2, eek-5 ]
+    #12   [ foo-1 , eek-1, zex-4, bah-4 ]
+    #13   [ bar-3, bah-4 ]
 
 
     # request eek zex foo
@@ -104,76 +107,123 @@ class VariantSorter(object):
     We calculate the weights (The weight to each variant is given by the intersection with the fam_requires )
       and separate them in variant slices of the same weight
                                              W
-    #1    [ foo-1 , eek-3 , zex-2, bah-2 ]   3
-    #3    [ foo-3 , eek-1 , zex-4, bah-4 ]   3
-    #6    [ foo-1 , eek-1 , zex-4, bah-4 ]   3
+    #1    [ foo-1, eek-3, zex-2, bah-2 ]   3
+    #3    [ foo-3, zex-4, bah-4, eek-4 ]   3
+    #6    [ foo-3, eek-1, zex-4, bah-4 ]   3
+    #11   [ foo-3, zex-4, bah-2, eek-5 ]   3
+    #12   [ foo-1, eek-1, zex-4, bah-4 ]   3
 
-    #0    [ foo-1 , bar-1 , zex-1, bah-1 ]   2
-    #2    [ foo-1 , bar-3 , zex-3, bah-3 ]   2
-    #4    [ foo-1 , bar-2 , zex-5, bah-5 ]   2
-    #5    [ foo-4 , bar-4 , zex-1, bah-6 ]   2
+    #0    [ foo-1, bar-1 , zex-1, bah-1 ]   2
+    #2    [ foo-1, bar-3 , zex-3, bah-3 ]   2
+    #4    [ foo-1, bar-2 , zex-5, bah-5 ]   2
+    #5    [ foo-4, bar-4 , zex-1, bah-6 ]   2
 
-    #8    [ bar-2 , bah-2, foo-1 ]           1
-    #9    [ bar-4 , bah-1, foo-2 ]           1
+    #8    [ bar-2, bah-2, foo-1 ]           1
+    #9    [ bar-4, bah-1, foo-2 ]           1
 
-    #7    [ bar-4 , bah-2 ]                  0
-    #10   [ bar-4 , bah-1 ]                  0
+    #7    [ bar-4, bah-1 ]                  0
+    #10   [ bar-4, bah-2 ]                  0
+    #13   [ bar-3, bah-4 ]                  0
 
     now we sort the different slices by the index (column of the smaller index in which the fam_requires appear)
        respecting the order of the request)
 
-    We start sorting the lowest weight first and adding back to the final list of variants
+    We start sorting the lowest weight first and add back to the final list of variants
 
-    Sort weight 0 , there are not fam names overlapping with these variants so the sorted() will be applied
-                    which cause to sort them by 'default' for the position first by column 0  and then by 1
+    Sorting variant slices of weight 0
+    -------------
+    There are not fam names overlapping with fam_requires fort these variants so the sorted()
+                    is applied which cause to sort them by 'default. That't it by column (0, 1)
 
-    #10   [ bar-4 , bah-1 ]                  0
-    #7    [ bar-4 , bah-2 ]                  0
+    #13   [ bar-3, bah-4 ]                  0
+    #7    [ bar-4, bah-1 ]                  0
+    #10   [ bar-4, bah-2 ]                  0
 
+
+    Sorting variant slices of weight 1
+    -------------
+    positions_of_package_request_in_variant = {foo=2}
+      - No requested packages are in the same column (There is no ambiguity to sort them, so no need to keep splitting)
     Sort weight 1 by columns (2, 0,  1)        # lowest of foo (2), and default 0, 1
 
-    #8    [ bar-2 , bah-2, foo-1 ]           1
-    #9    [ bar-4 , bah-1, foo-2 ]           1
+    #8    [ bar-2, bah-2, foo-1 ]           1
+    #9    [ bar-4, bah-1, foo-2 ]           1
 
+    Sorting variant slices of weight 2
+    --------------
+    positions_of_package_request_in_variant = {foo=0, zex=2}
+       - No requested packages are in the same column (There is no ambiguity to sort them, so no need to keep splitting)
+       - Sort them as the appear in the request (eek zex foo)
     Sort weight 2  by columns  (2 , 0 , 1, 3)   # lowest of zex (2), lowest of foo (0) and default 1, 3
 
+    #0    [ foo-1, bar-1, zex-1, bah-1 ]   2
+    #5    [ foo-4, bar-4, zex-1, bah-6 ]   2
+    #2    [ foo-1, bar-3, zex-3, bah-3 ]   2
+    #4    [ foo-1, bar-2, zex-5, bah-5 ]   2
 
-    #0    [ foo-1 , bar-1 , zex-1, bah-1 ]   2
-    #5    [ foo-4 , bar-4 , zex-1, bah-6 ]   2
-    #2    [ foo-1 , bar-3 , zex-3, bah-3 ]   2
-    #4    [ foo-1 , bar-2 , zex-5, bah-5 ]   2
 
-    Sort weight 3 by columns  (1, 2, 0, 3 )   # lowest of eek (1), lowest of zex(2), lowest of foo (0) and default 3
+    Sorting variant slices of weight 3
+    --------------
+    positions_of_package_request_in_variant = {foo=0, zex=1, eek=1}
+       - eek and zex appear in the same column, we need to give more weight to the one that appear first in fam_requires
+         ( eek, zex, foo), so invert the request list and use the new weight  or len(request_list) - fam_index)
+            (foo=0, zex=1, eek=2)
 
-    #6    [ foo-1 , eek-1 , zex-4, bah-4 ]   3
-    #3    [ foo-3 , eek-1 , zex-4, bah-4 ]   3
-    #1    [ foo-1 , eek-3 , zex-2, bah-2 ]   3
+            Intersection weight 3, position weight 1
+            #3    [ foo-3, zex-4, bah-4, eek-4 ]      3,1
+            #11   [ foo-3, zex-4, bah-2, eek-5 ]      3,1
 
-    so final list of variants sorted
+            intersection weight 3, position weight 2
+            #6    [ foo-3, eek-1, zex-4, bah-4 ]      3,2
+            #1    [ foo-1, eek-3, zex-2, bah-2 ]      3,2
+            #12   [ foo-1, eek-1, zex-4, bah-4 ]      3,2
+
+        ------
+
+            Sort Intersection weight 3, position weight 1
+               recompute positions_of_package_request_in_variant = {foo=0, zex=1, eek=3}
+               - No requested packages are in the same column (now there is no ambiguity to sort them, no need to split)
+               Sort weight 3 position weight 1 by columns  (3, 1, 0, 2)   # lowest of eek (3), lowest of zex(1),
+                                                                            lowest of foo (0) and default 2
+            #3    [ foo-3, zex-4, bah-4, eek-4 ]   3,1
+            #11   [ foo-3, zex-4, bah-2, eek-5 ]   3,1
+
+
+            Sort Intersection weight 3, position weight 2
+               recompute positions_of_package_request_in_variant = {foo=0, zex=2, eek=1}
+              - No requested packages are in the same column (now there is no ambiguity to sort them, no need to split)
+               Sort weight 3 position weight 2 by columns  (1, 2, 0, 3)  # lowest of eek (1), lowest of zex(2),
+                                                                           lowest of foo (0) and default 3
+
+            #12   [ foo-1, eek-1, zex-4, bah-4 ]   3,2
+            #6    [ foo-3, eek-1, zex-4, bah-4 ]   3,2
+            #1    [ foo-1, eek-3, zex-2, bah-2 ]   3,2
+
+
+    final list of variants sorted
 
                                              w      new index
-    #10   [ bar-4 , bah-1 ]                  0          #0
-    #7    [ bar-4 , bah-2 ]                  0          #1
-    #8    [ bar-2 , bah-2, foo-1 ]           1          #2
-    #9    [ bar-4 , bah-1, foo-2 ]           1          #3
-    #0    [ foo-1 , bar-1 , zex-1, bah-1 ]   2          #4
-    #5    [ foo-4 , bar-4 , zex-1, bah-6 ]   2          #5
-    #2    [ foo-1 , bar-3 , zex-3, bah-3 ]   2          #6
-    #4    [ foo-1 , bar-2 , zex-5, bah-5 ]   2          #7
-    #6    [ foo-1 , eek-1 , zex-4, bah-4 ]   3          #8
-    #3    [ foo-3 , eek-1 , zex-4, bah-4 ]   3          #9
-    #1    [ foo-1 , eek-3 , zex-2, bah-2 ]   3          #10
 
-    The solver should start consuming from the #10 which is our proffered and it would working its way up if that
+    #13   [ bar-3, bah-4 ]                  0           #0
+    #7    [ bar-4, bah-1 ]                  0           #1
+    #10   [ bar-4, bah-2 ]                  0           #2
+    #8    [ bar-2, bah-2, foo-1 ]           1           #3
+    #9    [ bar-4, bah-1, foo-2 ]           1           #4
+    #0    [ foo-1, bar-1, zex-1, bah-1 ]   2            #5
+    #5    [ foo-4, bar-4, zex-1, bah-6 ]   2            #6
+    #2    [ foo-1, bar-3, zex-3, bah-3 ]   2            #7
+    #4    [ foo-1, bar-2, zex-5, bah-5 ]   2            #8
+    #3    [ foo-3, zex-4, bah-4, eek-4 ]   3,1          #9
+    #11   [ foo-3, zex-4, bah-2, eek-5 ]   3,1          #10
+    #12   [ foo-1, eek-1, zex-4, bah-4 ]   3,2          #11
+    #6    [ foo-3, eek-1, zex-4, bah-4 ]   3,2          #12
+    #1    [ foo-1, eek-3, zex-2, bah-2 ]   3,2          #13
+
+
+    The solver should start consuming from the #1 which is our preferred and it would work its way up if the current
     does not resolve
 
     The order in which the family names  appear in the request would also influence the package selection
-
-    if a packages x has a variant  # 0  [foo, eek]
-                                   # 1  [bar, ekk]
-    A request "x bar foo" where both have the same weight will end up prioritizing variant #1
-    A request "x foo bar" where both have the same weight will end up prioritizing variant #0
-
     """
 
     def __init__(self, variants, package_requests):
@@ -184,70 +234,121 @@ class VariantSorter(object):
         """
         Sort the variant list pushing the most preferable to the end of the variants list
         the solver then would consume the last one first so if that satisfies all the requirements then we
-        get the 'preferred in terms of the requested packages, position on the variant list, and higher version
+        get the 'preferred in terms of the requested packages, position on the variant list,and higher version
         """
-        return self._sort_variants_by_weight
+        weighted_dic = self._weight_variants_against_family_request()
+        return self._sort_variants_by_weight(weighted_dic)
 
-    @property
-    def _sort_variants_by_weight(self):
-        """
-        Separate the variants by weight then sort the sliced list of variants of the same weight and
-           then return a list with the weighted variants_slices sorted
-        The weight to each variant is given by the intersection with the fam_requires
-            The more specific the variant is to the request then is the one we want the solver step to evaluate first
-        """
 
-        weighted_dic = self._weight_variants_against_package_request()
+    def _sort_variants_by_weight(self, weighted_dict):
+        """
+        Iterates the variant slices for each weight passed on weighted_dict and sort the individual variants slices
+
+        @param weighted_dict: a dic with the weight as the key and a variant_slice on the values
+        @return a list with the weighted variants_slices sorted
+        """
 
         ordered_variants = []
-        for weight in sorted(weighted_dic.keys()):  # Sorted so we start adding the one with the least weight first
-            variants_slice = weighted_dic[weight]
+        for weight in sorted(weighted_dict.keys()):  # Sorted, so we start adding the one with the least weight first
+            variants_slice = weighted_dict[weight]
             variants_sorted_by_position = self._sort_variant_slice_by_position(variants_slice)
             ordered_variants.extend(variants_sorted_by_position)
 
         return ordered_variants
 
-    def _weight_variants_against_package_request(self):
+    def _weight_variants_against_family_request(self):
         """
         Group the variants of the same weight
-        Returns a dic with the weight as the key a list of variants of the that weight
+        The weight to each variant is given by the intersection with the fam_requires
+
+        @return a dict with weight as the key and a list of variants in the value
         """
         fam_requires_set = set(self.fam_requires)
-        weight_dict = {}
+        weighted_dict = {}
         for variant in self.variants:
             weight = len(self.intersect_variant_with_package_request(fam_requires_set, variant))
-            weight_dict.setdefault(weight, []).append(variant)
+            weighted_dict.setdefault(weight, []).append(variant)
 
-        return weight_dict
+        return weighted_dict
 
     def intersect_variant_with_package_request(self, fam_requires_set, variant):
         """
-        Calculates the weight of a variant by intersecting the set with the fam_requires
+        Calculates the intersection of a variant and the fam_requires
         """
         fams = extract_family_name_from_requirements(variant)
-        weight = set(fams) & fam_requires_set
-        return weight
+        intersection_set = set(fams) & fam_requires_set
+        return intersection_set
+
 
     def _sort_variant_slice_by_position(self, variants_slice):
         """
-        Order a variant_slice by the index position in which fam names of the fam_request apears on the variants_slice
+        Order a variant_slice by the index position in which fam names of the fam_request appears on the variants_slice
+        @param variants_slice: a list of variants of the same intersecting weight
+        """
+        fam_to_index_map = self.find_lowest_index_of_each_package_family_in_variants(variants_slice)
+
+        # Check that there are no family names with the same index if they are we have to split them taking into account
+        # the order in which they appear in the package request
+        if self.is_sorting_ambiguous(fam_to_index_map):
+            # we need to keep splitting the variants_slice, but this time we use the position in the packages mapped
+            # to the order of the fam_requires to weight the packages
+            weighted_dic =self._weight_variants_against_family_position_in_variant(variants_slice, fam_to_index_map)
+            return self._sort_variants_by_weight(weighted_dict=weighted_dic)
+        else:
+             return self._apply_sorting(fam_to_index_map, variants_slice)
+
+    def is_sorting_ambiguous(self, fam_to_index_map):
+        """
+        checks if there is more than one repeated value in fam_to_index_map, which means that two requested family
+         names appear in the same column of a variants_slice
+
+         @param fam_to_index_map: a dict containing the lowest index fam names appear in a variant slice
+        """
+        return len(set(fam_to_index_map.values())) < len(fam_to_index_map.values())
+
+    def _weight_variants_against_family_position_in_variant(self, variants_slice, fam_to_index_map):
+        """
+        Group the variants_slice that of the same weight
+        variants_slice contains a list of ambiguous
+        Weight is given to the the variant based on the (inverse) order of the fam_requires.
+         package_request   [ foo, eek , bla ] --> weight foo=2, eek=1 bla=0
+
+        To assign a variant to a weight group we check if the variant family index is the same as the lowest index that
+         family appears on the the variants_slice
+
+        @param variants_slice: a list of variants with the same intersecting weight
+        @param fam_to_index_map: a dict containing the lowest index fam names appear in a variant slice
+        @return a dict with weight as the key and a list of variants_slice in the value
         """
 
-        # TODO We might need the longest/shortest instead of the length of the first variant
-        # for the asymmetric case of the same weight
+        weighted_dict = {}
+        for variant in variants_slice:
+            fams = extract_family_name_from_requirements(variant)
+            for fam in self.fam_requires:
+                if fam in fams and fams.index(fam) == fam_to_index_map[fam]:
+                    weighted_dict.setdefault(len(self.fam_requires) - self.fam_requires.index(fam), []).append(variant)
+                    break
 
-        fam_to_index_map = self.find_lowest_index_of_each_package_family_in_variants(variants_slice)
-        ordered_indexes_to_order_by = self._get_index_order_list(fam_to_index_map, len(variants_slice[0]))
+        return weighted_dict
 
-        if ordered_indexes_to_order_by:
-            return sorted(variants_slice, key=itemgetter(*ordered_indexes_to_order_by))
-        else:
-            return sorted(variants_slice)
 
+    def _apply_sorting(self, fam_to_index_map, variants_slice):
+
+        """
+        apply the sorting by columns in a variants slice
+
+        @param variants_slice: a list of variants with the same intersecting weight
+        @param fam_to_index_map: a dict containing the lowest index fam names appear in a variant slice
+
+        @return:
+        """
+        minimum_length_of_variants = min([len(variant) for variant in variants_slice])
+        ordered_indexes_to_order_by = self._get_index_order_list(fam_to_index_map, minimum_length_of_variants)
+
+        return sorted(variants_slice, key=itemgetter(*ordered_indexes_to_order_by))
 
     def _get_index_order_list(self, fam_to_index_map, variant_list_length):
         """
-
         Returns a list of the ordered indexes, first the smallest indexes the fam in the fam_requires appears
          and then padded with the left to right order (as they appear on the list)
 
@@ -257,33 +358,44 @@ class VariantSorter(object):
 
                 returns ( 2, 3 , 0, 1, 4)
 
-        @param fam_to_index_map: a dictionary with the lowest index a family appears on the variants_slice list
-        @param variant_list_length: The length of the list
-        @return: an ordered list of indexes
+        @param fam_to_index_map: a dict containing the lowest index fam names appear in a variant slice
+        @param variant_list_length: The shorted length a list in the variants_slice
+        @return: an ordered list of indexes based on the weight
         """
+        # get the indexes as they appear in the request
         ordered_indexes = [fam_to_index_map[fam] for fam in self.fam_requires if fam in fam_to_index_map]
 
         if ordered_indexes:
-            # Complete the list so we also sort the rest of the columns not named in fam_requires
+            # Complete the list so we also sort the rest of the columns
+            # not named in fam_requires by default decreasing order
             for index in xrange(variant_list_length):
                 if index not in ordered_indexes:
                     ordered_indexes.append(index)
         else:
+            # if no family names appear on the request we give them a default decreasing order
             ordered_indexes = range(0, variant_list_length)
 
         return ordered_indexes
 
-
     def find_lowest_index_of_each_package_family_in_variants(self, variants_slice):
         """
-        Returns a dictionary with the smallest index that a family name  appear on any of the variants
-        Note: Variants can appear in more than one position (column)
+        Returns a dictionary with the smallest index that a family name of the package request
+        appears on any of the variants
+
+        @param variants_slice: a list of variants with the same intersecting weight
+        @return: a dict containing the lowest index fam names appear in a variant slice
+
+        i.e request [foo eek zex ]   variants [ bla foo zex eek ]
+                                              [ bla eek zex     ]
+                                              [ foo zex
+            return foo=0 eek=1 zex=1
+
         """
         fam_to_index_map = {}
         for variant in variants_slice:
             fams = extract_family_name_from_requirements(variant)
             for fam in fams:
-                if fam not in fam_to_index_map or fam_to_index_map[fam] > fams.index(fam):
+                if fam in self.fam_requires and (fam not in fam_to_index_map or fam_to_index_map[fam] > fams.index(fam)):
                     fam_to_index_map[fam] = fams.index(fam)
         return fam_to_index_map
 

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -396,7 +396,7 @@ class VariantSorter(object):
                     # as the new key to sort by VersionRange
                     fam_requires = self._get_list_of_key_by_positional_weight(variants_slice)
 
-                ordered_variant_list.extend(self._sort_variants_by_version_range(tied_variants, fam_requires))
+                ordered_variant_list.extend(self._sort_variants_by_version_range(tied_variants, fam_requires[:]))
 
         return ordered_variant_list
 

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -657,7 +657,8 @@ class _PackageVariantList(_Common):
                                              index=var.index,
                                              userdata=var.resource_handle)
                     loaded_variants.append(variant)
-                loaded_variants = sorted(loaded_variants, key=lambda v: v.index)
+                # sort all now by version and variant
+                loaded_variants = sorted(loaded_variants, key=lambda v: (v.version, v.index))
 
             if loaded_variants:
                 self.variants = list(merge(self.variants, loaded_variants))

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -426,16 +426,20 @@ class VariantSorter(object):
         @return: a VersionRange - The version range of the package if it exists, the exact VersionRange if the package
         is a conflict, or the 'any VersionRange' if the the family is not found in the variant
         """
-        for requirement in variant:
-            if requirement.name == fam_name:
-                if not requirement.conflict:
-                    return requirement.range
-                else:
-                    # This stack on top of VersionRange("") when sorted
-                    # TODO any other more meaningful VersionRange we know is going to be on top when we sort by range?
-                    return VersionRange("==")
+        matching_fam_names_in_variant = [req for req in variant if req.name == fam_name]
+        if matching_fam_names_in_variant:
+            # Get the highest version if thre is more than one matching name
+            requirement = sorted(matching_fam_names_in_variant).pop()
+            if not requirement.conflict:
+                return requirement.range
+            else:
+                # This stack on top of VersionRange("") when sorted
+                # TODO any other more meaningful VersionRange we know is going to be on top when we sort by range?
+                return VersionRange("==")
+        else:
+            return VersionRange("")
 
-        return VersionRange("")
+
 
     def group_by_number_of_packages(self, variants_slice):
         """

--- a/src/rez/tests/data/solver/packages/asymmetric_variants/package.py
+++ b/src/rez/tests/data/solver/packages/asymmetric_variants/package.py
@@ -1,0 +1,9 @@
+name = 'asymmetric_variants'
+version = '1'
+authors = ["oops"]
+uuid = "asymmetric_variants"
+description = "package with asymmetric variants"
+variants = [
+    ["bah-2.0.0"],
+    ["eek-1.0.1", "bah-1.0.0"],
+    ["eek-1.0.0"]]

--- a/src/rez/tests/data/solver/packages/asymmetric_variants/package.py
+++ b/src/rez/tests/data/solver/packages/asymmetric_variants/package.py
@@ -1,7 +1,7 @@
 name = 'asymmetric_variants'
 version = '1'
 authors = ["oops"]
-uuid = "asymmetric_variants"
+uuid = "dfd5e678-846a-4e8f-94d2-fc5927c17648"
 description = "package with asymmetric variants"
 variants = [
     ["bah-2.0.0"],

--- a/src/rez/tests/data/solver/packages/bah/1.0.0/package.py
+++ b/src/rez/tests/data/solver/packages/bah/1.0.0/package.py
@@ -1,0 +1,5 @@
+name = 'bah'
+version = '1.0.0'
+authors = ["bah"]
+uuid = "a01e3fe0-c009-4413-b681-a7bb1ce967d7"
+description = "bah thing"

--- a/src/rez/tests/data/solver/packages/bah/1.0.1/package.py
+++ b/src/rez/tests/data/solver/packages/bah/1.0.1/package.py
@@ -1,0 +1,6 @@
+name = 'bah'
+version = '1.0.1'
+authors = ["bah"]
+uuid = "a01e3fe0-c009-4413-b681-a7bb1ce967d7"
+description = "bah thing"
+

--- a/src/rez/tests/data/solver/packages/bah/2.0.0/package.py
+++ b/src/rez/tests/data/solver/packages/bah/2.0.0/package.py
@@ -1,0 +1,6 @@
+name = 'bah'
+version = '2.0.0'
+authors = ["bah"]
+uuid = "a01e3fe0-c009-4413-b681-a7bb1ce967d7"
+description = "bah thing"
+

--- a/src/rez/tests/data/solver/packages/bar/4.5.3/package.py
+++ b/src/rez/tests/data/solver/packages/bar/4.5.3/package.py
@@ -1,0 +1,6 @@
+name = 'bar'
+version = '4.5.3'
+authors = ["bar"]
+uuid = "4e0d17db-b270-4667-897e-4f4b83bdaf7d"
+description = "bar thing"
+

--- a/src/rez/tests/data/solver/packages/bar/4.8.2/package.py
+++ b/src/rez/tests/data/solver/packages/bar/4.8.2/package.py
@@ -1,0 +1,6 @@
+name = 'bar'
+version = '4.8.2'
+authors = ["bar"]
+uuid = "4e0d17db-b270-4667-897e-4f4b83bdaf7d"
+description = "bar thing"
+

--- a/src/rez/tests/data/solver/packages/bar/4.8.5/package.py
+++ b/src/rez/tests/data/solver/packages/bar/4.8.5/package.py
@@ -1,0 +1,6 @@
+name = 'bar'
+version = '4.8.5'
+authors = ["bar"]
+uuid = "4e0d17db-b270-4667-897e-4f4b83bdaf7d"
+description = "bar thing"
+

--- a/src/rez/tests/data/solver/packages/eek/1.0.0/package.py
+++ b/src/rez/tests/data/solver/packages/eek/1.0.0/package.py
@@ -1,0 +1,5 @@
+name = 'eek'
+version = '1.0.0'
+authors = ["eek"]
+uuid = "0c077c54-5968-4fad-aa6e-43fac9805c86"
+description = "eek thing"

--- a/src/rez/tests/data/solver/packages/eek/1.0.1/package.py
+++ b/src/rez/tests/data/solver/packages/eek/1.0.1/package.py
@@ -1,0 +1,6 @@
+name = 'eek'
+version = '1.0.1'
+authors = ["eek"]
+uuid = "0c077c54-5968-4fad-aa6e-43fac9805c86"
+description = "eek thing"
+

--- a/src/rez/tests/data/solver/packages/eek/2.0.0/package.py
+++ b/src/rez/tests/data/solver/packages/eek/2.0.0/package.py
@@ -1,0 +1,6 @@
+name = 'eek'
+version = '2.0.0'
+authors = ["eek"]
+uuid = "0c077c54-5968-4fad-aa6e-43fac9805c86"
+description = "eek thing"
+

--- a/src/rez/tests/data/solver/packages/foo/1.0.0/foo/__init__.py
+++ b/src/rez/tests/data/solver/packages/foo/1.0.0/foo/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+__version__ = os.getenv("REZ_FOO_VERSION")
+
+def report():
+    return "hello from foo-%s" % __version__

--- a/src/rez/tests/data/solver/packages/foo/1.0.0/package.py
+++ b/src/rez/tests/data/solver/packages/foo/1.0.0/package.py
@@ -1,0 +1,6 @@
+name = 'foo'
+version = '1.0.0'
+authors = ["joe.bloggs"]
+uuid = "8031b8a1b1994ea8af86376647fbe530"
+description = "foo thing"
+

--- a/src/rez/tests/data/solver/packages/foo/1.0.0/rezbuild.py
+++ b/src/rez/tests/data/solver/packages/foo/1.0.0/rezbuild.py
@@ -1,0 +1,5 @@
+
+def build(source_path, build_path, install_path, targets):
+
+    pass
+

--- a/src/rez/tests/data/solver/packages/foo/1.1.0/foo/__init__.py
+++ b/src/rez/tests/data/solver/packages/foo/1.1.0/foo/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+__version__ = os.getenv("REZ_FOO_VERSION")
+
+def report():
+    return "hello from foo-%s" % __version__

--- a/src/rez/tests/data/solver/packages/foo/1.1.0/package.py
+++ b/src/rez/tests/data/solver/packages/foo/1.1.0/package.py
@@ -1,0 +1,6 @@
+name = 'foo'
+version = '1.1.0'
+authors = ["joe.bloggs"]
+uuid = "8031b8a1b1994ea8af86376647fbe530"
+description = "foo thing"
+

--- a/src/rez/tests/data/solver/packages/foo/1.1.0/rezbuild.py
+++ b/src/rez/tests/data/solver/packages/foo/1.1.0/rezbuild.py
@@ -1,0 +1,5 @@
+
+def build(source_path, build_path, install_path, targets):
+
+    pass
+

--- a/src/rez/tests/data/solver/packages/multi_packages_variant_sorted/package.py
+++ b/src/rez/tests/data/solver/packages/multi_packages_variant_sorted/package.py
@@ -1,0 +1,24 @@
+name = 'multi_packages_variant_sorted'
+version = '1'
+authors = ["oops"]
+uuid = "5e0b535e-a32b-4825-ae54-f88589f4bd79"
+description = "package with multi packages in variants sorted"
+variants = [
+    ["bah-1.0.0", "eek-1.0.0" ],
+    ["bah-1.0.0", "eek-1.0.1" ],
+    ["bah-1.0.0", "eek-2.0.0" ],
+    ["bah-1.0.1", "eek-1.0.0" ],
+    ["bah-1.0.1", "eek-1.0.1" ],
+    ["bah-1.0.1", "eek-2.0.0" ],
+    ["bah-2.0.0", "eek-1.0.0" ],
+    ["bah-2.0.0", "eek-1.0.1" ],
+    ["bah-2.0.0", "eek-2.0.0" ],
+    ["bah-1.0.0", "bar-4.5.3" ],
+    ["bah-1.0.0", "bar-4.8.2" ],
+    ["bah-1.0.0", "bar-4.8.5" ],
+    ["bah-1.0.1", "bar-4.5.3" ],
+    ["bah-1.0.1", "bar-4.8.2" ],
+    ["bah-1.0.1", "bar-4.8.5" ],
+    ["bah-2.0.0", "bar-4.5.3" ],
+    ["bah-2.0.0", "bar-4.8.2" ],
+    ["bah-2.0.0", "bar-4.8.5" ]]

--- a/src/rez/tests/data/solver/packages/multi_packages_variant_unsorted/package.py
+++ b/src/rez/tests/data/solver/packages/multi_packages_variant_unsorted/package.py
@@ -1,0 +1,26 @@
+name = 'multi_packages_variant_unsorted'
+version = '1'
+authors = ["oops"]
+uuid = "i73c9a11c-fa41-482b-bb38-867c7e19c6f9"
+description = "package with multi packages in variants unsorted"
+variants = [
+    ["bah-2.0.0", "bar-4.8.2" ],
+    ["bah-1.0.0", "eek-1.0.1" ],
+    ["bah-1.0.1", "eek-1.0.0" ],
+    ["bah-2.0.0", "bar-4.8.5" ],
+    ["bah-1.0.0", "eek-1.0.0" ],
+    ["bah-2.0.0", "eek-1.0.0" ],
+    ["bah-1.0.1", "bar-4.8.2" ],
+    ["bah-1.0.1", "eek-1.0.1" ],
+    ["bah-1.0.1", "bar-4.5.3" ],
+    ["bah-2.0.0", "eek-2.0.0" ],
+    ["bah-1.0.0", "bar-4.8.2" ],
+    ["bah-1.0.1", "eek-2.0.0" ],
+    ["bah-1.0.0", "bar-4.8.5" ],
+    ["bah-1.0.0", "eek-2.0.0" ],
+    ["bah-1.0.1", "bar-4.8.5" ],
+    ["bah-2.0.0", "bar-4.5.3" ],
+    ["bah-2.0.0", "eek-1.0.1" ],
+    ["bah-1.0.0", "bar-4.5.3" ]]
+
+

--- a/src/rez/tests/data/solver/packages/multi_version_variant_higher_to_lower_version_order/package.py
+++ b/src/rez/tests/data/solver/packages/multi_version_variant_higher_to_lower_version_order/package.py
@@ -1,0 +1,10 @@
+name = 'multi_version_variant_higher_to_lower_version_order'
+version = '1'
+authors = ["oops"]
+uuid = "ed8a45e3-233e-4341-8ba9-9d53c470658c"
+description = "package with several variants of bar ordered from higher lower version"
+variants = [
+    ["bar-4.8.5"],
+    ["bar-4.8.2"],
+    ["bar-4.5.3"]]
+

--- a/src/rez/tests/data/solver/packages/multi_version_variant_lower_to_higher_version_order/package.py
+++ b/src/rez/tests/data/solver/packages/multi_version_variant_lower_to_higher_version_order/package.py
@@ -1,0 +1,10 @@
+name = 'multi_version_variant_lower_to_higher_version_order'
+version = '1'
+authors = ["oops"]
+uuid = "ed8a45e3-233e-4341-8ba9-9d53c470658c"
+description = "package with several variants of bar ordered from lower to higher version"
+variants = [
+    ["bar-4.5.3"],
+    ["bar-4.8.2"],
+    ["bar-4.8.5"]]
+

--- a/src/rez/tests/data/solver/packages/package_name_in_require_and_variant/package.py
+++ b/src/rez/tests/data/solver/packages/package_name_in_require_and_variant/package.py
@@ -1,0 +1,11 @@
+name = 'package_name_in_require_and_variant'
+version = '1'
+authors = ["oops"]
+uuid = "eb06492a-540c-4db4-9110-a86883f1f9e4"
+description = "requires is on variants as well"
+requires = ["bah"]
+variants = [
+    ["eek-1.0.1", "bah-1.0.0"],
+    ["eek-1.0.1", "bah-2.0.0"]]
+
+

--- a/src/rez/tests/data/solver/packages/permuted_family_names/package.py
+++ b/src/rez/tests/data/solver/packages/permuted_family_names/package.py
@@ -1,0 +1,8 @@
+name = 'permuted_family_names'
+version = '1'
+authors = ["oops"]
+uuid = "ac1bc95a-35c5-4242-a9f1-b1c85fda8a61"
+description = "family name permuted in the variants"
+variants = [
+    ["bah-1.0.1", "eek-1.0.0"],
+    ["eek-1.0.1", "bah-2.0.0"]]

--- a/src/rez/tests/data/solver/packages/permuted_family_names_same_position_weight/package.py
+++ b/src/rez/tests/data/solver/packages/permuted_family_names_same_position_weight/package.py
@@ -1,0 +1,9 @@
+name = 'permuted_family_names_same_position_weight'
+version = '1'
+authors = ["oops"]
+uuid = "9f4defbe-ad1d-4f88-a43f-b298d79ebfe9"
+description = "family name permuted in the variants all with same average positional weight"
+variants = [
+    ["bah-1.0.1", 'foo-1.0.0', 'eek-1.0.1'],
+    ["eek-1.0.1", "bah-2.0.0", 'foo-1.0.0'],
+    ["foo-1.1.0", "eek-1.0.0", 'bah-2.0.0']]

--- a/src/rez/tests/data/solver/packages/three_packages_in_variant/package.py
+++ b/src/rez/tests/data/solver/packages/three_packages_in_variant/package.py
@@ -1,0 +1,16 @@
+name = 'three_packages_in_variant'
+version = '1'
+authors = ["oops"]
+uuid = "40f2650b-6150-4ad5-8646-5dd08d284a1e"
+description = "package with three packages in variants "
+variants = [
+    ["bah-1.0.1", "python-2.7", "eek-1.0.0"],
+    ["bah-1.0.1", "python-2.6", "eek-1.0.0"],
+    ["bah-1.0.1", "python-2.5", "eek-1.0.0"],
+    ["bah-1.0.1", "python-2.7", "eek-1.0.1"],
+    ["bah-1.0.1", "python-2.6", "eek-1.0.1"],
+    ["bah-1.0.1", "python-2.5", "eek-1.0.1"],
+    ["bah-1.0.1", "python-2.7", "eek-2.0.0"],
+    ["bah-1.0.1", "python-2.6", "eek-2.0.0"],
+    ["bah-1.0.1", "python-2.5", "eek-2.0.0"]]
+

--- a/src/rez/tests/data/solver/packages/two_packages_in_variant_unsorted/package.py
+++ b/src/rez/tests/data/solver/packages/two_packages_in_variant_unsorted/package.py
@@ -1,0 +1,14 @@
+name = 'two_packages_in_variant_unsorted'
+version = '1'
+authors = ["oops"]
+uuid = "1c84af87-db67-4734-a1f0-f1a09e3f0dbe"
+description = "package with two packages in variants "
+variants = [
+    ["bah-1.0.1", "eek-1.0.1"],
+    ["bah-1.0.1", "eek-2.0.0"],
+    ["bah-2.0.0", "eek-1.0.0"],
+    ["bah-2.0.0", "eek-1.0.1"],
+    ["bah-1.0.0", "eek-1.0.1"],
+    ["bah-1.0.0", "eek-2.0.0"]]
+
+

--- a/src/rez/tests/data/solver/packages/variable_variant_package_in_single_column/package.py
+++ b/src/rez/tests/data/solver/packages/variable_variant_package_in_single_column/package.py
@@ -1,0 +1,9 @@
+name = 'variable_variant_package_in_single_column'
+version = '1'
+authors = ["oops"]
+uuid = "52400418-4180-4c58-ad4b-e8bcd7896d2e"
+description = "package with variants with different package name in the same column "
+variants = [
+    ["foo-1.1.0", "eek-1.0.1"],
+    ["foo-1.0.0", "bah-1.0.1"]]
+

--- a/src/rez/tests/data/solver/packages/variant_with_antipackage/package.py
+++ b/src/rez/tests/data/solver/packages/variant_with_antipackage/package.py
@@ -1,0 +1,9 @@
+name = 'variant_with_antipackage'
+version = '1'
+authors = ["oops"]
+uuid = "ca952d6d-5eec-46f7-a8fd-31aa95c826b7"
+description = "package with an antipackage in the variant"
+variants = [
+    ["bah-1.0.0"],
+    ["bah-1.0.1"],
+    ["!bah-2.0.0"]]

--- a/src/rez/tests/data/solver/packages/variant_with_weak_package_in_variant/package.py
+++ b/src/rez/tests/data/solver/packages/variant_with_weak_package_in_variant/package.py
@@ -1,0 +1,9 @@
+name = 'variant_with_weak_package_in_variant'
+version = '1'
+authors = ["oops"]
+uuid = "2b95f39c-1ae2-4080-a7a7-3f2062e5a65d"
+description = "package with a weak ref in the variant"
+variants = [
+    ["bah-1.0.0"],
+    ["bah-1.0.1"],
+    ["~bah-2.0.0"]]

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -429,6 +429,11 @@ class TestVariantResolutionOrder(TestBase, TempdirMixin):
         expected_packages = ['bah-1.0.1']
         self._solve(request, expected_packages)
 
+    def test_package_name_in_require_and_variant(self):
+
+        request = ['package_name_in_require_and_variant']
+        expected_packages = ['bah-2.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
     @staticmethod
     def getResolvedPackageVersion(context, package_name):

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -430,9 +430,19 @@ class TestVariantResolutionOrder(TestBase, TempdirMixin):
         self._solve(request, expected_packages)
 
     def test_package_name_in_require_and_variant(self):
-
+        """
+        Test weird but valid case where a package family name appears in the requires and also in the variants
+        """
         request = ['package_name_in_require_and_variant']
         expected_packages = ['bah-2.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
+
+    def test_different_slices_sorting_respect_request_criteria(self):
+        """
+        Test that the sort of different variants slices get sorted with the same request criteria
+        """
+        request = ['python-2.7',  'eek', 'three_packages_in_variant']
+        expected_packages = ['bah-1.0.1', 'eek-2.0.0', 'python-2.7.0']
         self._solve(request, expected_packages)
 
     @staticmethod

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -1,3 +1,7 @@
+import shutil
+import tempfile
+from rez.packages import load_developer_package
+from rez.resolved_context import ResolvedContext
 from rez.vendor.version.requirement import Requirement
 from rez.solver import Solver, Cycle, SolverStatus
 import rez.vendor.unittest2 as unittest
@@ -188,6 +192,225 @@ class TestSolver(TestBase):
         self.assertFalse(isinstance(s.failure_reason(), Cycle))
 
 
+class TempdirMixin(object):
+    """Mixin that adds tmpdir create/delete."""
+    @classmethod
+    def setUpClass(cls):
+        cls.root = tempfile.mkdtemp(prefix="rez_test_")
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.root):
+            shutil.rmtree(cls.root)
+
+
+class TestVariantResolutionOrder(TestBase, TempdirMixin):
+
+    class FakeArgParseOpts(object):
+
+        def __getattr__(self, key):
+            return None
+
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+
+        path = os.path.dirname(__file__)
+        packages_path = os.path.join(path, "data", "solver", "packages")
+
+        cls.install_root = os.path.join(cls.root, "packages")
+
+        cls.settings = dict(
+            packages_path=[cls.install_root],
+            add_bootstrap_path=False,
+            resolve_caching=False,
+            warn_untimestamped=False,
+            implicit_packages=[])
+
+        shutil.copytree(packages_path, cls.install_root)
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    def test_resolve_higher_to_lower_version_ordered_variants(self):
+        """
+        Test we pick up the higher version of the dependant package when the variants are from higher to lower
+        """
+        expected_package_version = self.getPackageVersion('bar', '4.8.5')
+        request = ['multi_version_variant_higher_to_lower_version_order']
+        context = ResolvedContext(request)
+        resolved_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bar')
+
+        self.assertEqual(resolved_package_version, expected_package_version, 'wrong bar version selected')
+
+    def test_resolve_lower_to_higher_version_ordered_variants(self):
+        """
+        Test we pick up the higher version of the dependant package when the variants are ordered from lower to higher
+        """
+        expected_package_version = self.getPackageVersion('bar', '4.8.5')
+
+        request = ['multi_version_variant_lower_to_higher_version_order']
+        context = ResolvedContext(request)
+        resolved_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bar')
+
+        self.assertEqual(resolved_package_version, expected_package_version, 'wrong bar version selected')
+
+    def test_variant_selection_variant_default_order(self):
+        """
+        Test that the variant gets selected if based on the order of the variants when no variant package is selected
+        """
+        expected_bah_package_version = self.getPackageVersion("bah", "2.0.0")
+        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
+
+        request = ['two_packages_in_variant_unsorted']
+        context = ResolvedContext(request)
+        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
+        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
+
+        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
+        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+
+    def test_variant_selection_requested_priority(self):
+        """
+        Test that a particular variant gets selected if it is part of the requirements
+        """
+
+        expected_bah_package_version = self.getPackageVersion("bah", "2.0.0")
+        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
+
+        request = ['two_packages_in_variant_unsorted', 'bah']
+        context = ResolvedContext(request)
+        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
+        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
+
+        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
+        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+
+    def test_variant_selection_requested_priority_2(self):
+        """
+        Test that a particular variant gets selected if it is part of the requirements
+        """
+        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
+        expected_eek_package_version = self.getPackageVersion("eek", "2.0.0")
+
+        request = ['two_packages_in_variant_unsorted', 'eek']
+        context = ResolvedContext(request)
+        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
+        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
+
+        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
+        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+
+    def test_variant_selection_requested_priority_3(self):
+        """
+        Test that a particular variant gets selected if it is part of the requirements and the package contains
+        diff packages families in the same column
+        """
+
+        ###################### 1 #########################
+        expected_foo_package_version = self.getPackageVersion("foo", "1.0.0")
+        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
+
+        request = ['variable_variant_package_in_single_column', 'bah']
+        context = ResolvedContext(request)
+        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
+        resolved_foo_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'foo')
+
+        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
+        self.assertEqual(resolved_foo_package_version, expected_foo_package_version, 'wrong foo version selected')
+
+        ###################### 2 #########################
+        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
+        expected_foo_package_version = self.getPackageVersion("foo", "1.1.0")
+
+        request2 = ['variable_variant_package_in_single_column', 'eek']
+        context2 = ResolvedContext(request2)
+        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context2, 'eek')
+        resolved_foo_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context2, 'foo')
+
+        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+        self.assertEqual(resolved_foo_package_version, expected_foo_package_version, 'wrong foo version selected')
+
+        ###################### 3 #########################
+        expected_eek_package_version = self.getPackageVersion("eek", "2.0.0")
+        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
+        expected_foo_package_version = self.getPackageVersion("foo", "1.0.0")
+
+        request3 = ['variable_variant_package_in_single_column', 'eek-2']
+        context3 = ResolvedContext(request3)
+        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'eek')
+        resolved_foo_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'foo')
+        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'bah')
+
+        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+        self.assertEqual(resolved_foo_package_version, expected_foo_package_version, 'wrong foo version selected')
+        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
+
+        ###################### 4 #########################
+        expected_eek_package_version = self.getPackageVersion("eek", "2.0.0")
+        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
+        expected_foo_package_version = self.getPackageVersion("foo", "1.0.0")
+
+        request3 = ['variable_variant_package_in_single_column', 'eek-2', 'bah']
+        context3 = ResolvedContext(request3)
+        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'eek')
+        resolved_foo_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'foo')
+        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'bah')
+
+        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+        self.assertEqual(resolved_foo_package_version, expected_foo_package_version, 'wrong foo version selected')
+        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
+
+    def test_variant_selection_resolved_priority(self):
+        """
+        Test that a particular variant gets selected if it is already resolved
+        """
+        expected_bah_package_version = self.getPackageVersion("bah", "2.0.0")
+        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
+
+        request = ['two_packages_in_variant_unsorted', 'eek-1']
+        context = ResolvedContext(request)
+        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
+        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
+
+        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
+        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+
+    def test_variant_repeatable_ambiguous_selection(self):
+        """
+        Test the variant selection is repeatable when the selection is ambiguous
+        """
+
+        request = ['multi_packages_variant_sorted', 'bah']
+        context1 = ResolvedContext(request)
+        contextToCompare1 = []
+        for resolve_package in context1.resolved_packages:
+            if resolve_package.name != 'multi_packages_variant_sorted':
+                contextToCompare1.append(resolve_package)
+
+        request = ['multi_packages_variant_unsorted', 'bah']
+        context2 = ResolvedContext(request)
+        contextToCompare2 = []
+        for resolve_package in context2.resolved_packages:
+            if resolve_package.name != 'multi_packages_variant_unsorted':
+                contextToCompare2.append(resolve_package)
+
+        self.assertEqual(contextToCompare1, contextToCompare2, 'resolved packages differ not repeatable selection')
+
+    def getPackageVersion(self, package_name, package_version):
+        package_path = os.path.join(self.install_root, package_name, package_version)
+        package = load_developer_package(package_path)
+        return package.version
+
+    @staticmethod
+    def getResolvedPackageVersion(context, package_name):
+        for package in context.resolved_packages:
+            if package.name == package_name:
+                return package.version
+
+
+
 def get_test_suites():
     suites = []
     suite = unittest.TestSuite()
@@ -200,6 +423,8 @@ def get_test_suites():
     suite.addTest(TestSolver("test_7"))
     suite.addTest(TestSolver("test_8"))
     suites.append(suite)
+    suites.append(unittest.TestLoader().loadTestsFromTestCase(TestVariantResolutionOrder))
+
     return suites
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -1,6 +1,5 @@
 import shutil
 import tempfile
-from rez.packages import load_developer_package
 from rez.resolved_context import ResolvedContext
 from rez.vendor.version.requirement import Requirement
 from rez.solver import Solver, Cycle, SolverStatus
@@ -8,6 +7,7 @@ import rez.vendor.unittest2 as unittest
 from rez.tests.util import TestBase
 import itertools
 import os.path
+from rez.vendor.version.version import Version
 
 
 class TestSolver(TestBase):
@@ -233,149 +233,104 @@ class TestVariantResolutionOrder(TestBase, TempdirMixin):
     def tearDownClass(cls):
         TempdirMixin.tearDownClass()
 
+    def _solve(self, request, expected_packages=[], non_expected_packages=[]):
+
+        resolved_context = ResolvedContext(request)
+        for package in expected_packages:
+            expected_package_name, package_version = package.split('-')
+            expected_package_version = Version(package_version)
+            resolved_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(resolved_context,
+                                                                                            expected_package_name)
+            self.assertEqual(resolved_package_version, expected_package_version,
+                             'wrong %s version selected' % expected_package_name )
+
+        for non_expected in non_expected_packages:
+            for package in resolved_context.resolved_packages:
+                self.assertNotEquals(package.name, non_expected,
+                                     '%s should not be in the resolved packages' % non_expected)
+
+        return resolved_context
+
     def test_resolve_higher_to_lower_version_ordered_variants(self):
         """
-        Test we pick up the higher version of the dependant package when the variants are from higher to lower
+        Test we pick the higher version of the dependant package when the variants are ordered from higher to lower
+         version range
         """
-        expected_package_version = self.getPackageVersion('bar', '4.8.5')
         request = ['multi_version_variant_higher_to_lower_version_order']
-        context = ResolvedContext(request)
-        resolved_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bar')
-
-        self.assertEqual(resolved_package_version, expected_package_version, 'wrong bar version selected')
+        expected_packages = ['bar-4.8.5']
+        self._solve(request, expected_packages)
 
     def test_resolve_lower_to_higher_version_ordered_variants(self):
         """
-        Test we pick up the higher version of the dependant package when the variants are ordered from lower to higher
+        Test we pick the higher version of the dependant package when the variants are ordered from lower to higher
+         version range
         """
-        expected_package_version = self.getPackageVersion('bar', '4.8.5')
 
         request = ['multi_version_variant_lower_to_higher_version_order']
-        context = ResolvedContext(request)
-        resolved_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bar')
-
-        self.assertEqual(resolved_package_version, expected_package_version, 'wrong bar version selected')
+        expected_packages = ['bar-4.8.5']
+        self._solve(request, expected_packages)
 
     def test_variant_selection_variant_default_order(self):
         """
-        Test that the variant gets selected if based on the order of the variants when no variant package is selected
+        Test that we get the variant with the highest version of family with the highest weighted average of
+        where they appear in the variants
         """
-        expected_bah_package_version = self.getPackageVersion("bah", "2.0.0")
-        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
 
         request = ['two_packages_in_variant_unsorted']
-        context = ResolvedContext(request)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
+        expected_packages = ['bah-2.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
 
     def test_variant_selection_requested_priority(self):
         """
-        Test that a particular variant gets selected if it is part of the requirements
+        Test that the higher version of the package requested is selected first
         """
-
-        expected_bah_package_version = self.getPackageVersion("bah", "2.0.0")
-        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
 
         request = ['two_packages_in_variant_unsorted', 'bah']
-        context = ResolvedContext(request)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
-
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
-
-    def test_variant_selection_requested_priority_2(self):
-        """
-        Test that a particular variant gets selected if it is part of the requirements
-        """
-        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
-        expected_eek_package_version = self.getPackageVersion("eek", "2.0.0")
+        expected_packages = ['bah-2.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
         request = ['two_packages_in_variant_unsorted', 'eek']
-        context = ResolvedContext(request)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
+        expected_packages = ['bah-1.0.1', 'eek-2.0.0']
+        self._solve(request, expected_packages)
 
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
 
     def test_variant_selection_requested_priority_3(self):
         """
         Test that a particular variant gets selected if it is part of the requirements and the package contains
-        diff packages families in the same column
+        diff packages with the same average positional weight
         """
 
         ###################### 1 #########################
-        expected_foo_package_version = self.getPackageVersion("foo", "1.0.0")
-        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
-
         request = ['variable_variant_package_in_single_column', 'bah']
-        context = ResolvedContext(request)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
-        resolved_foo_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'foo')
-
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_foo_package_version, expected_foo_package_version, 'wrong foo version selected')
+        expected_packages = ['foo-1.0.0', 'bah-1.0.1']
+        self._solve(request, expected_packages)
 
         ###################### 2 #########################
-        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
-        expected_foo_package_version = self.getPackageVersion("foo", "1.1.0")
-
-        request2 = ['variable_variant_package_in_single_column', 'eek']
-        context2 = ResolvedContext(request2)
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context2, 'eek')
-        resolved_foo_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context2, 'foo')
-
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
-        self.assertEqual(resolved_foo_package_version, expected_foo_package_version, 'wrong foo version selected')
+        request = ['variable_variant_package_in_single_column', 'eek']
+        expected_packages = ['foo-1.1.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
         ###################### 3 #########################
-        expected_eek_package_version = self.getPackageVersion("eek", "2.0.0")
-        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
-        expected_foo_package_version = self.getPackageVersion("foo", "1.0.0")
-
-        request3 = ['variable_variant_package_in_single_column', 'eek-2']
-        context3 = ResolvedContext(request3)
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'eek')
-        resolved_foo_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'foo')
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'bah')
-
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
-        self.assertEqual(resolved_foo_package_version, expected_foo_package_version, 'wrong foo version selected')
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
+        request = ['variable_variant_package_in_single_column', 'eek-2']
+        expected_packages = ['foo-1.0.0', 'bah-1.0.1', 'eek-2.0.0']
+        self._solve(request, expected_packages)
 
         ###################### 4 #########################
-        expected_eek_package_version = self.getPackageVersion("eek", "2.0.0")
-        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
-        expected_foo_package_version = self.getPackageVersion("foo", "1.0.0")
+        request = ['variable_variant_package_in_single_column', 'eek-2', 'bah']
+        expected_packages = ['foo-1.0.0', 'bah-1.0.1', 'eek-2.0.0']
+        self._solve(request, expected_packages)
 
-        request3 = ['variable_variant_package_in_single_column', 'eek-2', 'bah']
-        context3 = ResolvedContext(request3)
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'eek')
-        resolved_foo_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'foo')
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'bah')
-
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
-        self.assertEqual(resolved_foo_package_version, expected_foo_package_version, 'wrong foo version selected')
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
 
     def test_variant_selection_resolved_priority(self):
         """
-        Test that a particular variant gets selected if it is already resolved
+        Test that a particular variant gets selected by the fam with highest positional weight once it is sorted
+         by the fam_requires
         """
-        expected_bah_package_version = self.getPackageVersion("bah", "2.0.0")
-        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
 
         request = ['two_packages_in_variant_unsorted', 'eek-1']
-        context = ResolvedContext(request)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
-
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+        expected_packages = ['bah-2.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
     def test_variant_repeatable_ambiguous_selection(self):
         """
@@ -383,14 +338,14 @@ class TestVariantResolutionOrder(TestBase, TempdirMixin):
         """
 
         request = ['multi_packages_variant_sorted', 'bah']
-        context1 = ResolvedContext(request)
+        context1 = self._solve(request)
         contextToCompare1 = []
         for resolve_package in context1.resolved_packages:
             if resolve_package.name != 'multi_packages_variant_sorted':
                 contextToCompare1.append(resolve_package)
 
         request = ['multi_packages_variant_unsorted', 'bah']
-        context2 = ResolvedContext(request)
+        context2 = self._solve(request)
         contextToCompare2 = []
         for resolve_package in context2.resolved_packages:
             if resolve_package.name != 'multi_packages_variant_unsorted':
@@ -400,88 +355,86 @@ class TestVariantResolutionOrder(TestBase, TempdirMixin):
 
     def test_variant_with_permuted_family_names(self):
         """
-        Test that the weight in the package request has more weight than the order on the package
-
-        This is sort of an edge case but valid variants
-            ["bah-1.0.1", "eek-1.0.0"],
-            ["eek-1.0.1", "bah-2.0.0"]
-
-        the request, "bah eek", will order the lower version of both tool to be consumed first :(
-        TODO Discuss with Allan
-
+        Test that the Version range has more weight than the order of the packages on the variant for fam name in the
+         fam_requires
         """
 
-        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
-        expected_bah_package_version = self.getPackageVersion("bah", "2.0.0")
-
         request = ['permuted_family_names', 'eek', 'bah']
-        context = ResolvedContext(request)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
+        expected_packages = ['bah-2.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+        request = ['permuted_family_names',  'bah', 'eek']
+        expected_packages = ['bah-2.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
-        expected_bah_package_version = self.getPackageVersion("bah", "1.0.1")
-        expected_eek_package_version = self.getPackageVersion("eek", "1.0.0")
+    def test_variant_with_same_positional_weight(self):
+        """
+        Test that when we have a tie on positional average weight we pick the a fam name by alphabetical order
+        """
 
-        request2 = ['permuted_family_names',  'bah', 'eek']
-        context2 = ResolvedContext(request2)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context2, 'bah')
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context2, 'eek')
+        request = ['permuted_family_names_same_position_weight']
+        # All have the same positional average weight
+        # It should sort alphabetically first by bah then eek and then foo
+        expected_packages = ['bah-2.0.0', 'eek-1.0.1', 'foo-1.0.0']
+        self._solve(request, expected_packages)
 
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
 
     def test_asymmetric_variant_selection(self):
         """
-        Test we can resolve packages that have asymmetric variants, variants with different number of packages
+        Test we can resolve packages that have asymmetric variants
+         variants with different number of packages
         """
-        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
-        expected_bah_package_version = self.getPackageVersion("bah", "1.0.0")
 
         request = ['asymmetric_variants', 'eek']
-        context = ResolvedContext(request)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'bah')
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context, 'eek')
+        expected_packages = ['bah-1.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+        request = ['asymmetric_variants',  'bah', 'eek']
+        expected_packages = ['bah-1.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
-        expected_eek_package_version = self.getPackageVersion("eek", "1.0.1")
-        expected_bah_package_version = self.getPackageVersion("bah", "1.0.0")
+        request = ['asymmetric_variants',  'bah']
+        expected_packages = ['bah-2.0.0']
+        non_expected_packages = ['eek']
+        self._solve(request, expected_packages, non_expected_packages)
 
-        request2 = ['asymmetric_variants',  'bah', 'eek']
-        context2 = ResolvedContext(request2)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context2, 'bah')
-        resolved_eek_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context2, 'eek')
+    def test_variant_with_antipackage(self):
+        """
+        Test the antipackage does not show up in the resolved context
+        """
 
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        self.assertEqual(resolved_eek_package_version, expected_eek_package_version, 'wrong eek version selected')
+        request = ['asymmetric_variants', '!eek', 'bah']
+        expected_packages = ['bah-2.0.0']
+        non_expected_packages = ['eek']
+        self._solve(request, expected_packages, non_expected_packages)
 
-        expected_bah_package_version = self.getPackageVersion("bah", "2.0.0")
+        request = [ 'variant_with_antipackage', 'asymmetric_variants', 'bah']
+        expected_packages = ['bah-1.0.1', 'eek-1.0.0']
+        self._solve(request, expected_packages)
 
-        request3 = ['asymmetric_variants',  'bah']
-        context3 = ResolvedContext(request3)
-        resolved_bah_package_version = TestVariantResolutionOrder.getResolvedPackageVersion(context3, 'bah')
+        request = [ 'variant_with_antipackage', 'asymmetric_variants', 'eek']
+        expected_packages = ['bah-1.0.1', 'eek-1.0.0']
+        self._solve(request, expected_packages)
 
-        self.assertEqual(resolved_bah_package_version, expected_bah_package_version, 'wrong bah version selected')
-        for package in context3.resolved_packages:
-            self.assertNotEquals(package.name, "eek", 'eek should not be in the resolved packages')
+        request = [ 'asymmetric_variants', 'variant_with_antipackage', 'eek', 'bah']
+        expected_packages = ['bah-1.0.0', 'eek-1.0.1']
+        self._solve(request, expected_packages)
 
+    def test_variant_with_weak_packages(self):
+        """
+        Test that the variant with a weak package gets sorted at the end
+        """
 
-    def getPackageVersion(self, package_name, package_version):
-        package_path = os.path.join(self.install_root, package_name, package_version)
-        package = load_developer_package(package_path)
-        return package.version
+        request = ['variant_with_weak_package_in_variant', 'bah']
+        expected_packages = ['bah-1.0.1']
+        self._solve(request, expected_packages)
+
 
     @staticmethod
     def getResolvedPackageVersion(context, package_name):
         for package in context.resolved_packages:
             if package.name == package_name:
                 return package.version
-
-
 
 def get_test_suites():
     suites = []
@@ -496,7 +449,6 @@ def get_test_suites():
     suite.addTest(TestSolver("test_8"))
     suites.append(suite)
     suites.append(unittest.TestLoader().loadTestsFromTestCase(TestVariantResolutionOrder))
-
     return suites
 
 if __name__ == '__main__':

--- a/src/rez/vendor/version/requirement.py
+++ b/src/rez/vendor/version/requirement.py
@@ -271,6 +271,17 @@ class Requirement(_Common):
             and (self.range_ == other.range_) \
             and (self.conflict_ == other.conflict_)
 
+    def __cmp__(self, other):
+        """order from minor to mayor version"""
+        if not other:
+            return +1
+
+        if other.range < self.range_:
+            return +1
+        elif other.range > self.range_:
+            return -1
+        return 0
+
     def __hash__(self):
         return hash((self.name_, self.range_, self.conflict_))
 
@@ -377,3 +388,7 @@ class RequirementList(_Common):
             return "%s <--!--> %s" % (s1, s2)
         else:
             return ' '.join(str(x) for x in self.requirements_)
+
+
+def extract_family_name_from_requirements(requirement_list):
+    return [req.name for req in requirement_list]


### PR DESCRIPTION
First version of the variants sorting algorithm (WIP), just to get some feedback and know if we are in the same page heading in the right direction.

Need to add more test cases to fully test it (i.e asymmetric variants list with the same weight)

The hashing we discussed for the ambiguous cases seems that it should not be necessary since the default sorting takes care of those cases and guarantees repetitive results regardless of the variants positions on the package.yaml 
I think we should guarantee the same result if the packages are changed in order (line in which they appear).. but if the contents are changed (position of the packages inside a variant, or new variants lines are added/removed) then we can not guaranteed (should not expect) the same result.


