### PR TITLE
Remove Validation From Resources

### DIFF
--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -7,6 +7,7 @@ from rez.exceptions import ResourceNotFoundError, PackageMetadataError, \
 from rez.util import deep_update, print_warning
 from rez.vendor.version.version import Version
 from rez.vendor.version.requirement import Requirement
+from rez.util import safe_str
 import re
 
 
@@ -218,7 +219,7 @@ class BaseVariantResource(BasePackageResource):
         if idx is not None:
             try:
                 variant_requires = variants[idx]
-                data["_internal"] = dict(variant_requires=variant_requires)
+                data["_internal"] = dict(variant_requires=[safe_str(v) for v in variant_requires])
                 requires = data.get("requires", []) + variant_requires
                 data["requires"] = requires
             except IndexError:

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -362,7 +362,7 @@ class Variant(_PackageBase):
         if self.index is None:
             return ''
         else:
-            dirs = [Requirement(x).safe_str()
+            dirs = [x
                     for x in self._internal.get("variant_requires")]
             return os.path.join(*dirs) if dirs else ''
 

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1119,3 +1119,10 @@ class ResolvedContext(object):
 
         # append system paths
         executor.append_system_paths()
+
+if __name__ == "__main__":
+    rc = ResolvedContext(["pydot", "ALF"], verbosity=0, timestamp=None,
+                 building=False, caching=None, package_paths=None,
+                 add_implicit_packages=True, add_bootstrap_path=False,
+                 max_fails=-1, time_limit=-1, callback=None)
+    rc.print_info()

--- a/src/rez/resources.py
+++ b/src/rez/resources.py
@@ -646,6 +646,7 @@ class FileSystemResource(Resource):
         return super(FileSystemResource, cls).from_path(path, search_paths)
 
     @classmethod
+    @lru_cache()
     def iter_instances(cls, parent_resource):
         for name in _listdir(parent_resource.path, cls.is_file):
             match = _ResourcePathParser.parse_filepart(cls, name)

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -683,7 +683,7 @@ def convert_old_commands(commands, annotate=True):
                 if idx in (0, len(parts) - 1):
                     func = "appendenv" if idx == 0 else "prependenv"
                     parts = parts[1:] if idx == 0 else parts[:-1]
-                    val = os.pathsep.join(parts)
+                    val = separator.join(parts)
                     loc.append("%s('%s', '%s')" % (func, var, _en(val)))
                     continue
 
@@ -1555,3 +1555,11 @@ def _atexit():
         timings.dump()
     except:
         pass
+
+
+def safe_str(input):
+    import platform
+    if platform.system() == "Windows":
+        raise NotImplemented
+    else:
+        return str(self)

--- a/src/rez/vendor/version/requirement.py
+++ b/src/rez/vendor/version/requirement.py
@@ -1,5 +1,6 @@
 from rez.vendor.version.version import Version, VersionRange
 from rez.vendor.version.util import _Common
+from rez.util import safe_str
 import re
 
 
@@ -188,11 +189,7 @@ class Requirement(_Common):
         """Return a string representation that is safe for the current filesystem,
         and guarantees that no two different Requirement objects will encode to
         the same value."""
-        import platform
-        if platform.system() == "Windows":
-            raise NotImplemented
-        else:
-            return str(self)
+        return safe_str(str(self))
 
     def conflicts_with(self, other):
         """Returns True if this requirement conflicts with another."""

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -541,12 +541,36 @@ class _VersionRangeParser(object):
             self.bounds.append(self._bound(lower, upper, tokens))
 
     def _parse(self, s, make_token, debug):
-        self.stack = []
-        self.bounds = []
-        self.make_token = make_token
-        self.debug = debug
-        self.ranges.parseString(s, parseAll=True)
-        return self.bounds
+        
+        bounds = []
+        lower = None
+        upper = None
+        exclusive = False
+        
+        
+        exact_version_regex = "==(?P<version>[0-9a-zA-Z_][.\-0-9a-zA-Z_]*)"
+        match = re.search(exact_version_regex, s)
+        if match:
+            ver = Version(''.join(match.groupdict()["version"]), make_token=make_token)
+            lower = _LowerBound(ver, True)
+            upper = _UpperBound(ver, True)
+        
+        lower_bound_regex = "(?P<version>[0-9a-zA-Z_][.\-0-9a-zA-Z_]*)\+"
+        match = re.search(lower_bound_regex, s)
+        if match:
+            ver = Version(''.join(match.groupdict()["version"]), make_token=make_token)
+            lower = _LowerBound(ver, True)
+        
+        upper_bound_regex = "<=|<(?P<version>[0-9a-zA-Z_][.\-0-9a-zA-Z_]*)"
+        match = re.search(upper_bound_regex, s)
+        if match:
+            ver = Version(''.join(match.groupdict()["version"]), make_token=make_token)
+            upper = _UpperBound(ver, False)
+        
+        bounds.append(self._bound(lower, upper, ""))
+        
+        return bounds
+
 
 
 class VersionRange(_Comparable):


### PR DESCRIPTION
This change is a first pass at moving validation out of `resources.py`/`package_resources.py` and into the `DataWrapper` as discussed.  And primarily it's had little impact if anything it might have made rez a tad slower...

The classes defined in `resources.py`/`package_resources.py` no longer provide a schema, but do perform some level of data manipulation (for example, ensuring the version number is valid, and that the package name matches).  This manipulation is not possible in the `Schema` layer and so has to remain here.  As `_PackageBase` already derives from `DataWrapper` (via `ResourceWrapper`) there wasn't too much to do on that side of things.

Some resources in `package_resources.py` appear to be orphaned.  For example the `ReleaseInfoResource` refers to the rez 1 release metadata files but the data it provides doesn't get used.  Previously this file would still be validated, now it is not.  The assumption is that a consumer of this resource would also implement it's own `DataWrapper` layer to provide this.

I haven't removed CombinedPackageFamilyResource and CombinedPackageResource.  However, I'm not immediately clear how these would be implemented as a result of these changes with the new setup.

That aside, I am not sure how, by removing code, I've managed to not get a greater speed improvement as expected.  Resolving a moderate number of packages (using `ResolvedContext` directly, not `rez env`) doesn't really show any improvement.  Maybe I've missed something very obvious...?

One very specific area where I can get see a loss of ~0.5 seconds in a moderate example is the `load` method of `BaseVariantResource`.  This sets a list of `variant_requires` on the `_internal` property which is then used by the `subpath` method on the `Variant` class.  Creating the necessary `Requirement` objects is relatively slow.  For the moment I've delayed this by doing the cast in the `subpath` method, but technically it doesn't belong here.  But the previous implementation must have been doing something similar.
