### PR TITLE
Cache the `iter_instances` Method

### DIFF
--- a/src/rez/resources.py
+++ b/src/rez/resources.py
@@ -494,6 +494,7 @@ class Resource(object):
             yield cls.parent_resource
 
     @classmethod
+    @config.lru_cache("resource_caching", "resource_caching_maxsize")
     def ancestors(cls):
         """Get a tuple of all the resources above this one, in descending order
         """
@@ -689,7 +690,12 @@ class FileSystemResource(Resource):
         return super(FileSystemResource, cls).from_path(path, search_paths)
 
     @classmethod
+    @config.lru_cache("resource_caching", "resource_caching_maxsize")
     def iter_instances(cls, parent_resource):
+        return list(cls._iter_instances(parent_resource))
+
+    @classmethod
+    def _iter_instances(cls, parent_resource):
         for name in _listdir(parent_resource.path, cls.is_file):
             match = _ResourcePathParser.parse_filepart(cls, name)
             if match is not None:
@@ -805,6 +811,7 @@ class ResourceWrapper(DataWrapper):
 # Main Entry Points
 # -----------------------------------------------------------------------------
 
+@config.lru_cache("resource_caching", "resource_caching_maxsize")
 def list_resource_classes(keys=None):
     """List resource classes matching the search criteria.
 


### PR DESCRIPTION
This change gives the biggest performance boost.  It is also dependent on pull requests #107 and #106.

By caching the `iter_instances` method we avoid needlessly recomputing the entire resource set for every package request.  

I also cache two other methods that appear high up in the cprofile output whose output doesn't change once the hierarchy is defined.

I have just noticed I should probably add these three caches to the `clear_caches` method.  I will do this tomorrow and update the pull request.
