### PR TITLE
Let user test if an env variable is in environment or not

### DIFF
--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -660,10 +660,15 @@ class EnvironmentDict(UserDict.DictMixin):
 
     def __getitem__(self, key):
         if key not in self._var_cache:
-            self._var_cache[key] = EnvironmentVariable(key, self)
+            raise KeyError(key)
         return self._var_cache[key]
 
+    def __createitem__(self, key):
+        self._var_cache[key] = EnvironmentVariable(key, self)
+    
     def __setitem__(self, key, value):
+        if key not in self._var_cache:
+            self.__createitem__(key)
         self[key].set(value)
 
     def __contains__(self, key):

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -996,11 +996,9 @@ class AttrDictWrapper(MutableMapping):
             d = self.__dict__
         else:
             d = self._data
-        try:
-            return d[attr]
-        except KeyError:
-            raise AttributeError("'%s' object has no attribute '%s'"
-                                 % (self.__class__.__name__, attr))
+        if attr not in d:
+            self._data.__createitem__(attr)
+        return d[attr]
 
     def __setattr__(self, attr, value):
         # For things like '__class__', for instance


### PR DESCRIPTION
Hi,

Currently it is not possible to test if a variable is in the environment or not, because the getter creates it automatically.
The goal of this PR is to keep the dictionnary as a standard dictionnary and to keep the magic of empty EnvironmentVariable creation in the AttrDictWrapper.
So it becomes possible to do:

```
if "FOO" in env:
    print("Foo is %s" % env.FOO)
```

And:

```
print("Foo is %s" % env.get("FOO", "default value"))
```

`env.BAR = "value"` and `env["BAR"] = "value"` will continue to work as before (because here the variable is created in the setter).

Now, env is a standard dict, so: `env["BAR_PATH"].append("value")` will raise.
But `env.BAR_PATH.append("value")` will continue to work as before.

Regards,
Fabien
