### PR TITLE
Making the pruning of a conflicted graph configurable

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -210,6 +210,7 @@ config_schema = Schema({
     "debug_resources":                  Bool,
     "debug_all":                        Bool,
     "debug_none":                       Bool,
+    "prune_conflict_graph":             Bool,
     "quiet":                            Bool,
     "show_progress":                    Bool,
     "catch_rex_errors":                 Bool,

--- a/src/rez/rezconfig
+++ b/src/rez/rezconfig
@@ -197,6 +197,10 @@ debug_all: false
 # Turn off all debugging messages. This overrides debug_all.
 debug_none: false
 
+# Prune unnecessary nodes in a graph that contains conflicts
+prune_conflict_graph: true
+
+
 # When an error is encountered in rex code, rez catches the error and processes
 # it, removing internal info (such as the stacktrace inside rez itself) that is
 # generally not interesting to the package author. If set to False, rex errors

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -1265,7 +1265,7 @@ class _ResolvePhase(_Common):
                     g.add_edge_attribute(e, ("fontcolor", "red"))
 
         # prune nodes not related to failure
-        if failure_nodes:
+        if failure_nodes and config.prune_conflict_graph:
             access_dict = accessibility(g)
             del_nodes = set()
 


### PR DESCRIPTION
Hi Allan,

As discussed [here](https://groups.google.com/forum/#!topic/rez-config/B-ISTkYD-ok), sometimes the pruning of a conflicted graph does prune too much and it is not possible to find the error. So we have made that configurable. 

Cheers
Fede
