### PR TITLE
Handling quoted values in shells

### DIFF
--- a/src/rez/tests/data/commands/packages/shelltest/1/package.yaml
+++ b/src/rez/tests/data/commands/packages/shelltest/1/package.yaml
@@ -1,0 +1,5 @@
+name: shelltest
+version: '1'
+
+commands:
+  - export VARIABLE_WITH_QUOTES="loadPlugin(\"mayaPlugin\")"

--- a/src/rez/tests/data/commands/packages/shelltest2/1/package.py
+++ b/src/rez/tests/data/commands/packages/shelltest2/1/package.py
@@ -1,0 +1,8 @@
+name = 'shelltest2'
+version = '1'
+
+def commands():
+    # prepend to existing var
+    setenv("VARIABLE_WITH_QUOTES", 'loadPlugin("mayaPlugin")')
+    setenv("VARIABLE_ESCAPED_WITH_QUOTES", 'loadPlugin(\"mayaPlugin\")')
+

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -20,7 +20,7 @@ import os
 
 
 def _stdout(proc):
-    out_, _ = proc.communicate()
+    out_,_ = proc.communicate()
     return out_.strip()
 
 
@@ -36,6 +36,7 @@ class TestShells(TestBase, TempdirMixin):
         cls.settings = dict(
             packages_path=[packages_path],
             implicit_packages=[],
+            add_bootstrap_path=False,
             warn_untimestamped=False,
             resolve_caching=False)
 
@@ -49,83 +50,96 @@ class TestShells(TestBase, TempdirMixin):
 
     @shell_dependent
     def test_no_output(self):
-        sh = create_shell()
-        _, _, _, command = sh.startup_capabilities(command=True)
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        _,_,_,command = sh.startup_capabilities(command=True)
         if command:
             r = self._create_context(["hello_world"])
             p = r.execute_shell(command="hello_world -q",
-                                stdout=subprocess.PIPE)
+                                stdout=subprocess.PIPE,
+                                shell=current_shell)
 
-            self.assertEqual(
-                _stdout(p), '',
+            self.assertEqual(_stdout(p), '', \
                 "This test and others will fail, because one or more of your "
                 "startup scripts are printing to stdout. Please remove the "
                 "printout and try again.")
 
     @shell_dependent
     def test_command(self):
-        sh = create_shell()
-        _, _, _, command = sh.startup_capabilities(command=True)
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        _,_,_,command = sh.startup_capabilities(command=True)
 
         if command:
             r = self._create_context(["hello_world"])
             p = r.execute_shell(command="hello_world",
-                                stdout=subprocess.PIPE)
+                                stdout=subprocess.PIPE,
+                                shell=current_shell)
             self.assertEqual(_stdout(p), "Hello Rez World!")
 
     @shell_dependent
     def test_command_returncode(self):
-        sh = create_shell()
-        _, _, _, command = sh.startup_capabilities(command=True)
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        _,_,_,command = sh.startup_capabilities(command=True)
 
         if command:
             r = self._create_context(["hello_world"])
             command = "hello_world -q -r 66"
             commands = (command, command.split())
             for cmd in commands:
-                p = r.execute_shell(command=cmd, stdout=subprocess.PIPE)
+                p = r.execute_shell(command=cmd, 
+                                    stdout=subprocess.PIPE,
+                                    shell=current_shell)
                 p.wait()
                 self.assertEqual(p.returncode, 66)
 
     @shell_dependent
     def test_norc(self):
-        sh = create_shell()
-        _, norc, _, command = sh.startup_capabilities(norc=True, command=True)
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        _,norc,_,command = sh.startup_capabilities(norc=True, command=True)
 
         if norc and command:
             r = self._create_context(["hello_world"])
             p = r.execute_shell(norc=True,
                                 command="hello_world",
-                                stdout=subprocess.PIPE)
+                                stdout=subprocess.PIPE,
+                                shell=current_shell)
             self.assertEqual(_stdout(p), "Hello Rez World!")
 
     @shell_dependent
     def test_stdin(self):
-        sh = create_shell()
-        _, _, stdin, _ = sh.startup_capabilities(stdin=True)
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        _,_,stdin,_ = sh.startup_capabilities(stdin=True)
 
         if stdin:
             r = self._create_context(["hello_world"])
             p = r.execute_shell(stdout=subprocess.PIPE,
-                                stdin=subprocess.PIPE)
-            stdout, _ = p.communicate(input="hello_world\n")
+                                stdin=subprocess.PIPE,
+                                norc=True,
+                                shell=current_shell)
+            stdout,_ = p.communicate(input="hello_world\n")
             stdout = stdout.strip()
             self.assertEqual(stdout, "Hello Rez World!")
 
     @shell_dependent
     def test_rcfile(self):
-        sh = create_shell()
-        rcfile, _, _, command = sh.startup_capabilities(rcfile=True, command=True)
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        rcfile,_,_,command = sh.startup_capabilities(rcfile=True, command=True)
 
         if rcfile and command:
-            f, path = tempfile.mkstemp()
+            f,path = tempfile.mkstemp()
             os.write(f, "hello_world\n")
             os.close(f)
 
             r = self._create_context(["hello_world"])
             p = r.execute_shell(rcfile=path,
                                 command="hello_world -q",
-                                stdout=subprocess.PIPE)
+                                stdout=subprocess.PIPE,
+                                shell=current_shell)
             self.assertEqual(_stdout(p), "Hello Rez World!")
             os.remove(path)
 
@@ -150,16 +164,17 @@ class TestShells(TestBase, TempdirMixin):
     @shell_dependent
     @install_dependent
     def test_rez_command(self):
-        sh = create_shell()
-        _, _, _, command = sh.startup_capabilities(command=True)
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        _,_,_,command = sh.startup_capabilities(command=True)
 
         if command:
             r = self._create_context([])
-            p = r.execute_shell(command="rezolve -h")
+            p = r.execute_shell(command="rezolve -h", shell=current_shell)
             p.wait()
             self.assertEqual(p.returncode, 0)
 
-            p = r.execute_shell(command="rez-env -h")
+            p = r.execute_shell(command="rez-env -h", shell=current_shell)
             p.wait()
             self.assertEqual(p.returncode, 0)
 
@@ -192,8 +207,9 @@ class TestShellsCommands(TestBase, TempdirMixin):
                                caching=False)
 
     @shell_dependent
-    def test_escape_quoted_value(self):
+    def test_escape_quoted_value_old_command(self):
         """Test that a command which contains quotes in the value gets escaped properly different shells
+           from a old style resource definition (package.yaml) compatible with rez1
            ie. - export VARIABLE_WITH_QUOTES="loadPlugin(\"mayaPlugin\")"
                  does not need any change in sh and bash but need to be escaped for tcsh and csh like
                  setenv VARIABLE_WITH_QUOTES "loadPlugin(\"\""mayaPlugin\"\"")"
@@ -222,6 +238,48 @@ class TestShellsCommands(TestBase, TempdirMixin):
                     elif sh.name() in ['csh', 'tcsh']:
                         self.assertEqual(csh_expected, line.strip())
 
+    @shell_dependent
+    def test_escape_quoted_value_new_command(self):
+        """Test that a command which contains quotes in the value gets escaped properly different shells
+           from a new style resource definition (package.py)
+           ie. - setenv("VARIABLE_WITH_QUOTES", 'loadPlugin("mayaPlugin")')
+                 in sh and bash should end up like
+                 export VARIABLE_ESCAPED_WITH_QUOTES="loadPlugin(\"mayaPlugin\")"
+                 and in tcsh anc csh
+                 setenv VARIABLE_ESCAPED_WITH_QUOTES "loadPlugin("\""mayaPlugin"\"")"
+
+        """
+        sh_expected=r'export VARIABLE_WITH_QUOTES="loadPlugin(\"mayaPlugin\")"'
+        escpaed_sh_expected=r'export VARIABLE_ESCAPED_WITH_QUOTES="loadPlugin(\"mayaPlugin\")"'
+
+        csh_expected=r'setenv VARIABLE_WITH_QUOTES "loadPlugin("\""mayaPlugin"\"")"'
+        escpaed_csh_expected=r'setenv VARIABLE_ESCAPED_WITH_QUOTES "loadPlugin("\""mayaPlugin"\"")"'
+
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        _,_,_,command = sh.startup_capabilities(command=True)
+
+        context_file = tempfile.mktemp(prefix='context_', suffix='.rxt')
+
+        if command:
+            r = self._create_context(["shelltest2"])
+
+            p = r.execute_shell(command="env", shell=current_shell, context_filepath=context_file)
+            p.wait()
+            self.assertEqual(p.returncode, 0)
+
+        with open(context_file, 'r') as f:
+            for line in f.readlines():
+                if line.find('VARIABLE_WITH_QUOTES') != -1 and not line.startswith('#'):
+                    if sh.name() in ['sh', 'bash']:
+                        self.assertEqual(sh_expected, line.strip())
+                    elif sh.name() in ['csh', 'tcsh']:
+                        self.assertEqual(csh_expected, line.strip())
+                if line.find('VARIABLE_ESCAPED_WITH_QUOTES') != -1 and not line.startswith('#'):
+                    if sh.name() in ['sh', 'bash']:
+                        self.assertEqual(escpaed_sh_expected, line.strip())
+                    elif sh.name() in ['csh', 'tcsh']:
+                        self.assertEqual(escpaed_csh_expected, line.strip())
 
 
 def get_test_suites():
@@ -235,7 +293,8 @@ def get_test_suites():
     suite.addTest(TestShells("test_rcfile"))
     suite.addTest(TestShells("test_rez_env_output"))
     suite.addTest(TestShells("test_rez_command"))
-    suite.addTest(TestShellsCommands("test_escape_quoted_value"))
+    suite.addTest(TestShellsCommands("test_escape_quoted_value_old_command"))
+    suite.addTest(TestShellsCommands("test_escape_quoted_value_new_command"))
     suites.append(suite)
     return suites
 

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -2,10 +2,12 @@
 Test noninteractive invocation of each type of shell (bash etc), and ensure that
 their behaviour is correct wrt shell options such as --rcfile, -c, --stdin etc.
 """
+import shutil
 
 from rez.system import system
 from rez.shells import create_shell
 from rez.resolved_context import ResolvedContext
+from rez.config import config
 import rez.vendor.unittest2 as unittest
 from rez.vendor.sh import sh
 from rez.tests.util import TestBase, TempdirMixin, shell_dependent, \
@@ -15,7 +17,6 @@ from rez.bind import hello_world
 import subprocess
 import tempfile
 import os
-import sys
 
 
 def _stdout(proc):
@@ -163,6 +164,66 @@ class TestShells(TestBase, TempdirMixin):
             self.assertEqual(p.returncode, 0)
 
 
+class TestShellsCommands(TestBase, TempdirMixin):
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+
+        path = os.path.dirname(__file__)
+        packages_path = os.path.join(path, "data", "commands", "packages")
+
+        cls.install_root = os.path.join(cls.root, "packages")
+
+        cls.settings = dict(
+            packages_path=[cls.install_root],
+            add_bootstrap_path=False,
+            resolve_caching=False,
+            warn_untimestamped=False,
+            implicit_packages=[])
+
+        shutil.copytree(packages_path, cls.install_root)
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    def _create_context(self, pkgs):
+        return ResolvedContext(pkgs,
+                               caching=False)
+
+    @shell_dependent
+    def test_escape_quoted_value(self):
+        """Test that a command which contains quotes in the value gets escaped properly different shells
+           ie. - export VARIABLE_WITH_QUOTES="loadPlugin(\"mayaPlugin\")"
+                 does not need any change in sh and bash but need to be escaped for tcsh and csh like
+                 setenv VARIABLE_WITH_QUOTES "loadPlugin(\"\""mayaPlugin\"\"")"
+        """
+        sh_expected=r'export VARIABLE_WITH_QUOTES="loadPlugin(\"mayaPlugin\")"'
+        csh_expected=r'setenv VARIABLE_WITH_QUOTES "loadPlugin(\"\""mayaPlugin\"\"")"'
+
+        current_shell = config.get('default_shell')
+        sh = create_shell(shell=current_shell)
+        _,_,_,command = sh.startup_capabilities(command=True)
+
+        context_file = tempfile.mktemp(prefix='context_', suffix='.rxt')
+
+        if command:
+            r = self._create_context(["shelltest"])
+
+            p = r.execute_shell(command="env", shell=current_shell, context_filepath=context_file)
+            p.wait()
+            self.assertEqual(p.returncode, 0)
+
+        with open(context_file, 'r') as f:
+            for line in f.readlines():
+                if line.find('VARIABLE_WITH_QUOTES') != -1 and not line.startswith('#'):
+                    if sh.name() in ['sh', 'bash']:
+                        self.assertEqual(sh_expected, line.strip())
+                    elif sh.name() in ['csh', 'tcsh']:
+                        self.assertEqual(csh_expected, line.strip())
+
+
+
 def get_test_suites():
     suites = []
     suite = unittest.TestSuite()
@@ -174,6 +235,7 @@ def get_test_suites():
     suite.addTest(TestShells("test_rcfile"))
     suite.addTest(TestShells("test_rez_env_output"))
     suite.addTest(TestShells("test_rez_command"))
+    suite.addTest(TestShellsCommands("test_escape_quoted_value"))
     suites.append(suite)
     return suites
 

--- a/src/rezplugins/shell/csh.py
+++ b/src/rezplugins/shell/csh.py
@@ -99,7 +99,13 @@ class CSH(UnixShell):
     def _saferefenv(self, key):
         self._addline("if (!($?%s)) setenv %s" % (key, key))
 
+    def _escapeDoubleQuotes(self, value):
+        if '"' in value:
+            value = value.replace ( '"','"\\""' )
+        return value
+
     def setenv(self, key, value):
+        value = self._escapeDoubleQuotes(value)
         self._addline('setenv %s "%s"' % (key, value))
 
     def unsetenv(self, key):

--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -99,7 +99,22 @@ class SH(UnixShell):
         completion = os.path.join(module_root_path, "completion", "complete.sh")
         self.source(completion)
 
+    def _needs_escaping(self, value):
+        if '"' in value:
+            try:
+                if value[value.index('"')-1] == '\\':
+                    return False
+            except:
+                return True
+        return True
+
+    def _escapeDoubleQuotes(self, value):
+        if self._needs_escaping(value):
+            value = value.replace ( '"','\\"' )
+        return value
+
     def setenv(self, key, value):
+        value = self._escapeDoubleQuotes(value)
         self._addline('export %s="%s"' % (key, value))
 
     def unsetenv(self, key):


### PR DESCRIPTION
Sometimes we need to set values that contains quotes, and we don't want the shell to interpret them. So we need to escape them. 
with the old command, escaping like so will be good for bash but not for tcsh
` - export VARIABLE_WITH_QUOTES="loadPlugin(\"mayaPlugin\")"`

with  new commands
`setenv("VARIABLE_WITH_QUOTES", 'loadPlugin("mayaPlugin")')`
they need to be escaped in both tcsh and bash

Added some test cases to show this. Also fixed the other test so they really run in the shell. The **@shell_dependent** function decorator is only changing the value in the config, we need to create the shell with that value and also pass it to  `excecute_shell`