### PR TITLE
Add user to Rex bindings

### DIFF
--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1308,6 +1308,7 @@ class ResolvedContext(object):
         executor.bind('request', RequirementsBinding(self._package_requests))
         executor.bind('implicits', RequirementsBinding(self.implicit_packages))
         executor.bind('resolve', VariantsBinding(resolved_pkgs))
+        executor.bind('user', self.user)
         executor.bind('building', bool(os.getenv('REZ_BUILD_ENV')))
 
         #


### PR DESCRIPTION
Rez 1 supported `!USER!` in the bash commands which in Rez 2 equates to `{user}`.  

However this value hadn't been bound to Rex and so was not able to be expanded.

This changes addresses this problem.
