### PR TITLE
trying to fix escaping and quoting

### DIFF
--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -9,7 +9,7 @@ from string import Formatter
 from rez.system import system
 from rez.config import config
 from rez.exceptions import RexError, RexUndefinedVariableError
-from rez.util import AttrDictWrapper, shlex_join, expandvars
+from rez.util import AttrDictWrapper, shlex_join, expandvars, remove_enclosing_quotes
 from rez.vendor.enum import Enum
 
 
@@ -336,22 +336,18 @@ class ActionManager(object):
         if expanded_key in self.environ:
             env_sep = self._env_sep(expanded_key)
             self.actions.append(action(unexpanded_key, str(unexpanded_value)))
-            parts = self.environ[expanded_key].split(env_sep)
+            parts = remove_enclosing_quotes(self.environ[expanded_key]).split(env_sep)
 
-            unexpanded_values = env_sep.join(
-                addfunc(self._escape(unexpanded_value),
-                        [self._keytoken(expanded_key)]))
+            unexpanded_values = addfunc(self._escape(unexpanded_value), [self._keytoken(expanded_key)], env_sep)
 
-            expanded_values = env_sep.join(
-                addfunc(self._escape(expanded_value), parts))
+            expanded_values = addfunc(self._escape(expanded_value), parts, env_sep)
 
-            self.environ[expanded_key] = \
-                env_sep.join(addfunc(str(expanded_value), parts))
+            self.environ[expanded_key] = addfunc(str(expanded_value), parts, env_sep)
         else:
             self.actions.append(Setenv(unexpanded_key, str(unexpanded_value)))
             self.environ[expanded_key] = str(expanded_value)
-            unexpanded_values = self._expand(unexpanded_value)
-            expanded_values = self._expand(expanded_value)
+            unexpanded_values = self._escape(self._expand(unexpanded_value))
+            expanded_values = self._escape(self._expand(expanded_value))
             interpfunc = None
 
         applied = False
@@ -374,12 +370,27 @@ class ActionManager(object):
             self.interpreter.setenv(key, value)
 
     def prependenv(self, key, value):
-        self._pendenv(key, value, Prependenv, self.interpreter.prependenv,
-                      lambda x, y: [x] + y)
+        def prepend_quoted(x, y, sep=None):
+            if sep:
+                value_list = [x] + y
+                # remove the quotes of individual items on the list and return the joined string quoted
+                value_list = [remove_enclosing_quotes(x) for x in value_list]
+                return '"%s"' % sep.join(value_list)
+            else:
+                return [x] + y
+        self._pendenv(key, value, Prependenv, self.interpreter.prependenv, prepend_quoted)
 
     def appendenv(self, key, value):
-        self._pendenv(key, value, Appendenv, self.interpreter.appendenv,
-                      lambda x, y: y + [x])
+        def append_quoted(x, y, sep=None):
+            if sep:
+                value_list = y + [x]
+                # remove the quotes of individual items on the list and return the joined string quoted
+                value_list = [remove_enclosing_quotes(x) for x in value_list]
+                return '"%s"' % sep.join(value_list)
+            else:
+                return y + [x]
+
+        self._pendenv(key, value, Appendenv, self.interpreter.appendenv, append_quoted)
 
     def alias(self, key, value):
         key = str(self._format(key))

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -373,9 +373,12 @@ class ActionManager(object):
         def prepend_quoted(x, y, sep=None):
             if sep:
                 value_list = [x] + y
-                # remove the quotes of individual items on the list and return the joined string quoted
-                value_list = [remove_enclosing_quotes(x) for x in value_list]
-                return '"%s"' % sep.join(value_list)
+                if sep != os.path.pathsep:
+                    # remove the quotes of individual items on the list and return the joined string quoted
+                    value_list = [remove_enclosing_quotes(x) for x in value_list]
+                    return '"%s"' % sep.join(value_list)
+                else:
+                    return sep.join(value_list)
             else:
                 return [x] + y
         self._pendenv(key, value, Prependenv, self.interpreter.prependenv, prepend_quoted)
@@ -384,9 +387,12 @@ class ActionManager(object):
         def append_quoted(x, y, sep=None):
             if sep:
                 value_list = y + [x]
-                # remove the quotes of individual items on the list and return the joined string quoted
-                value_list = [remove_enclosing_quotes(x) for x in value_list]
-                return '"%s"' % sep.join(value_list)
+                if sep != os.path.pathsep:
+                    # remove the quotes of individual items on the list and return the joined string quoted
+                    value_list = [remove_enclosing_quotes(x) for x in value_list]
+                    return '"%s"' % sep.join(value_list)
+                else:
+                    return sep.join(value_list)
             else:
                 return y + [x]
 

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -86,8 +86,8 @@ class TestRex(TestBase):
                        Source('./script.src')],
                    expected_output = {
                        'FOO': 'foo',
-                       'A': os.pathsep.join(["/data","/tmp"]),
-                       'B': os.pathsep.join(["/tmp","/data"])})
+                       'A': '"%s"' % os.pathsep.join(["/data","/tmp"]),
+                       'B': '"%s"' % os.pathsep.join(["/tmp","/data"])})
 
     def test_2(self):
         """Test simple setenvs and assignments."""
@@ -129,8 +129,8 @@ class TestRex(TestBase):
                        Prependenv('BAH', 'B'),
                        Appendenv('BAH', 'C')],
                    expected_output = {
-                       'FOO': os.pathsep.join(["test1","test2","test3"]),
-                       'BAH': os.pathsep.join(["B","A","C"])})
+                       'FOO': '"%s"' % os.pathsep.join(["test1","test2","test3"]),
+                       'BAH': '"%s"' % os.pathsep.join(["B","A","C"])})
 
         # FOO and BAH enabled as parent variables, but not present
         expected_actions = [Appendenv('FOO', 'test1'),
@@ -144,8 +144,8 @@ class TestRex(TestBase):
                    env={},
                    expected_actions=expected_actions,
                    expected_output = {
-                       'FOO': os.pathsep.join(["", "test1","test2","test3"]),
-                       'BAH': os.pathsep.join(["B","A", "","C"])},
+                       'FOO': '"%s"' % os.pathsep.join(["", "test1","test2","test3"]),
+                       'BAH': '"%s"' % os.pathsep.join(["B","A", "","C"])},
                    parent_variables=["FOO","BAH"])
 
         # FOO and BAH enabled as parent variables, and present
@@ -154,8 +154,8 @@ class TestRex(TestBase):
                         "BAH": "Z"},
                    expected_actions=expected_actions,
                    expected_output = {
-                       'FOO': os.pathsep.join(["tmp", "test1","test2","test3"]),
-                       'BAH': os.pathsep.join(["B","A", "Z","C"])},
+                       'FOO': '"%s"' % os.pathsep.join(["tmp", "test1","test2","test3"]),
+                       'BAH': '"%s"' % os.pathsep.join(["B","A", "Z","C"])},
                    parent_variables=["FOO","BAH"])
 
     def test_4(self):
@@ -306,8 +306,41 @@ class TestRex(TestBase):
                        Prependenv('BAH', 'B'),
                        Appendenv('BAH', 'C')],
                    expected_output = {
-                       'FOO': ",".join(["test1","test2","test3"]),
-                       'BAH': " ".join(["B","A","C"])})
+                       'FOO': '"%s"' % ",".join(["test1","test2","test3"]),
+                       'BAH': '"%s"' % " ".join(["B","A","C"])})
+
+    def test_9(self):
+        """Convert old style commands to rex"""
+
+        expected = ""
+        rez_commands = convert_old_commands([], annotate=False)
+        self.assertEqual(rez_commands, expected)
+
+        expected = "setenv('A', 'B')"
+        rez_commands = convert_old_commands(["export A=B"], annotate=False)
+        self.assertEqual(rez_commands, expected)
+
+        expected = "setenv('A', 'B:{env.C}')"
+        rez_commands = convert_old_commands(["export A=B:$C"], annotate=False)
+        self.assertEqual(rez_commands, expected)
+
+        expected = "appendenv('A', 'B')"
+        rez_commands = convert_old_commands(["export A=$A:B"], annotate=False)
+        self.assertEqual(rez_commands, expected)
+
+        expected = "prependenv('A', 'B')"
+        rez_commands = convert_old_commands(["export A=B:$A"], annotate=False)
+        self.assertEqual(rez_commands, expected)
+
+        expected = "appendenv('A', 'B:{env.C}')"
+        rez_commands = convert_old_commands(["export A=$A:B:$C"],
+                                            annotate=False)
+        self.assertEqual(rez_commands, expected)
+
+        expected = "prependenv('A', '{env.C}:B')"
+        rez_commands = convert_old_commands(["export A=$C:B:$A"],
+                                            annotate=False)
+        self.assertEqual(rez_commands, expected)
 
     def test_version_binding(self):
         """Test the Rex binding of the Version class."""
@@ -371,6 +404,7 @@ def get_test_suites():
     suite.addTest(TestRex("test_6"))
     suite.addTest(TestRex("test_7"))
     suite.addTest(TestRex("test_8"))
+    suite.addTest(TestRex("test_9"))
     suite.addTest(TestRex("test_version_binding"))
     suite.addTest(TestRex("test_old_style_commands"))
     suites.append(suite)

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -86,8 +86,8 @@ class TestRex(TestBase):
                        Source('./script.src')],
                    expected_output = {
                        'FOO': 'foo',
-                       'A': '"%s"' % os.pathsep.join(["/data","/tmp"]),
-                       'B': '"%s"' % os.pathsep.join(["/tmp","/data"])})
+                       'A': os.pathsep.join(["/data","/tmp"]),
+                       'B': os.pathsep.join(["/tmp","/data"])})
 
     def test_2(self):
         """Test simple setenvs and assignments."""
@@ -129,8 +129,8 @@ class TestRex(TestBase):
                        Prependenv('BAH', 'B'),
                        Appendenv('BAH', 'C')],
                    expected_output = {
-                       'FOO': '"%s"' % os.pathsep.join(["test1","test2","test3"]),
-                       'BAH': '"%s"' % os.pathsep.join(["B","A","C"])})
+                       'FOO':  os.pathsep.join(["test1","test2","test3"]),
+                       'BAH':  os.pathsep.join(["B","A","C"])})
 
         # FOO and BAH enabled as parent variables, but not present
         expected_actions = [Appendenv('FOO', 'test1'),
@@ -144,8 +144,8 @@ class TestRex(TestBase):
                    env={},
                    expected_actions=expected_actions,
                    expected_output = {
-                       'FOO': '"%s"' % os.pathsep.join(["", "test1","test2","test3"]),
-                       'BAH': '"%s"' % os.pathsep.join(["B","A", "","C"])},
+                       'FOO': os.pathsep.join(["", "test1","test2","test3"]),
+                       'BAH': os.pathsep.join(["B","A", "","C"])},
                    parent_variables=["FOO","BAH"])
 
         # FOO and BAH enabled as parent variables, and present
@@ -154,8 +154,8 @@ class TestRex(TestBase):
                         "BAH": "Z"},
                    expected_actions=expected_actions,
                    expected_output = {
-                       'FOO': '"%s"' % os.pathsep.join(["tmp", "test1","test2","test3"]),
-                       'BAH': '"%s"' % os.pathsep.join(["B","A", "Z","C"])},
+                       'FOO': os.pathsep.join(["tmp", "test1","test2","test3"]),
+                       'BAH': os.pathsep.join(["B","A", "Z","C"])},
                    parent_variables=["FOO","BAH"])
 
     def test_4(self):

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -183,6 +183,8 @@ class TestShells(TestBase, TempdirMixin):
             def _print(value):
                 env.FOO = value
                 info("${FOO}")
+                env.FOO.prepend("${FOO}")
+                env.FOO.append("${FOO}")
 
             env.GREET = "hi"
             env.WHO = "Gary"

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -823,6 +823,13 @@ def expandvars(text, environ=None):
     return text
 
 
+def remove_enclosing_quotes(string_):
+    """
+    return a string without the enclosing double quotes
+    """
+    return string_[1:-1] if string_.startswith('"') and string_.endswith('"') else string_
+
+
 def find_last_sublist(list_, sublist):
     """Given a list, find the last occurance of a sublist within it.
 


### PR DESCRIPTION
Hi Allan,

What I'm currently doing here is attempting to fix the escaping and quoting issue I mentioned before.

Basically I quote the whole string instead of the individual items when there is a list of values separated by an `env_sep`

so basically we end up with python strings like    `'"/path1:/path2"'   '"/path1;/path2"'` which are what we expect when they get interpreted by any shell

but with that change and adapting some test cases, there is one test case failing on `tests_context`. (probably the only piece of code calling `execute_command`) 

That fails  because the `PATH` end up like `'"/path1:/path2"'` with is totally fine if it gets interpreted by any shell but is breaks when is interpreted by python itself
The `subprocess` module does a naive split by `os.path.pathsep` ending up like
`"/path1`
`/path2"`

So these change does not fix the issue