### PR TITLE
Changelog Maxsize Setting

### DIFF
--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -234,11 +234,19 @@ class StandardBuildProcess(BuildProcess):
         self._hdr("Releasing %s..." % self.package.qualified_name)
         _do_build(install=True, clean=False)
 
+        def _trim_changelog(changelog, maxsize):
+            if maxsize == -1:
+                return changelog
+
+            lines = changelog.split("\n")
+            return "\n".join(lines[:maxsize])
+
         # write release info (changelog etc) into release path
+        changelog_maxsize = self.package.config.changelog_maxsize
         release_info = dict(
             timestamp=int(time.time()),
             revision=revision,
-            changelog=changelog)
+            changelog=_trim_changelog(changelog, changelog_maxsize))
 
         if self.release_message:
             release_message = self.release_message.strip()

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -195,6 +195,7 @@ config_schema = Schema({
     "resource_caching_maxsize":         Int,
     "resolve_max_depth":                Int,
     "resolve_start_depth":              Int,
+    "changelog_maxsize":                Int,
     "color_enabled":                    Bool,
     "resource_caching":                 Bool,
     "resolve_caching":                  Bool,

--- a/src/rez/rezconfig
+++ b/src/rez/rezconfig
@@ -239,7 +239,7 @@ release_hooks: []
 # release emails or elsewhere in the system.  No care is taken to ensure the
 # log is truncated gracefully so sentences may be cut off midway etc.
 # The size is measured in lines.  A value of -1 denotes an unbound changelog.
-changelog_maxsize: 0
+changelog_maxsize: -1
 
 
 ###############################################################################

--- a/src/rez/rezconfig
+++ b/src/rez/rezconfig
@@ -231,6 +231,16 @@ build_directory: build
 # rezplugins/release_hook.
 release_hooks: []
 
+# Limit the size of the changelog that is written to the release.yaml file. A
+# large changelog (especially one stretching to many megabytes) can
+# significantly hurt the performance of Rez at runtime as time is lost parsing
+# the yaml file.  Note this will only affect the size of the changelog in the
+# release.yaml file, it will not affect the changelog that appears in post-
+# release emails or elsewhere in the system.  No care is taken to ensure the
+# log is truncated gracefully so sentences may be cut off midway etc.
+# The size is measured in lines.  A value of -1 denotes an unbound changelog.
+changelog_maxsize: 0
+
 
 ###############################################################################
 # Suites


### PR DESCRIPTION
Add a setting to `rezconfig` that allows the changelog to be trimmed to a maximum size.  This prevents overly large `release.yaml` files (7MB is our largest yet) which greatly increase the resolve time in `rez env`.