### PR TITLE
rez lint command

### DIFF
--- a/src/rez/cli/_complete_util.py
+++ b/src/rez/cli/_complete_util.py
@@ -138,3 +138,7 @@ class SequencedCompleter(CombinedCompleter):
                 return completer(prefix, **kwargs)
 
         return []
+
+
+def EnvironmentVariableCompleter(prefix, **kwargs):
+    return os.environ.keys()

--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -16,6 +16,7 @@ subcommands = [
     "forward",
     "help",
     "interpret",
+    "lint",
     "python",
     "release",
     "search",

--- a/src/rez/cli/lint.py
+++ b/src/rez/cli/lint.py
@@ -1,0 +1,166 @@
+'''
+Sanity check envrionment variables in the current environment.  For path based
+variables, the following tests are performed:
+    * not null - to check an empty string (e.g. '   ') has not been used.
+    * duplicate - check for paths that appear more than once.
+    * not found - check the path exists on the current system.
+    * empty - check the path is not empty.
+    * file - the path is a single file (a folder is expected).
+'''
+from rez.colorize import heading, critical, error, warning, info, Printer
+from rez.config import config
+from rez.exceptions import RezError
+from rez.util import columnise
+from operator import attrgetter
+import os
+
+
+PRIORITY_MAPPING = {
+     50: critical,
+     40: error,
+     30: warning,
+     20: info
+}
+
+
+def setup_parser(parser, completions=False):
+
+    parser.add_argument("--errors-only", action="store_true",
+        help="only report paths that contain a problem.")
+    ENVVARS_action = parser.add_argument(
+        "ENVVARS", type=str, nargs='*',
+        help='variables in the environment to test')
+
+    if completions:
+        from rez.cli._complete_util import EnvironmentVariableCompleter
+        ENVVARS_action.completer = EnvironmentVariableCompleter
+
+
+def command(opts, parser, extra_arg_groups=None):
+
+    evironment_variables = opts.ENVVARS
+    errors_only = opts.errors_only
+
+    lint(variables=evironment_variables, errors_only=errors_only)
+
+
+def lint(variables=None, errors_only=False):
+    if not variables:
+        variables = config.lint_variables
+
+    rows = []
+    colours = []
+
+    for variable in variables:
+        rows.append((variable, ""))
+        colours.append(heading)
+
+        results = linter(variable)
+        if not results:
+            rows.append(("  -- no paths defined --", ""))
+            colours.append(info)
+            continue
+
+        for path, issues in results:
+            if errors_only and not issues:
+                continue
+
+            tags = '(%s)' % ', '.join(map(str, issues)) if issues else '(ok)'
+            cols = sorted(issues, key=attrgetter('priority'), reverse=True)
+
+            rows.append(("  %s" % path, tags))
+            colours.append(PRIORITY_MAPPING[cols[0].priority] if cols else info)
+
+    _pr = Printer()
+
+    for colour, line in zip(colours, columnise(rows)):
+        _pr(line, colour)
+
+
+def linter(variable):
+    separator = config.env_var_separators.get(variable, os.pathsep)
+    values = os.getenv(variable, "").split(separator)
+
+    consumed = []
+    for value in values:
+        if not value:
+            continue
+
+        issues = []
+
+        for seen in consumed:
+            if seen[0] == value:
+                issues.append(LintDuplicate())
+                break
+
+        else:
+            if not value.strip():
+                issues.append(LintNull())
+            elif not exists(value):
+                issues.append(LintNotFound())
+            else:
+                if is_dir(value):
+                    if is_empty(value):
+                        issues.append(LintEmpty())
+                else:
+                    issues.append(LintSingleFile())
+
+        consumed.append((value, issues))
+
+    return consumed
+
+
+def exists(path):
+    return os.path.exists(path)
+
+
+def is_dir(path):
+    return os.path.isdir(path)
+
+
+def is_empty(path):
+    return not bool(os.listdir(path))
+
+
+class LintError(RezError):
+    pass
+
+
+class LintNull(LintError):
+    priority = 30
+    colour = warning
+
+    def __str__(self):
+        return "null"
+
+
+class LintDuplicate(LintError):
+    priority = 40
+    colour = error
+
+    def __str__(self):
+        return "duplicate"
+
+
+class LintNotFound(LintError):
+    priority = 50
+    colour = critical
+
+    def __str__(self):
+        return "not found"
+
+
+class LintEmpty(LintError):
+    priority = 30
+    colour = warning
+
+    def __str__(self):
+        return "empty"
+
+
+class LintSingleFile(LintError):
+    priority = 20
+    colour = info
+
+    def __str__(self):
+        return "single file"

--- a/src/rez/cli/selftest.py
+++ b/src/rez/cli/selftest.py
@@ -34,6 +34,8 @@ def setup_parser(parser, completions=False):
                         help="test versions")
     parser.add_argument("--schema", action="store_true",
                         help="test schema validation")
+    parser.add_argument("--lint", action="store_true",
+                        help="test environment linting")
 
 
 def get_suites(opts):
@@ -41,7 +43,7 @@ def get_suites(opts):
 
     tests = ["shells", "solver", "formatter", "commands", "rex", "build",
              "release", "context", "resources", "packages", "config",
-             "completion", "suites", "version", "schema"]
+             "completion", "suites", "version", "schema", "lint"]
     suites = []
     test_all = all(not getattr(opts, test) for test in tests)
 

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -152,6 +152,7 @@ config_schema = Schema({
     "parent_variables":                 StrList,
     "resetting_variables":              StrList,
     "release_hooks":                    StrList,
+    "lint_variables":                   StrList,
     "critical_styles":                  OptionalStrList,
     "error_styles":                     OptionalStrList,
     "warning_styles":                   OptionalStrList,

--- a/src/rez/rezconfig
+++ b/src/rez/rezconfig
@@ -165,6 +165,13 @@ terminal_emulator_command:
 env_var_separators:
     CMAKE_MODULE_PATH: ';'
 
+# These environment variables are used with the 'rez lint' command for basic 
+# sanity checking purposes.
+lint_variables:
+- PYTHONPATH
+- LD_LIBRARY_PATH
+- PATH
+
 
 ###############################################################################
 # Debugging

--- a/src/rez/tests/test_lint.py
+++ b/src/rez/tests/test_lint.py
@@ -1,0 +1,104 @@
+from rez.cli.lint import linter, LintNull
+from rez.tests.util import TestBase, TempdirMixin
+import rez.vendor.unittest2 as unittest
+import os
+
+
+class TestLint(TestBase, TempdirMixin):
+
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+
+        cls.settings = dict()
+        cls.test_variable = "LINT_TEST_VARIABLE"
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    def assertConsumed(self, expected, actual):
+        self.assertEqual(expected[0], actual[0], "consumed path error")
+        self.assertEqual(expected[1], map(str, actual[1]), "exceptions error")
+
+
+class TestLintOk(TestLint):
+
+    @classmethod
+    def setUpClass(cls):
+        TestLint.setUpClass()
+
+        cls.test_file = os.path.join(cls.root, "LINT_TEST_FILE")
+        with open(cls.test_file, "w") as fd:
+            fd.write("Hello, World!")
+
+    def test_variable_with_file(self):
+        os.environ[self.test_variable] = self.test_file
+        consumed = linter(self.test_variable)
+
+        self.assertEqual(1, len(consumed))
+        self.assertConsumed((self.test_file, ["single file"]), consumed[0])
+
+    def test_valid_variable(self):
+        os.environ[self.test_variable] = self.root
+        consumed = linter(self.test_variable)
+
+        self.assertEqual(1, len(consumed))
+        self.assertConsumed((self.root, []), consumed[0])
+
+
+class TestLintFailures(TestLint):
+
+    def test_variable_with_no_paths(self):
+
+        os.environ[self.test_variable] = ""
+        consumed = linter(self.test_variable)
+
+        self.assertEqual(0, len(consumed))
+
+    def test_variable_with_empty_paths(self):
+
+        os.environ[self.test_variable] = "  "
+        consumed = linter(self.test_variable)
+
+        self.assertEqual(1, len(consumed))
+        self.assertConsumed(("  ", ["null"]), consumed[0])
+
+    def test_variable_with_missing_path(self):
+
+        os.environ[self.test_variable] = "/foo"
+        consumed = linter(self.test_variable)
+
+        self.assertEqual(1, len(consumed))
+        self.assertConsumed(("/foo", ["not found"]), consumed[0])
+
+    def test_variable_exists_but_empty(self):
+        os.environ[self.test_variable] = self.root
+        consumed = linter(self.test_variable)
+
+        self.assertEqual(1, len(consumed))
+        self.assertConsumed((self.root, ["empty"]), consumed[0])
+
+    def test_variable_with_duplicate_path(self):
+        os.environ[self.test_variable] = "/foo:/foo"
+        consumed = linter(self.test_variable)
+
+        self.assertEqual(2, len(consumed))
+        self.assertConsumed(("/foo", ["not found"]), consumed[0])
+        self.assertConsumed(("/foo", ["duplicate"]), consumed[1])
+
+
+def get_test_suites():
+
+    suites = []
+    tests = [TestLintFailures]
+
+    for test in tests:
+        suites.append(unittest.TestLoader().loadTestsFromTestCase(test))
+
+    return suites
+
+
+if __name__ == '__main__':
+
+    unittest.main()


### PR DESCRIPTION
Add a new `rez lint` command.

This command inspects a list of predefined environment variables (`PYTHONPATH`, `LD_LIBRARY_PATH` and `PATH` by default) and reports back information about the entries in the variable.  Information includes:
- duplicates
- paths which do not exist
- paths which exist and are empty

All three of these are potentially considered error conditions resulting in an unclean environment.  This tool can be used as a diagnostic to identify these problems.

Ideally this would also tell you the name-version of the package that introduced the path in question.  Currently this is implied from the path itself.  As discussed, an update to Rex would be required to enable this.
