### PR TITLE
Doxygen Tagfiles Support

### DIFF
--- a/src/rez/rezconfig
+++ b/src/rez/rezconfig
@@ -164,6 +164,7 @@ terminal_emulator_command:
 # configured separator will be used.
 env_var_separators:
     CMAKE_MODULE_PATH: ';'
+    DOXYGEN_TAGFILES: ' '
 
 
 ###############################################################################


### PR DESCRIPTION
The `rez_install_doxygen` macro can be used to generate a tag file automatically by adding the `GENERATE_TAGFILE` option.  With this option enabled the `GENERATE_TAGFILE` setting will be automatically added to the doxyfile with a value of `<package>.tag`.  At build time this will cause Doxygen to generate a tag file named `<package>.tag` and install it alongside the remainder of the documentation.

To allow another project access to the tag file, an environment variable called `DOXYGEN_TAGS` must be extended (either append or prepend) to include the file that has been generated.  This can be done by adding to the commands section of the package's package.yaml file.

    commands:
    - export DOXYGEN_TAGFILES='!ROOT!/doc/<package>.tag=!ROOT!/doc/html $DOXYGEN_TAGFILES'

To use the tag file provided by a dependency as part of your documentation you can use the `rez_install_doxygen` macro by adding the `USE_TAGFILES` option.  With this option enabled the `TAGFILES` settings will be automatically added to the doxyfile with a value of `$(DOXYGEN_TAGFILES)`.  At build time this will cause Doxygen to reference the DOXYGEN_TAGFILES environment variable set by the dependencies and therefore enable the documentation currently being built to link to them.

More on doxygen tagfiles can be found at http://www.stack.nl/~dimitri/doxygen/manual/external.html.