### PR TITLE
Sort print_info on ResolvedContext

### DIFF
--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -591,8 +591,13 @@ class ResolvedContext(object):
             d["removed_packages"] = removed_packages
         return d
 
-    def print_info(self, buf=sys.stdout, verbosity=0):
+    def print_info(self, buf=sys.stdout, verbosity=0, sort=False):
         """Prints a message summarising the contents of the resolved context.
+
+        Args:
+            sort: If True, the packages will be sorted alphabetically before
+                being printed.  If False, packages are printed in the
+                resolved order.
         """
         _pr = Printer(buf)
 
@@ -657,7 +662,13 @@ class ResolvedContext(object):
         _pr("resolved packages:", heading)
         rows = []
         colors = []
-        for pkg in (self.resolved_packages or []):
+
+        pkgs = (self.resolved_packages or [])
+        if sort:
+            pkgs = sorted(self.resolved_packages,
+                          key=lambda rpkg : rpkg.name.lower())
+
+        for pkg in pkgs:
             t = []
             col = None
             if not os.path.exists(pkg.root):


### PR DESCRIPTION
Add an argument to allow the output of `print_info` method on a `ResolvedContext` to be alphabetically sorted.

We discussed making this configurable so that the global behaviour can be set for `rez env`, as well as adding a command line option.  I haven't had time to to this, and most likely wont before Christmas.  This keeps current behaviour and gets us part of the way there - I'll try and finish it off with a new pull request next year.