### PR TITLE
Targeted Resource Location

### DIFF
--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -1,7 +1,7 @@
 from rez.resources import _or_regex, _updated_schema, register_resource, \
     Resource, SearchPath, ArbitraryPath, FolderResource, FileResource, \
     Required, metadata_loaders, iter_descendant_resources, _listdir, \
-    _ResourcePathParser
+    _ResourcePathParser, _findpath
 from rez.config import config, Config, create_config
 from rez.exceptions import ResourceNotFoundError, PackageMetadataError
 from rez.util import propertycache, deep_update, print_warning
@@ -121,6 +121,10 @@ class MetadataFolder(FolderResource):
     path_pattern = '.metadata'
     parent_resource = PackageVersionFolder
 
+    @classmethod
+    def _iter_instances(cls, parent_resource):
+        return cls._iter_instance(parent_resource)
+
 
 class ReleaseTimestampResource(FileResource):
     # Deprecated
@@ -128,6 +132,10 @@ class ReleaseTimestampResource(FileResource):
     path_pattern = 'release_time.txt'
     parent_resource = MetadataFolder
     schema = Use(int)
+
+    @classmethod
+    def _iter_instances(cls, parent_resource):
+        return cls._iter_instance(parent_resource)
 
 
 class ChangelogResource(FileResource):
@@ -180,6 +188,10 @@ class ReleaseDataResource(FileResource):
         Optional('previous_revision'): object,
         Optional(basestring): object
     })
+
+    @classmethod
+    def _iter_instances(cls, parent_resource):
+        return cls._iter_instance(parent_resource)
 
 
 class BasePackageResource(FileResource):
@@ -370,22 +382,14 @@ class VersionedPackageResource(BasePackageResource):
     versioned = True
 
     @classmethod
-    def iter_instances(cls, parent_resource):
-        instances = []
-        for name in _listdir(parent_resource.path, cls.is_file):
-            match = _ResourcePathParser.parse_filepart(cls, name)
-            if match is not None:
-                variables = match[1]
+    def _iter_instances(cls, parent_resource):
+        for ext in ['yaml', 'py', 'txt']:
+            filepath = os.path.join(parent_resource.path, "package." + ext)
+            if _findpath(filepath, is_file=cls.is_file):
+                variables = {"ext": ext}
                 variables.update(parent_resource.variables)
-                filepath = os.path.join(parent_resource.path, name)
-                instances.append(cls(filepath, variables))
-
-        if instances:
-            if len(instances) > 1:
-                ext_sort_order = ('py', 'yaml', 'txt')
-                instances.sort(
-                    key=lambda x: ext_sort_order.index(x.variables['ext']))
-            yield instances[0]
+                yield cls(filepath, variables)
+                break
 
     def convert_version(self, value):
         """Deals with two errors:


### PR DESCRIPTION
Some resources have a static pattern for the file being located (no wildcards).  This means we can look for them directly rather than looking at every child of the parent resource.  For things like `release.yaml` this can make quite a difference in resolution time.

I know you are working on the resource system anyway, but we've had this change locally for quite a while and it's working well.  Until the larger work is done, every little helps!