### PR TITLE
Misc. Build Process Changes

### DIFF
--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -148,12 +148,13 @@ class StandardBuildProcess(BuildProcess):
     def release(self):
         assert(self.vcs)
         install_path = self.package.config.release_packages_path
+
+        if not os.path.exists(install_path):
+            os.mkdir(install_path)
+
         base_build_path = os.path.join(self.working_dir,
                                        self.package.config.build_directory,
                                        "release")
-
-        if not os.path.exists(install_path):
-            raise ReleaseError("Release path does not exist: %r" % install_path)
 
         print "Checking state of repository..."
         self.vcs.validate_repostate()
@@ -377,6 +378,9 @@ class LocalSequentialBuildProcess(StandardBuildProcess):
             if r.status != ResolverStatus.solved:
                 raise BuildContextResolveError(r)
 
+            if install and not os.path.exists(install_path):
+                os.makedirs(install_path)
+
             # run build system
             self._pr("\nInvoking %s build system..." % self.buildsys.name())
             ret = self.buildsys.build(r,
@@ -392,8 +396,6 @@ class LocalSequentialBuildProcess(StandardBuildProcess):
 
                 extra_files = ret.get("extra_files", []) + [rxt_file]
                 if install and extra_files:
-                    if not os.path.exists(install_path):
-                        os.makedirs(install_path)
                     for file in extra_files:
                         shutil.copy(file, install_path)
             else:

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -154,8 +154,6 @@ class CMakeBuildSystem(BuildSystem):
         # assemble make command
         cmd = ["make"]
         cmd += (self.child_build_args or [])
-        if install and "install" not in cmd:
-            cmd.append("install")
 
         # execute make within the build env
         _pr("\nExecuting: %s" % ' '.join(cmd))
@@ -163,6 +161,16 @@ class CMakeBuildSystem(BuildSystem):
                                               block=True,
                                               cwd=build_path,
                                               actions_callback=callback)
+        if not retcode and install and "install" not in cmd:
+            cmd.append("install")
+
+            # execute make install within the build env
+            _pr("\nExecuting: %s" % ' '.join(cmd))
+            retcode, _, _ = context.execute_shell(command=cmd,
+                                                  block=True,
+                                                  cwd=build_path,
+                                                  actions_callback=callback)
+
         ret["success"] = (not retcode)
         return ret
 


### PR DESCRIPTION
+ Call `make ; make install` instead of just `make install`.  This is closer to Rez 1 behaviour and works around a problem in the ExternalProjectAdd macro of CMake.

+ Ensure install paths are always made.  This includes the `REZ_LOCAL_PACKAGES_PATH` value as well as the variant subfolder.  Previously this was taken care of by CMake macros when installing `package.yaml` files etc.  Now that is no longer the case not having them made can cause build issues.
