### PR TITLE
fix for resolving of CombinedPackages

### DIFF
--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -505,6 +505,16 @@ class CombinedPackageResource(BasePackageResource):
             yield cls(parent_resource.path, variables)
 
 
+class CombinedVariantResource(BaseVariantResource):
+    """A variant within a `CombinedPackageResource`."""
+    key = 'variant.combined'
+    parent_resource = CombinedPackageResource
+    variable_keys = ["index"]
+    sub_resource = True
+    schema = None
+    versioned = True
+
+
 # -----------------------------------------------------------------------------
 # Developer Package Resources
 # -----------------------------------------------------------------------------
@@ -573,6 +583,7 @@ register_resource(VersionlessVariantResource)
 register_resource(ReleaseDataResource)
 register_resource(CombinedPackageFamilyResource)
 register_resource(CombinedPackageResource)
+register_resource(CombinedVariantResource)
 # deprecated
 register_resource(MetadataFolder)
 register_resource(ReleaseTimestampResource)

--- a/src/rez/resources.py
+++ b/src/rez/resources.py
@@ -556,7 +556,7 @@ class Resource(object):
     @classmethod
     def _path_pattern(cls):
         hierarchy = cls.ancestors() + (cls,)
-        parts = [r.path_pattern for r in hierarchy if r]
+        parts = [r.path_pattern for r in hierarchy if r and r.path_pattern]
         return os.path.sep.join(parts)
 
     @classmethod

--- a/src/rez/tests/data/solver/packages/multi.yaml
+++ b/src/rez/tests/data/solver/packages/multi.yaml
@@ -1,0 +1,15 @@
+name: multi
+
+tools:
+- tweak
+
+versions:
+- '1.0'
+- '1.1'
+- '1.2'
+
+version_overrides:
+    '1.1+':
+        tools:
+        - twerk
+

--- a/src/rez/tests/data/solver/packages/single_unversioned.yaml
+++ b/src/rez/tests/data/solver/packages/single_unversioned.yaml
@@ -1,0 +1,1 @@
+name: single_unversioned

--- a/src/rez/tests/data/solver/packages/single_versioned.yaml
+++ b/src/rez/tests/data/solver/packages/single_versioned.yaml
@@ -1,0 +1,4 @@
+name: single_versioned
+
+versions:
+- '3.5'

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -190,6 +190,14 @@ class TestSolver(TestBase):
         s = self._fail("pymum-2")
         self.assertFalse(isinstance(s.failure_reason(), Cycle))
 
+    def test_9(self):
+        """Basic solves involving single combined packages"""
+        self._solve(["multi"],
+                    ["multi-1.2[]"])
+        self._solve(["single_unversioned"],
+                    ["single_unversioned[]"])
+        self._solve(["single_versioned"],
+                    ["single_versioned-3.5[]"])
 
 def get_test_suites():
     suites = []
@@ -202,6 +210,7 @@ def get_test_suites():
     suite.addTest(TestSolver("test_6"))
     suite.addTest(TestSolver("test_7"))
     suite.addTest(TestSolver("test_8"))
+    suite.addTest(TestSolver("test_9"))
     suites.append(suite)
     return suites
 


### PR DESCRIPTION
Basically, CombinedPackages were broken, as they woudn't resolve, due to the lack of a CombinedVariantResource class, to allow them to handle variants.  This adds such a subclass, and adds tests for basic resolving of combined pacakges.