### PR TITLE
Removed $ prefix from env var names in os.getenv (csh and sh plugins)

### DIFF
--- a/src/rezplugins/shell/csh.py
+++ b/src/rezplugins/shell/csh.py
@@ -82,8 +82,8 @@ class CSH(UnixShell):
 
     def _bind_interactive_rez(self):
         if config.prompt:
-            stored_prompt = os.getenv("$REZ_STORED_PROMPT")
-            curr_prompt = stored_prompt or os.getenv("$prompt", "[%m %c]%# ")
+            stored_prompt = os.getenv("REZ_STORED_PROMPT")
+            curr_prompt = stored_prompt or os.getenv("prompt", "[%m %c]%# ")
             if not stored_prompt:
                 self.setenv("REZ_STORED_PROMPT", '"%s"' % curr_prompt)
 

--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -82,8 +82,8 @@ class SH(UnixShell):
 
     def _bind_interactive_rez(self):
         if config.prompt:
-            stored_prompt = os.getenv("$REZ_STORED_PROMPT")
-            curr_prompt = stored_prompt or os.getenv("$PS1", "\\h:\\w]$ ")
+            stored_prompt = os.getenv("REZ_STORED_PROMPT")
+            curr_prompt = stored_prompt or os.getenv("PS1", "\\h:\\w]$ ")
             if not stored_prompt:
                 self.setenv("REZ_STORED_PROMPT", '"%s"' % curr_prompt)
 


### PR DESCRIPTION
In the csh and sh plugins, the 'REZ_STORED_PROMPT', 'PS1' and 'prompt'
environment varialbe names were prefixed with '$' when passed to
os.getenv. This resulted in os.getenv looking for, for example, an
environment variable called '$REZ_STORED_PROMPT' instead of
'REZ_STORED_PROMPT', which resulted in incorrect prompts being
generated in Rez sub-shells.