### PR TITLE
_get_family_dirs makes sure location exists on disk

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -483,6 +483,8 @@ class FileSystemPackageRepository(PackageRepository):
     @mem_cached(DataType.listdir, key_func=_get_family_dirs__key)
     def _get_family_dirs(self):
         dirs = []
+        if not os.path.isdir(self.location):
+            return dirs
         for name in os.listdir(self.location):
             path = os.path.join(self.location, name)
             if os.path.isdir(path):


### PR DESCRIPTION
When using auto-completion, rez could trip in listing fodlers that don't exist. This takes care of that.