### PR TITLE
Added missing 'variant' keyword argument

### DIFF
--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -168,7 +168,7 @@ class CMakeBuildSystem(BuildSystem):
         return ret
 
     @staticmethod
-    def _add_build_actions(executor, context, package, build_type):
+    def _add_build_actions(executor, context, package, variant, build_type):
         settings = package.config.plugins.build_system.cmake
         cmake_path = os.path.join(os.path.dirname(__file__), "cmake_files")
         template_path = os.path.join(os.path.dirname(__file__), "template_files")


### PR DESCRIPTION
Commit 5622205 removed the 'variant' keyword argument from the
_add_build_actions method in the cmake.py build system. It looks like this
might have been done in error during merging of that commit. The
argument was introduced in commit 6256b04, and rez build fails with a
TypeError exception without it.