### PR TITLE
make is_local return False by default, with real implementation on filesystem resources

### DIFF
--- a/src/rez/package_resources_.py
+++ b/src/rez/package_resources_.py
@@ -207,6 +207,14 @@ class PackageRepositoryResource(Resource):
         """
         raise NotImplementedError
 
+    @property
+    def is_local(self):
+        """Returns True if the variant is from a local package"""
+        # Base implementation returns False, because currently, a file is local
+        # only if it was found inside the directory defined by the
+        # local_packages_path - which means only FileSystem resources can be
+        # local... so override a "real" check for is_local in those subclasses
+        return False
 
 class PackageFamilyResource(PackageRepositoryResource):
     """A package family.
@@ -382,3 +390,8 @@ class VariantResourceHelper(VariantResource):
     def _load(self):
         # doesn't have its own data, forwards on from parent instead
         return None
+
+    @property
+    def is_local(self):
+        """Returns True if the family is from a local package"""
+        return self.parent.is_local

--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -5,7 +5,6 @@ from rez.package_resources_ import PackageFamilyResource, PackageResource, \
 from rez.package_serialise import dump_package_data
 from rez.utils.data_utils import cached_property
 from rez.utils.formatting import StringFormatMixin, StringFormatType
-from rez.utils.filesystem import is_subdirectory
 from rez.utils.schema import schema_keys
 from rez.utils.resources import ResourceHandle, ResourceWrapper
 from rez.exceptions import PackageMetadataError, PackageFamilyNotFoundError
@@ -73,8 +72,13 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
 
     @cached_property
     def is_local(self):
-        """Returns True if the variant is from a local package"""
+        """Returns True if the package/variant is from a local package"""
         return is_subdirectory(self.base, config.local_packages_path)
+
+    @cached_property
+    def is_local(self):
+        """Returns True if the package/variant is from a local package"""
+        return self.wrapped.is_local
 
     def print_info(self, buf=None, format_=FileFormat.yaml,
                    skip_attributes=None, include_release=False):

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -653,14 +653,15 @@ class ResolvedContext(object):
         for pkg in resolved_packages:
             t = []
             col = None
-            if not os.path.exists(pkg.root):
+            if pkg.root and not os.path.exists(pkg.root):
                 t.append('NOT FOUND')
                 col = critical
             if pkg.is_local:
                 t.append('local')
                 col = local
             t = '(%s)' % ', '.join(t) if t else ''
-            rows.append((pkg.qualified_package_name, pkg.root, t))
+            location = pkg.root or pkg.base or pkg.uri
+            rows.append((pkg.qualified_package_name, location, t))
             colors.append(col)
 
         for col, line in zip(colors, columnise(rows)):

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -38,8 +38,8 @@ class TempDirs(object):
         self.clear()
 
 
-def is_subdirectory(path_a, path_b):
-    """Returns True if `path_a` is a subdirectory of `path_b`."""
+def is_subpath(path_a, path_b):
+    """Returns True if `path_a` is a subpath of `path_b`."""
     path_a = os.path.realpath(path_a)
     path_b = os.path.realpath(path_b)
     relative = os.path.relpath(path_a, path_b)


### PR DESCRIPTION
since is_local is defined by whether or not it is found in the "local packages path", it seems a concept that really only makes sense for filesystem resources.  As source, made the default implementation of is_local always return False, and override this on the filesystem resources.

This is a potential fix to this issue: https://github.com/nerdvegas/rez/issues/162

...and it touches on some of the issues in this thread: https://groups.google.com/forum/#!topic/rez-config/5q1k0iJFGEs

However, it's still not an ideal solution, as it still makes the assumption that pkg.root is a directory (and runs os.path.exists on it).

Perhaps a better / more generic approach would be allow resources to provide aritrary "tags" with additional information about that particular resource, and then rez-context could display these tags.  In this particular case, filesystem resources could attach a "local" tag to packages it finds within the local packages path.

The "NOT FOUND" information could also be implemented as a tag... or, alternatively, we could provide resources with the ability to perform validation, in some way appropriate for that resource type, and return brief descriptions if problems are found.