### PR TITLE
rex_bindings: VersionBinding shouldn't have an infinite iterator

### DIFF
--- a/src/rez/rex_bindings.py
+++ b/src/rez/rex_bindings.py
@@ -92,6 +92,11 @@ class VersionBinding(Binding):
     def __str__(self):
         return str(self.__version)
 
+    def __iter__(self):
+        # without this, the binding will iterate infinitely, returning more
+        # None objects...
+        return iter(self.__version)
+
 
 class VariantBinding(Binding):
     """Binds a packages.Variant object."""


### PR DESCRIPTION
Otherwise, a line this this:

env.VER_ALT = '*'.join(str(x) for x in version)

...will hang