### PR TITLE
RezInstallCMake Fix for Windows

### DIFF
--- a/src/rezplugins/build_system/cmake_files/RezInstallCMake.cmake
+++ b/src/rezplugins/build_system/cmake_files/RezInstallCMake.cmake
@@ -123,7 +123,7 @@ macro(rez_install_cmake)
     endif()
 	install(CODE "
 		set(REZ_BUILD_ENV 1)
-		list(APPEND CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
+		list(APPEND CMAKE_MODULE_PATH ${POSIX_CMAKE_MODULE_PATH})
 		include(RezInstallCMake)
 		_rez_install_auto_cmake(${auto_args})
 	    set(REZ_BUILD_ENV 0)


### PR DESCRIPTION
Sorry @nerdvegas a small variable name fix for the `RezInstallCMake` module - a dodgy refactor while changing this code.