### PR TITLE
make rez-status print URI, not path

### DIFF
--- a/src/rez/status.py
+++ b/src/rez/status.py
@@ -271,10 +271,10 @@ class Status(object):
             else:
                 name = package.qualified_package_name  # Variant
             _pr("Package:  %s" % name)
+            path_str = "URI:      %s" % package.uri
             if package.is_local:
-                _pr("Path:     %s  (local)" % package.path, local)
-            else:
-                _pr("Path:     %s" % package.search_path)
+                path_str += "  (local)"
+            _pr(path_str)
 
         try:
             req = PackageRequest(request_str)


### PR DESCRIPTION
fix for https://github.com/nerdvegas/rez/issues/173

in resources2 branch, packages aren't guaranteed to have paths, only URI