### PR TITLE
Version normalize

### DIFF
--- a/src/rez/package_resources_.py
+++ b/src/rez/package_resources_.py
@@ -4,7 +4,7 @@ from rez.utils.logging_ import print_warning
 from rez.utils.data_utils import cached_property, SourceCode, \
     AttributeForwardMeta, LazyAttributeMeta
 from rez.utils.formatting import PackageRequest
-from rez.exceptions import PackageMetadataError
+from rez.exceptions import ResourceError, PackageMetadataError
 from rez.config import config, Config, create_config
 from rez.vendor.version.version import Version
 from rez.vendor.schema.schema import Schema, SchemaError, Optional, Or, And, Use
@@ -186,9 +186,17 @@ class PackageRepositoryResource(Resource):
     schema_error = PackageMetadataError
     repository_type = None
 
+    @classmethod
+    def normalize_variables(cls, variables):
+        if "repository_type" not in variables or "location" not in \
+                variables:
+            raise ResourceError("%s resources require a repository_type and "
+                                "location" % cls.__name__)
+        return super(PackageRepositoryResource, cls).normalize_variables(
+            variables)
+
     def __init__(self, variables=None):
         super(PackageRepositoryResource, self).__init__(variables)
-        self._repository = None
 
     @cached_property
     def uri(self):
@@ -234,7 +242,7 @@ class PackageResource(PackageRepositoryResource):
         # if the version is False, empty string, etc, throw it out
         if variables.get('version', True) in ('', False, '_NO_VERSION', None):
             del variables['version']
-        return variables
+        return super(PackageResource, cls).normalize_variables(variables)
 
     @cached_property
     def version(self):

--- a/src/rez/package_resources_.py
+++ b/src/rez/package_resources_.py
@@ -226,6 +226,16 @@ class PackageResource(PackageRepositoryResource):
     A repository implementation's package resource(s) must derive from this
     class. It must satisfy the schema `package_schema`.
     """
+
+    @classmethod
+    def normalize_variables(cls, variables):
+        """Make sure version is treated consistently
+        """
+        # if the version is False, empty string, etc, throw it out
+        if variables.get('version', True) in ('', False, '_NO_VERSION', None):
+            del variables['version']
+        return variables
+
     @cached_property
     def version(self):
         ver_str = self.get("version", "")

--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -415,19 +415,19 @@ def create_package(name, data):
 
 
 def get_variant(variant_handle):
-    """Create a variant given its handle.
+    """Create a variant given its handle (or serialized dict equivalent)
 
     Args:
         variant_handle (`ResourceHandle` or dict): Resource handle, or
-            equivalent dict.
+            equivalent serialized dict representation from
+            ResourceHandle.to_dict
 
     Returns:
         `Variant`.
     """
     if isinstance(variant_handle, dict):
         variant_handle = ResourceHandle.from_dict(variant_handle)
-
-    variant_resource = package_repository_manager.get_resource(variant_handle)
+    variant_resource = package_repository_manager.get_resource_from_handle(variant_handle)
     variant = Variant(variant_resource)
     return variant
 

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -260,5 +260,17 @@ class TestPackages(TestBase, TempdirMixin):
             self.assertDictEqual(data, data_)
 
 
+class TestMemoryPackages(TestBase):
+    def test_1_memory_variant_parent(self):
+        """Test that a package's variant's parent is the original package
+        """
+        desc = 'the foo package'
+        package = create_package('foo', {'description': desc})
+        self.assertEqual(package.description, desc)
+        variant = package.iter_variants().next()
+        parent_package = variant.parent
+        self.assertEqual(package.description, desc)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/utils/resources.py
+++ b/src/rez/utils/resources.py
@@ -80,12 +80,12 @@ class Resource(object):
         return variables
 
     def __init__(self, variables=None):
-        self.variables = variables or {}
+        self.variables = self.normalize_variables(variables or {})
 
     @cached_property
     def handle(self):
         """Get the resource handle."""
-        return self._repository.make_resource_handle(self.key, **self.variables)
+        return ResourceHandle(self.key,self.variables)
 
     @cached_property
     def _data(self):

--- a/src/rezplugins/package_repository/memory.py
+++ b/src/rezplugins/package_repository/memory.py
@@ -72,7 +72,9 @@ class MemoryPackageResource(PackageResourceHelper):
 
     def _load(self):
         family_data = self._repository.data.get(self.name, {})
-        version_str = self.get("version", "_NO_VERSION")
+        version_str = self.get("version")
+        if not version_str:
+            version_str = "_NO_VERSION"
         package_data = family_data.get(version_str, {})
         return package_data
 


### PR DESCRIPTION
This is a fix for https://github.com/nerdvegas/rez/issues/190

Currently, resource handle objects have no means for enforcing standardization, which can result in cache misses, since they're used as keys.  This is particularly problematic with memory resources, since a cache miss can mean not just inefficiency, but retrieving the wrong data.

This branch adds a mechanism for allowing different resource types to normalize / standardize their variables, and then uses that to standard the way the "version" variable is stored.

There's also a few minor test updates in this branch