### PR TITLE
Custom per-package version priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Rez is a cross-platform software package management API and set of tools. Rez can
 build and install packages, and resolve environments at runtime that use a dependency
-resolution algorithm to avoid version conflicts. The main tools are:
+resolution algorithm to avoid version conflicts. Both third party and internally
+developed packages can be made into Rez packages, and any kind of package (python,
+compiled, etc) is supported.
+
+The main tools are:
 
 * **rez-env**: Creates a configured shell containing a set of requested packages.
   Supports *bash*, *tcsh* and *cmd* (Windows), and can be extended to other shells.

--- a/src/rez/cli/python.py
+++ b/src/rez/cli/python.py
@@ -13,6 +13,7 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "ARG", type=str, nargs='*',
         help='arguments to python script')
+    parser.add_argument('-c', help="python code to execute", dest='command')
 
     if completions:
         from rez.cli._complete_util import FilesCompleter
@@ -28,6 +29,9 @@ def command(opts, parser, extra_arg_groups=None):
 
     if opts.interactive:
         cmd.append("-i")
+
+    if opts.command:
+        cmd.extend(['-c', opts.command])
 
     if opts.FILE:
         cmd.append(opts.FILE)

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -214,6 +214,7 @@ config_schema = Schema({
     "rez_tools_visibility":                         RezToolsVisibility_,
     "suite_alias_prefix_char":                      Char,
     "tmpdir":                                       OptionalStr,
+    "context_tmpdir":                               OptionalStr,
     "default_shell":                                OptionalStr,
     "terminal_emulator_command":                    OptionalStr,
     "editor":                                       OptionalStr,
@@ -508,6 +509,10 @@ class Config(object):
     # -- dynamic defaults
 
     def _get_tmpdir(self):
+        from rez.utils.platform_ import platform_
+        return platform_.tmpdir
+
+    def _get_context_tmpdir(self):
         from rez.utils.platform_ import platform_
         return platform_.tmpdir
 

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -184,38 +184,69 @@ class VariantSelectMode_(Str):
 class VersionPriority_(Setting):
     @cached_class_property
     def schema(cls):
-        from rez.solver import VersionPriorityMode
         return Or(
             {},
             # None, in which case it's an empty dict..
             And(None, Use(lambda x: {})),
             # Or they give a dict, mapping from package name to setting...
             Schema({
-                str: Or(
-                    # each package is either "lastest" / "earliest", or...
-                    VersionPriorityMode,
-                    And(Or(*(x.name for x in VersionPriorityMode)),
-                        Use(VersionPriorityMode.__getitem__)),
-
-                    # ...a list, giving an explicit version priority
-                    And(
-                        [Or(
-                            # Allow False, or "", which is converted to
-                            # False
-                            False,
-                            And("", Use(bool)),
-                            # Or a VersionRange,
-                            VersionRange,
-                            # ...or value which can be converted to a
-                            # VersionRange
-                            And(basestring, Use(VersionRange)),
-                            And(Or(int, float), Use(str),
-                                Use(VersionRange)))],
-                        # Verify that there's at most one False
-                        lambda x: x.count(False) <= 1)
-                )
+                str: cls.version_priority_entry_validate_schema,
             }),
         )
+
+    @classmethod
+    def _make_version_priority_entry_schema(cls, output_python_objs):
+        from rez.solver import VersionPriorityMode
+
+        if output_python_objs:
+            to_ver_prio_mode = Use(VersionPriorityMode.__getitem__)
+            to_ver_range = Use(VersionRange)
+        else:
+            nop = lambda x: x
+            to_ver_prio_mode = nop
+            to_ver_range = nop
+
+        return Or(
+            # each package is either "lastest" / "earliest", or...
+            And(Or(*(x.name for x in VersionPriorityMode)),
+                to_ver_prio_mode
+            ),
+
+            # ...a list, giving an explicit version priority
+            And(
+                [Or(
+                    # Allow False, or "", which is converted to
+                    # False
+                    False,
+                    And("", Use(bool)),
+                    # ...or value which can be converted to a
+                    # VersionRange
+                    And(basestring, to_ver_range),
+                    And(Or(int, float), Use(str), to_ver_range),
+                )],
+                # Verify that there's at most one False
+                lambda x: x.count(False) <= 1
+            )
+        )
+
+
+    @cached_class_property
+    def version_priority_entry_validate_schema(cls):
+        '''Schema used to validate entries in the version_priority dictionary
+
+        But it will keep the data in "raw" form - ie, using only basic python
+        objects, so it is yaml-dumpable (ie, by rez-config command-line tool)
+        '''
+        return cls._make_version_priority_entry_schema(False)
+
+    @cached_class_property
+    def version_priority_entry_convert_schema(cls):
+        '''Schema used to convert entries in the version_priority dictionary
+
+        Will convert entries into python objects, to make it easier to
+        interact with them..
+        '''
+        return cls._make_version_priority_entry_schema(True)
 
 
 class RezToolsVisibility_(Str):

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -338,7 +338,7 @@ config_schema = Schema({
     "env_var_separators":                           Dict,
     "variant_select_mode":                          VariantSelectMode_,
     "package_filter":                               OptionalDictOrDictList,
-    "version_priorities":                           VersionPriorityDict,
+    "version_priority":                             VersionPriorityDict,
     "new_session_popen_args":                       OptionalDict,
 
     # GUI settings

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -187,6 +187,30 @@ class RezToolsVisibility_(Str):
         return Or(*(x.name for x in RezToolsVisibility))
 
 
+class BuildThreadCount_(Setting):
+    # may be a positive int, or the values "physical" or "logical"
+
+    @cached_class_property
+    def schema(cls):
+        from rez.utils.platform_ import platform_
+
+        # Note that this bakes the physical / logical cores at the time the
+        # config is read... which should be fine
+        return Or(
+            And(int, lambda x: x > 0),
+            And("physical_cores", Use(lambda x: platform_.physical_cores)),
+            And("logical_cores", Use(lambda x: platform_.logical_cores)),
+        )
+
+    def _parse_env_var(self, value):
+        try:
+            return int(value)
+        except ValueError:
+            # wasn't a string - hopefully it's "physical" or "logical"...
+            # ...but this will be validated by the schema...
+            return value
+
+
 config_schema = Schema({
     "packages_path":                                PathList,
     "plugin_path":                                  PathList,
@@ -239,7 +263,7 @@ config_schema = Schema({
     "implicit_back":                                OptionalStr,
     "alias_fore":                                   OptionalStr,
     "alias_back":                                   OptionalStr,
-    "build_thread_count":                           Int,
+    "build_thread_count":                           BuildThreadCount_,
     "resource_caching_maxsize":                     Int,
     "max_package_changelog_chars":                  Int,
     "memcached_package_file_min_compress_len":      Int,

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -18,6 +18,8 @@ package_key_order = [
     'description',
     'authors',
     'tools',
+    'has_plugins',
+    'plugin_for',
     'requires',
     'build_requires',
     'private_build_requires',

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -107,7 +107,7 @@ class ResolvedContext(object):
     shell.
     """
     serialize_version = (4, 1)
-    tmpdir_manager = TempDirs(config.tmpdir, prefix="rez_context_")
+    tmpdir_manager = TempDirs(config.context_tmpdir, prefix="rez_context_")
 
     class Callback(object):
         def __init__(self, max_fails, time_limit, callback, buf=None):

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -328,10 +328,16 @@ catch_rex_errors = True
 # source directory (this is typically where temporary build files are written).
 build_directory = "build"
 
-# The number of threads a build system should use, eg the make '-j' option. If
-# zero, this is set to the number of processes on the build host. This setting
-# is exposed as the environment variable $REZ_BUILD_THREAD_COUNT during builds.
-build_thread_count = 0
+
+# The number of threads a build system should use, eg the make '-j' option.
+# If the string values "logical_cores" or "physical_cores", it is set to the
+# detected number of logical / physical cores on the host system.
+# (Logical cores are the number of cores reported to the OS, physical are the
+# number of actual hardware processor cores.  They may differ if, ie, the CPUs
+# support hyperthreading, in which case logical_cores == 2 * physical_cores).
+# This setting is exposed as the environment variable $REZ_BUILD_THREAD_COUNT
+# during builds.
+build_thread_count = "physical_cores"
 
 
 ###############################################################################

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -208,6 +208,78 @@ variant_select_mode = "version_priority"
 # foo-5+                Same as range(foo-5+)
 package_filter = None
 
+# Version priorities. Used to customize which version of a package is
+# preferred when solving. Should be a dict which maps from a package family
+# name to a list of version ranges to prioritize, in decreasing priority order.
+#
+# As an example, consider a package splunge which has versions:
+#
+#   [1.0, 1.1, 1.2, 1.4, 2.0, 2.1, 3.0, 3.2]
+#
+# By default, version priority is given to the higest version, so version
+# priority, from most to least preferred, is:
+#
+#   [3.2, 3.0, 2.1, 2.0, 1.4, 1.2, 1.1, 1.0]
+#
+# However, if you set version_priorities like this:
+#
+# version_priorities:
+#   splunge:
+#   - 2
+#   - 1.1+<1.4
+#
+# Then the preferred versions, from most to least preferred, will be:
+#  [2.1, 2.0, 1.2, 1.1, 3.2, 3.0, 1.4, 1.0]
+#
+# Any version which does not match any of these expressions are sorted in
+# decreasing version order (like normal) and then appended to this list (so they
+# have lower priority). So if you do:
+#
+# version_priorities:
+#   splunge:
+#   - 3.0
+#
+# resulting order is:
+#
+#   [3.0, 3.2, 2.1, 2.0, 1.4, 1.2, 1.1, 1.0]
+#
+#
+# You may also include a single False or empty string in the list, in which case
+# all "other" versions will be placed at that spot. ie
+#
+# version_priorities:
+#   splunge:
+#   - ""
+#   - 3+
+#
+# yields:
+#
+#  [2.1, 2.0, 1.4, 1.2, 1.1, 1.0, 3.2, 3.0]
+#
+# Note that you could also have gotten the same result by doing:
+#
+# version_priorities:
+#   splunge:
+#   - <3
+#
+# If a version matches more than one range expression, it will be placed at
+# the highest-priority matching spot, so:
+#
+# version_priorities:
+#   splunge: [1.2+<=2.0, 1.1+<3]
+#
+# gives:
+#  [2.0, 1.4, 1.2, 2.1, 1.1, 3.2, 3.0, 1.0]
+#
+# Also note that this does not change the version sort order for any purpose but
+# determining solving priorities - for instance, even if version priorities is:
+#
+# version_priorities:
+#   splunge: [2, 3, 1]
+#
+# The expression splunge-1+<3 would still match version 2.
+
+version_priorities = None
 
 ###############################################################################
 # Environment Resolution

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -141,6 +141,26 @@ prune_failed_graph = True
 #   present in the request;
 # - intersection_priority: Prefer variants that contain the most number of
 #   packages that are present in the request.
+#
+# As an example, suppose you have a package foo which has two variants:
+#
+#    ["bar-3.0", "baz-2.1"], ["bar-2.8", "burgle-1.0"]
+# if you do:
+#
+#    rez-env foo bar
+#
+# ...then, in either variant_select_mode, it will prefer the first variant,
+# ["bar-3.0", "baz-2.1"], because it has a higher version of the first variant
+# requirement (bar). However, if we instead do:
+#
+#    rez-env foo bar burgle
+#
+# ...we get different behavior. version_priority mode will still return
+# ["bar-3.0", "baz-2.1"], because the first requirement's version is higher.
+#
+# However, intersection_priority mode will pick the second variant,
+# ["bar-2.8", "burgle-1.0"], because it contains more packages that were in the
+# original request (burgle).
 variant_select_mode = "version_priority"
 
 # Package filter. One or more filters can be listed, each with a list of

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -52,8 +52,18 @@ local_packages_path = "~/packages"
 release_packages_path = "~/.rez/packages/int"
 
 # Where temporary files go. Defaults to appropriate path depending on your
-# system - for example, *nix distributions will probably set this to "/tmp".
+# system - for example, *nix distributions will probably set this to "/tmp". It
+# is highly recommended that this be set to local storage, such as /tmp.
 tmpdir = None
+
+
+# Where temporary files for contexts go. Defaults to appropriate path depending
+# on your system - for example, *nix distributions will probably set this to "/tmp".
+# This is separate to 'tmpdir' because you sometimes might want to set this to an
+# NFS location - for example, perhaps rez is used during a render and you'd like
+# to store these tempfiles in the farm queuer's designated tempdir so they're
+# cleaned up when the render completes.
+context_tmpdir = None
 
 
 ###############################################################################

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -208,7 +208,7 @@ variant_select_mode = "version_priority"
 # foo-5+                Same as range(foo-5+)
 package_filter = None
 
-# Version priorities. Used to customize which version of a package is
+# Version priority. Used to customize which version of a package is
 # preferred when solving. Should be a dict which maps from a package family
 # name to a list of version ranges to prioritize, in decreasing priority order.
 #
@@ -221,9 +221,9 @@ package_filter = None
 #
 #   [3.2, 3.0, 2.1, 2.0, 1.4, 1.2, 1.1, 1.0]
 #
-# However, if you set version_priorities like this:
+# However, if you set version_priority like this:
 #
-# version_priorities:
+# version_priority:
 #   splunge:
 #   - 2
 #   - 1.1+<1.4
@@ -235,7 +235,7 @@ package_filter = None
 # decreasing version order (like normal) and then appended to this list (so they
 # have lower priority). So if you do:
 #
-# version_priorities:
+# version_priority:
 #   splunge:
 #   - 3.0
 #
@@ -247,7 +247,7 @@ package_filter = None
 # You may also include a single False or empty string in the list, in which case
 # all "other" versions will be placed at that spot. ie
 #
-# version_priorities:
+# version_priority:
 #   splunge:
 #   - ""
 #   - 3+
@@ -258,14 +258,14 @@ package_filter = None
 #
 # Note that you could also have gotten the same result by doing:
 #
-# version_priorities:
+# version_priority:
 #   splunge:
 #   - <3
 #
 # If a version matches more than one range expression, it will be placed at
 # the highest-priority matching spot, so:
 #
-# version_priorities:
+# version_priority:
 #   splunge: [1.2+<=2.0, 1.1+<3]
 #
 # gives:
@@ -274,12 +274,12 @@ package_filter = None
 # Also note that this does not change the version sort order for any purpose but
 # determining solving priorities - for instance, even if version priorities is:
 #
-# version_priorities:
+# version_priority:
 #   splunge: [2, 3, 1]
 #
 # The expression splunge-1+<3 would still match version 2.
 
-version_priorities = None
+version_priority = None
 
 ###############################################################################
 # Environment Resolution

--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -4,15 +4,24 @@ Read and write data from file. File caching via a memcached server is supported.
 from rez.utils.scope import ScopeContext
 from rez.utils.data_utils import SourceCode
 from rez.utils.logging_ import print_debug
+from rez.utils.filesystem import TempDirs
 from rez.exceptions import ResourceError
 from rez.utils.memcached import memcached
 from rez.config import config
 from rez.vendor.enum import Enum
 from rez.vendor import yaml
+from contextlib import contextmanager
 from inspect import isfunction
+from StringIO import StringIO
 import sys
 import os
 import os.path
+
+
+tmpdir_manager = TempDirs(config.tmpdir, prefix="rez_write_")
+
+
+file_cache = {}
 
 
 class FileFormat(Enum):
@@ -26,8 +35,32 @@ class FileFormat(Enum):
         self.extension = extension
 
 
-def load_from_file(filepath, format_=FileFormat.py, update_data_callback=None,
-                   data_type=None):
+@contextmanager
+def open_file_for_write(filepath):
+    """Writes both to given filepath, and tmpdir location.
+
+    This is to get around the problem with some NFS's where immediately reading
+    a file that has jusr been written is problematic. Instead, any files that we
+    write, we also write to /tmp, and reads of these files are redirected there.
+    """
+    stream = StringIO()
+    yield stream
+    content = stream.getvalue()
+
+    filepath = os.path.realpath(filepath)
+    tmpdir = tmpdir_manager.mkdtemp()
+    cache_filepath = os.path.join(tmpdir, os.path.basename(filepath))
+
+    with open(filepath, 'w') as f:
+        f.write(content)
+
+    with open(cache_filepath, 'w') as f:
+        f.write(content)
+
+    file_cache[filepath] = cache_filepath
+
+
+def load_from_file(filepath, format_=FileFormat.py, update_data_callback=None):
     """Load data from a file.
 
     Note:
@@ -38,18 +71,23 @@ def load_from_file(filepath, format_=FileFormat.py, update_data_callback=None,
         format_ (`FileFormat`): Format of file contents.
         update_data_callback (callable): Used to change data before it is
             returned or cached.
-        data_type (`DataType`): Use if the data type being loaded is different
-            from the default (`DataType.package_file`).
 
     Returns:
         dict.
     """
-    kwargs = dict(filepath=os.path.realpath(filepath),
-                  format_=format_,
-                  update_data_callback=update_data_callback)
-    if data_type is not None:
-        kwargs["_data_type"] = data_type
-    return _load_from_file(**kwargs)
+    filepath = os.path.realpath(filepath)
+
+    cache_filepath = file_cache.get(filepath)
+    if cache_filepath:
+        # file has been written by this process, read it from /tmp to avoid
+        # potential write-then-read issues over NFS
+        return _load_file(filepath=cache_filepath,
+                          format_=format_,
+                          update_data_callback=update_data_callback)
+    else:
+        return _load_from_file(filepath=filepath,
+                               format_=format_,
+                               update_data_callback=update_data_callback)
 
 
 def _load_from_file__key(filepath, *nargs, **kwargs):
@@ -62,6 +100,10 @@ def _load_from_file__key(filepath, *nargs, **kwargs):
            key=_load_from_file__key,
            debug=config.debug_memcache)
 def _load_from_file(filepath, format_, update_data_callback):
+    return _load_file(filepath, format_, update_data_callback)
+
+
+def _load_file(filepath, format_, update_data_callback):
     load_func = load_functions[format_]
 
     if config.debug("file_loads"):
@@ -149,6 +191,7 @@ def load_yaml(stream, **kwargs):
                 if getattr(mark, 'name') == '<string>':
                     mark.name = stream.name
         raise e
+
 
 def load_txt(stream, **kwargs):
     """Load text data from a stream.

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -418,7 +418,7 @@ def _package_version_sort_key2(version_priority, version):
     if isinstance(version_priority, VersionPriorityMode):
         # note that if the version_priority is a VersionPriorityMode,
         # we return only one item, instead of a tuple of 2 items... but this
-        # should be ok, since all packages in a familty will share the same
+        # should be ok, since all packages in a family will share the same
         # setting, and _package_version_sort_key will sort by family first
         if version_priority == VersionPriorityMode.latest:
             return version

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -704,7 +704,8 @@ class _PackageVariantSlice(_Common):
                 if not request.conflict and request.name not in names:
                     additional_key.append((request.range, request.name))
 
-            if config.variant_select_mode == VariantSelectMode.version_priority:
+            if (VariantSelectMode[config.variant_select_mode] ==
+                    VariantSelectMode.version_priority):
                 k = (requested_key,
                      -len(additional_key),
                      additional_key,

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -392,13 +392,16 @@ def _package_version_sort_key(family_name, version, sort_key_cache):
     """Given a package and a version-like-object, returns a sort key that takes
     customized version prioritization into account
     """
+    from rez.config import VersionPriority_
+    format_ver_prio = VersionPriority_.version_priority_entry_convert_schema.validate
+
     family_cache = sort_key_cache.setdefault(family_name, {})
     key = family_cache.get(version)
     if key is not None:
         return key
 
-    version_priority = config.version_priority.get(family_name,
-                                                   VersionPriorityMode.latest)
+    version_priority = config.version_priority.get(family_name, "latest")
+    version_priority = format_ver_prio(version_priority)
     ver_key = _package_version_sort_key2(version_priority, version)
 
     # need to make sure that we always sort first by package, then by

--- a/src/rez/tests/data/solver/packages/pyvariants/2/package.py
+++ b/src/rez/tests/data/solver/packages/pyvariants/2/package.py
@@ -1,0 +1,4 @@
+name = "pyvariants"
+version = "2"
+
+variants = [["python-2.7.0"], ["python-2.6.8", "nada"]]

--- a/src/rez/tests/test_completion.py
+++ b/src/rez/tests/test_completion.py
@@ -48,9 +48,9 @@ class TestCompletion(TestBase):
 
         _eq("zzz", [])
         _eq("", ["bahish", "nada", "nopy", "pybah", "pydad", "pyfoo", "pymum",
-                 "pyodd", "pyson", "pysplit", "python"])
+                 "pyodd", "pyson", "pysplit", "python", "pyvariants"])
         _eq("py", ["pybah", "pydad", "pyfoo", "pymum", "pyodd", "pyson",
-            "pysplit", "python"])
+            "pysplit", "python", "pyvariants"])
         _eq("pys", ["pyson", "pysplit"])
         _eq("pyb", ["pybah", "pybah-4", "pybah-5"])
         _eq("pybah-", ["pybah-4", "pybah-5"])

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -2,14 +2,16 @@
 test configuration settings
 """
 import rez.vendor.unittest2 as unittest
-from rez.tests.util import TestBase
+from rez.tests.util import TestBase, get_cli_output
 from rez.exceptions import ConfigurationError
-from rez.config import Config, get_module_root_config
+from rez.config import Config, get_module_root_config, config,\
+    _create_locked_config
 from rez.system import system
 from rez.utils.data_utils import RO_AttrDictWrapper
 from rez.packages_ import get_developer_package
 import os
 import os.path
+import sys
 
 
 class TestConfig(TestBase):
@@ -179,6 +181,24 @@ class TestConfig(TestBase):
 
         with self.assertRaises(ConfigurationError):
             _ = c.debug_all
+
+    def test_6_command_line_config_version_priority(self):
+        """Check that the rez-config command-line tool works when using a
+        custom package version-priority"""
+        import rez.vendor.yaml as yaml
+
+        ver_prio = {'foo': ['2'], 'bar': 'earliest'}
+        self.update_settings({'version_priority': ver_prio})
+
+        output, exitcode = get_cli_output(['config'])
+        self.assertEqual(exitcode, 0)
+        parsed_out = yaml.load(output)
+        self.assertEqual(ver_prio, parsed_out['version_priority'])
+
+        output, exitcode = get_cli_output(['config', 'version_priority'])
+        self.assertEqual(exitcode, 0)
+        parsed_out = yaml.load(output)
+        self.assertEqual(ver_prio, parsed_out)
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -27,6 +27,7 @@ ALL_PACKAGES = set([
     'pyson-1', 'pyson-2',
     'pysplit-5', 'pysplit-6', 'pysplit-7',
     'python-2.5.2', 'python-2.6.0', 'python-2.6.8', 'python-2.7.0',
+    'pyvariants-2',
     # packages from data/packages
     'unversioned',
     'unversioned_py',

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -216,11 +216,11 @@ class TestSolver(TestBase):
     # re-prioritization tests
 
     def test_11_direct_complete(self):
-        """Test setting of the version_priorities in simple situations, where
+        """Test setting of the version_priority in simple situations, where
         the altered package is a direct request
         """
         # test a complete ordering
-        config.override("version_priorities",
+        config.override("version_priority",
                         {"python": ["2.6.0", "2.5.2", "2.7.0", "2.6.8"]})
         self._solve(["python"],
                     ["python-2.6.0[]"])
@@ -240,7 +240,7 @@ class TestSolver(TestBase):
         """check that if you specify only one version, that version is highest
         priority, rest are normal
         """
-        config.override("version_priorities", {"python": ["2.6.8"]})
+        config.override("version_priority", {"python": ["2.6.8"]})
         self._solve(["python"],
                     ["python-2.6.8[]"])
         self._solve(["python", "!python-2.6.8"],
@@ -258,8 +258,7 @@ class TestSolver(TestBase):
 
     def test_13_empty_string(self):
         """confirm that we can use empty string to match unmatched versions"""
-        config.override("version_priorities", {"python": ["", "2.7.0"]})
-        print config.version_priorities
+        config.override("version_priority", {"python": ["", "2.7.0"]})
         self._solve(["python"],
                     ["python-2.6.8[]"])
         self._solve(["python", "!python-2.6.8"],
@@ -269,7 +268,7 @@ class TestSolver(TestBase):
         self._solve(["python>2.6.8"],
                     ["python-2.7.0[]"])
 
-        config.override("version_priorities", {"python": ["2.6.0", "",
+        config.override("version_priority", {"python": ["2.6.0", "",
                                                           "2.7.0"]})
         self._solve(["python"],
                     ["python-2.6.0[]"])
@@ -282,7 +281,7 @@ class TestSolver(TestBase):
 
     def test_14_false(self):
         """confirm that we can use False to match unmatched versions"""
-        config.override("version_priorities", {"python": [False, "2.7.0"]})
+        config.override("version_priority", {"python": [False, "2.7.0"]})
         self._solve(["python"],
                     ["python-2.6.8[]"])
         self._solve(["python", "!python-2.6.8"],
@@ -292,7 +291,7 @@ class TestSolver(TestBase):
         self._solve(["python>2.6.8"],
                     ["python-2.7.0[]"])
 
-        config.override("version_priorities", {"python": ["2.6.0", False,
+        config.override("version_priority", {"python": ["2.6.0", False,
                                                           "2.7.0"]})
         self._solve(["python"],
                     ["python-2.6.0[]"])
@@ -304,11 +303,11 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]"])
 
     def test_15_requirement_1_deep(self):
-        """Test setting of the version_priorities for a required package 1 level
+        """Test setting of the version_priority for a required package 1 level
         deep
         """
         # python 2.5 is preferred...
-        config.override("version_priorities", {"python": [2.5]})
+        config.override("version_priority", {"python": [2.5]})
 
         # # so if we request python directly, we get 2.5...
         self._solve(["python"],
@@ -320,15 +319,15 @@ class TestSolver(TestBase):
                     ["python-2.6.8[]", "pyfoo-3.1.0[]"])
 
         # but if we make specifically python-2.6.0 prioritized, it will be used
-        config.override("version_priorities", {"python": ["2.6.0"]})
+        config.override("version_priority", {"python": ["2.6.0"]})
         self._solve(["pyfoo"],
                     ["python-2.6.0[]", "pyfoo-3.1.0[]"])
 
     def test_16_requirement_2_deep(self):
-        """Test setting of the version_priorities for a required package 2
+        """Test setting of the version_priority for a required package 2
         levels deep
         """
-        config.override("version_priorities", {"python": ["2.6.0", "2.5"]})
+        config.override("version_priority", {"python": ["2.6.0", "2.5"]})
         self._solve(["pyodd"],
                     ["python-2.5.2[]", "pybah-5[]", "pyodd-2[]"])
         self._solve(["pyodd-2"],
@@ -336,7 +335,7 @@ class TestSolver(TestBase):
         self._solve(["pyodd-1"],
                     ["python-2.6.0[]", "pyfoo-3.1.0[]", "pyodd-1[]"])
 
-        config.override("version_priorities", {"pybah": ["4"],
+        config.override("version_priority", {"pybah": ["4"],
                                                "pyfoo": ["3.0.0"],
                                                "python": ["2.6.0"]})
         self._solve(["pyodd"],
@@ -349,16 +348,16 @@ class TestSolver(TestBase):
     def test_17_multiple_false(self):
         """Make sure that multiple False / empty values raises an error
         """
-        config.override("version_priorities", {"python": ["2.6.0", False, False,
+        config.override("version_priority", {"python": ["2.6.0", False, False,
                                                           "2.5"]})
         self.assertRaises(ConfigurationError,
                           self._solve, ["python"], ["python-2.6.0[]"])
 
-        config.override("version_priorities", {"python": ["2.6.0", "", "",
+        config.override("version_priority", {"python": ["2.6.0", "", "",
                                                           "2.5"]})
         self.assertRaises(ConfigurationError,
                           self._solve, ["python"], ["python-2.6.0[]"])
-        config.override("version_priorities", {"python": ["2.6.0", "", False,
+        config.override("version_priority", {"python": ["2.6.0", "", False,
                                                           "2.5"]})
         self.assertRaises(ConfigurationError,
                           self._solve, ["python"], ["python-2.6.0[]"])
@@ -366,7 +365,7 @@ class TestSolver(TestBase):
     def test_18_multiple_matches(self):
         """Test that if matches more than one, higher-priority is used
         """
-        config.override("version_priorities", {"python": ["2.7.0|2.6.8",
+        config.override("version_priority", {"python": ["2.7.0|2.6.8",
                                                           "2.5",
                                                           "2.6.8|2.6.0"]})
         self._solve(["python<2.7"],

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -371,6 +371,87 @@ class TestSolver(TestBase):
         self._solve(["python<2.7"],
                     ["python-2.6.8[]"])
 
+    def test_19_latest(self):
+        """Test setting a package to latest version_priority
+        """
+        config.override("version_priority", {})
+        self._solve(["python"],
+                    ["python-2.7.0[]"])
+        self._solve(["python", "!python-2.7.0"],
+                    ["python-2.6.8[]"])
+        self._solve(["python-2.6"],
+                    ["python-2.6.8[]"])
+        self._solve(["python-2.6+<2.7"],
+                    ["python-2.6.8[]"])
+        self._solve(["python<2.6"],
+                    ["python-2.5.2[]"])
+
+        config.override("version_priority", {"python": "latest"})
+        self._solve(["python"],
+                    ["python-2.7.0[]"])
+        self._solve(["python", "!python-2.7.0"],
+                    ["python-2.6.8[]"])
+        self._solve(["python-2.6"],
+                    ["python-2.6.8[]"])
+        self._solve(["python-2.6+<2.7"],
+                    ["python-2.6.8[]"])
+        self._solve(["python<2.6"],
+                    ["python-2.5.2[]"])
+
+    def test_20_earliest(self):
+        """Test setting a package to earliest version_priority
+        """
+        config.override("version_priority", {"python": "earliest"})
+        self._solve(["python"],
+                    ["python-2.5.2[]"])
+        self._solve(["python", "!python-2.7.0"],
+                    ["python-2.5.2[]"])
+        self._solve(["python", "!python-2.5.2"],
+                    ["python-2.6.0[]"])
+        self._solve(["python-2.6"],
+                    ["python-2.6.0[]"])
+        self._solve(["python-2.6+<2.7"],
+                    ["python-2.6.0[]"])
+        self._solve(["python<2.6"],
+                    ["python-2.5.2[]"])
+
+    def test_21_earliest_is_requirement(self):
+        """Test setting a package to earliest version_priority, when it is a
+        requirement
+        """
+        config.override("version_priority", {"python": "earliest"})
+        self._solve(["pyfoo"],
+                    ["python-2.6.0[]", "pyfoo-3.1.0[]"])
+        self._solve(["pyfoo-3.0"],
+                    ["python-2.5.2[]", "pyfoo-3.0.0[]"])
+        self._solve(["pyfoo-3.1"],
+                    ["python-2.6.0[]", "pyfoo-3.1.0[]"])
+        self._solve(["pybah"],
+                    ["python-2.5.2[]", "pybah-5[]"])
+        self._solve(["pybah-4"],
+                    ["python-2.6.0[]", "pybah-4[]"])
+        self._solve(["pybah-5"],
+                    ["python-2.5.2[]", "pybah-5[]"])
+
+    def test_22_earliest_has_requirement(self):
+        """Test setting a package to earliest version_priority, when it has a
+        requirement
+        """
+        config.override("version_priority", {"pyfoo": "earliest",
+                                             "pybah": "earliest"})
+        self._solve(["pyfoo"],
+                    ["python-2.5.2[]", "pyfoo-3.0.0[]"])
+        self._solve(["pyfoo-3.0"],
+                    ["python-2.5.2[]", "pyfoo-3.0.0[]"])
+        self._solve(["pyfoo-3.1"],
+                    ["python-2.6.8[]", "pyfoo-3.1.0[]"])
+        self._solve(["pybah"],
+                    ["python-2.6.8[]", "pybah-4[]"])
+        self._solve(["pybah-4"],
+                    ["python-2.6.8[]", "pybah-4[]"])
+        self._solve(["pybah-5"],
+                    ["python-2.5.2[]", "pybah-5[]"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -3,6 +3,7 @@ test dependency resolving algorithm
 """
 from rez.vendor.version.requirement import Requirement
 from rez.solver import Solver, Cycle, SolverStatus
+from rez.config import config
 import rez.vendor.unittest2 as unittest
 from rez.tests.util import TestBase
 import itertools
@@ -92,7 +93,7 @@ class TestSolver(TestBase):
 
         return s1
 
-    def test_1(self):
+    def test_01(self):
         """Extremely basic solves involving a single package."""
         self._solve([],
                     [])
@@ -113,7 +114,7 @@ class TestSolver(TestBase):
         self._solve(["!python"],
                     [])
 
-    def test_2(self):
+    def test_02(self):
         """Basic solves involving a single package."""
         self._solve(["nada", "~nada"],
                     ["nada[]"])
@@ -134,24 +135,24 @@ class TestSolver(TestBase):
         self._solve(["!python-2.6+", "python"],
                     ["python-2.5.2[]"])
 
-    def test_3(self):
+    def test_03(self):
         """Failures in the initial request."""
         self._fail("nada", "!nada")
         self._fail("python-2.6", "~python-2.7")
         self._fail("pyfoo", "nada", "!nada")
 
-    def test_4(self):
+    def test_04(self):
         """Basic failures."""
         self._fail("pybah", "!python")
         self._fail("pyfoo-3.1", "python-2.7+")
         self._fail("pyodd<2", "python-2.7")
         self._fail("nopy", "python-2.5.2")
 
-    def test_5(self):
+    def test_05(self):
         """More complex failures."""
         self._fail("bahish", "pybah<5")
 
-    def test_6(self):
+    def test_06(self):
         """Basic solves involving multiple packages."""
         self._solve(["nada", "nopy"],
                     ["nada[]", "nopy-2.1[]"])
@@ -168,7 +169,7 @@ class TestSolver(TestBase):
         self._solve(["python", "pybah"],
                     ["python-2.6.8[]", "pybah-4[]"])
 
-    def test_7(self):
+    def test_07(self):
         """More complex solves."""
         self._solve(["python", "pyodd"],
                     ["python-2.6.8[]", "pybah-4[]", "pyodd-2[]"])
@@ -181,7 +182,7 @@ class TestSolver(TestBase):
         self._solve(["python", "bahish", "pybah"],
                     ["python-2.5.2[]", "pybah-5[]", "bahish-2[]"])
 
-    def test_8(self):
+    def test_08(self):
         """Cyclic failures."""
         def _test(*pkgs):
             s = self._fail(*pkgs)
@@ -195,6 +196,21 @@ class TestSolver(TestBase):
         s = self._fail("pymum-2")
         self.assertFalse(isinstance(s.failure_reason(), Cycle))
 
+    # variant tests
+
+    def test_09_version_priority_mode(self):
+        config.override("variant_select_mode", "version_priority")
+        self._solve(["pyvariants", "python"],
+                    ["python-2.7.0[]", "pyvariants-2[0]"])
+        self._solve(["pyvariants", "python", "nada"],
+                    ["python-2.7.0[]", "pyvariants-2[0]", "nada[]"])
+
+    def test_10_intersection_priority_mode(self):
+        config.override("variant_select_mode", "intersection_priority")
+        self._solve(["pyvariants", "python"],
+                    ["python-2.7.0[]", "pyvariants-2[0]"])
+        self._solve(["pyvariants", "python", "nada"],
+                    ["python-2.6.8[]", "nada[]", "pyvariants-2[1]"])
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -17,16 +17,60 @@ class TestBase(unittest.TestCase):
 
     def setUp(self):
         self.maxDiff = None
-        # shield unit tests from any user config overrides
         os.environ["REZ_QUIET"] = "true"
+
+        # shield unit tests from any user config overrides
+        self.setup_config()
+
+    def tearDown(self):
+        self.teardown_config()
+
+    # These are moved into their own functions so update_settings can call
+    # them without having to call setUp / tearDown, and without worrying
+    # about future or subclass modifications to those methods...
+    def setup_config(self):
         # to make sure config changes from one test don't affect another, copy
         # the overrides dict...
         self._config = _create_locked_config(dict(self.settings))
         config._swap(self._config)
 
-    def tearDown(self):
+    def teardown_config(self):
+        # moved to it's own section because it's called in update_settings...
+        # so if in the future, tearDown does more than call this,
+        # update_settings is still valid
         config._swap(self._config)
         self._config = None
+
+    def update_settings(self, new_settings, override=False):
+        """Can be called within test methods to modify settings on a
+        per-test basis (as opposed cls.settings, which modifies it for all
+        tests on the class)
+
+        Note that multiple calls will not "accumulate" updates, but will
+        instead patch the class's settings with the new_settings each time.
+
+        new_settings : dict
+            the updated settings to override the config with
+        override : bool
+            normally, the resulting config will be the result of merging
+            the base cls.settings with the new_settings - ie, like doing
+            cls.settings.update(new_settings).  If this is True, however,
+            then the cls.settings will be ignored entirely, and the
+            new_settings will be the only configuration settings applied
+        """
+        # restore the "normal" config...
+        self.teardown_config()
+
+        # ...then copy the class settings dict to instance, so we can
+        # modify...
+        if override:
+            self.settings = dict(new_settings)
+        else:
+            self.settings = dict(type(self).settings)
+            self.settings.update(new_settings)
+
+        # now swap the config back in...
+        self.setup_config()
 
 
 class TempdirMixin(object):
@@ -105,3 +149,73 @@ def install_dependent(fn):
             print ("\nskipping test, must be run via 'rez-selftest' tool, from "
                    "a PRODUCTION rez installation.")
     return _fn
+
+def get_cli_output(args):
+    """Invoke the named command-line rez command, with the given string
+    command line args
+
+    Note that it does this by calling rez.cli._main.run within the same
+    python process, for efficiency; if for some reason this is not sufficient
+    encapsulation / etc, you can use subprocess to invoke the rez as a
+    separate process
+
+    Returns
+    -------
+    stdout : basestring
+        the captured output to sys.stdout
+    exitcode : int
+        the returncode from the command
+    """
+
+    import sys
+    from StringIO import StringIO
+
+    command = args[0]
+    other_args = list(args[1:])
+    if command.startswith('rez-'):
+        command = command[4:]
+    exitcode = None
+
+    # first swap sys.argv...
+    old_argv = sys.argv
+    new_argv = ['rez-%s' % command] + other_args
+    sys.argv = new_argv
+    try:
+
+        # then redirect stdout using os.dup2
+
+        # we can't just ye' ol sys.stdout swap trick, because some places may
+        # still be holding onto references to the "real" sys.stdout - ie, if
+        # a function has a kwarg default (as in rez.status.Status.print_info)
+        # So, instead we swap at a file-descriptor level... potentially less
+        # portable, but has been tested to work on linux, osx, and windows...
+        with tempfile.TemporaryFile(bufsize=0, prefix='rez_cliout') as tf:
+            new_fileno = tf.fileno()
+            old_fileno = sys.stdout.fileno()
+            old_fileno_dupe = os.dup(old_fileno)
+
+            # make sure we flush before any switches...
+            sys.stdout.flush()
+            # ...then redirect stdout to our temp file...
+            os.dup2(new_fileno, old_fileno)
+            try:
+                try:
+                    # and finally invoke the "command-line" rez-COMMAND
+                    from rez.cli._main import run
+                    run(command)
+                except SystemExit as e:
+                    exitcode = e.args[0]
+            finally:
+                # restore stdout
+                sys.stdout.flush()
+                tf.flush()
+                os.dup2(old_fileno_dupe, old_fileno)
+
+            # ok, now read the output we redirected to the file...
+            tf.seek(0, os.SEEK_SET)
+            output = tf.read()
+    finally:
+        # restore argv...
+        sys.argv = old_argv
+
+    return output, exitcode

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,4 +1,4 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.0.rc1.28"
+_rez_version = "2.0.rc1.29"

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,4 +1,4 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.0.rc1.29"
+_rez_version = "2.0.rc1.30"

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -77,7 +77,13 @@ class Platform(object):
     @cached_property
     def physical_cores(self):
         """Return the number of physical cpu cores on the system."""
-        return self._physical_cores_base()
+        try:
+            return self._physical_cores_base()
+        except Exception as e:
+            from rez.utils.logging_ import print_error
+            print_error("Error detecting physical core count, defaulting to 1: %s"
+                        % str(e))
+        return 1
 
     @cached_property
     def logical_cores(self):
@@ -86,7 +92,13 @@ class Platform(object):
         May be different from physical_cores if, ie, intel's hyperthreading is
         enabled.
         """
-        return self._logical_cores()
+        try:
+            return self._logical_cores()
+        except Exception as e:
+            from rez.utils.logging_ import print_error
+            print_error("Error detecting logical core count, defaulting to 1: %s"
+                        % str(e))
+        return 1
 
     # -- implementation
 
@@ -142,6 +154,7 @@ class Platform(object):
     def _logical_cores(self):
         from multiprocessing import cpu_count
         return cpu_count()
+
 
 # -----------------------------------------------------------------------------
 # Unix (Linux and OSX)

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -2,6 +2,7 @@ import platform
 import sys
 import os
 import os.path
+import re
 from rez.util import which
 from rez.utils.data_utils import cached_property
 from rez.exceptions import RezSystemError
@@ -73,6 +74,20 @@ class Platform(object):
         """Return system default temporary directory path."""
         return self._tmpdir()
 
+    @cached_property
+    def physical_cores(self):
+        """Return the number of physical cpu cores on the system."""
+        return self._physical_cores_base()
+
+    @cached_property
+    def logical_cores(self):
+        """Return the number of cpu cores as reported to the os.
+
+        May be different from physical_cores if, ie, intel's hyperthreading is
+        enabled.
+        """
+        return self._logical_cores()
+
     # -- implementation
 
     def _arch(self):
@@ -103,6 +118,30 @@ class Platform(object):
         """Create a symbolic link pointing to source named link_name."""
         os.symlink(source, link_name)
 
+    def _physical_cores_base(self):
+        if self.logical_cores == 1:
+            # if we only have one core, we only have one core... no need to
+            # bother with platform-specific stuff...
+
+            # we do this check for all because on some platforms, the output
+            # of various commands (dmesg, lscpu, /proc/cpuinfo) can be
+            # very different if there's only one cpu, and don't want to have
+            # to deal with that case
+            return 1
+        cores = self._physical_cores()
+        if cores is None:
+            from rez.utils.logging_ import print_warning
+            print_warning("Could not determine number of physical cores - "
+                          "falling back on logical cores value")
+            cores = self.logical_cores
+        return cores
+
+    def _physical_cores(self):
+        raise NotImplementedError
+
+    def _logical_cores(self):
+        from multiprocessing import cpu_count
+        return cpu_count()
 
 # -----------------------------------------------------------------------------
 # Unix (Linux and OSX)
@@ -228,6 +267,100 @@ class LinuxPlatform(_UnixPlatform):
         from rez.util import which
         return which("kdiff3", "meld", "diff")
 
+    @classmethod
+    def _parse_colon_table_to_dict(cls, table_text):
+        '''Given a simple text output where each line gives a key-value pair
+      of the form "key: value", parse and return a dict'''
+        lines = [l.strip() for l in table_text.splitlines()]
+        lines = [l for l in lines if l]
+        pairs = [l.split(':', 1) for l in lines]
+        pairs = [(k.strip(), v.strip()) for k, v in pairs]
+        data = dict(pairs)
+        assert len(data) == len(pairs)
+        return data
+
+    def _physical_cores_from_cpuinfo(self):
+        cpuinfo = '/proc/cpuinfo'
+        if not os.path.isfile(cpuinfo):
+            return None
+
+        with open(cpuinfo) as f:
+            contents = f.read()
+
+        known_ids = set()
+
+        proc_re = re.compile('^processor\s*:\s+[0-9]+\s*$', re.MULTILINE)
+        procsplit = proc_re.split(contents)
+
+        if len(procsplit) <= 1:
+            # no procs found... give up
+            return None
+        elif len(procsplit) == 2:
+            # if there's only two entries - the first is the stuff before the
+            # processor, and can be ingored... which means there's only one
+            # proc
+
+            # besides, if there's only one proc, the output changes - ie, no
+            # "core id", etc
+            return 1
+
+        # the first result is the stuff before the first processor line -
+        # ignore it...
+        for proc in procsplit[1:]:
+            proc = self._parse_colon_table_to_dict(proc)
+            # physical id corresponds to the socket, and core id to the
+            # physical core number on that socket
+            p_id = proc.get('physical id')
+            c_id = proc.get('core id')
+            if p_id is None or c_id is None:
+                # something is screwy, we weren't able to parse correctly...
+                return None
+
+            # hyperthreaded procs will share the same physical_id + core id...
+            # so if we just throw them all in a set, duplicates will be
+            # ignored, and we'll know the total number of "real" cores
+            known_ids.add((int(p_id), int(c_id)))
+        return len(known_ids)
+
+    def _physical_cores_from_lscpu(self):
+        import subprocess
+        try:
+            p = subprocess.Popen(['lscpu'], stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        except (OSError, IOError):
+            return None
+
+        stdout, stderr = p.communicate()
+        if p.returncode:
+            return None
+
+        data = self._parse_colon_table_to_dict(stdout)
+
+        # lscpu gives output like this:
+        #
+        # CPU(s):                24
+        # On-line CPU(s) list:   0-23
+        # Thread(s) per core:    2
+        # Core(s) per socket:    6
+        # Socket(s):             2
+
+        # we want to take sockets * cores, and ignore threads...
+
+        # some versions of lscpu format the sockets line differently...
+        sockets = data.get('Socket(s)', data.get('CPU socket(s)'))
+        if not sockets:
+            return None
+        cores = data.get('Core(s) per socket')
+        if not cores:
+            return None
+        return int(sockets) * int(cores)
+
+    def _physical_cores(self):
+        cores = self._physical_cores_from_cpuinfo()
+        if cores is not None:
+            return cores
+        return self._physical_cores_from_lscpu()
+
 
 # -----------------------------------------------------------------------------
 # OSX
@@ -257,6 +390,23 @@ class OSXPlatform(_UnixPlatform):
     def _editor(self):
         return "open"
 
+    def _physical_cores_from_osx_sysctl(self):
+        import subprocess
+        try:
+            p = subprocess.Popen(['sysctl', '-n', 'hw.physicalcpu'],
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        except (OSError, IOError):
+            return None
+
+        stdout, stderr = p.communicate()
+        if p.returncode:
+            return None
+
+        return int(stdout.strip())
+
+    def _physical_cores(self):
+        return self._physical_cores_from_osx_sysctl()
 
 # -----------------------------------------------------------------------------
 # Windows
@@ -314,6 +464,30 @@ class WindowsPlatform(Platform):
 
     def _terminal_emulator_command(self):
         return "CMD.exe /Q /K"
+
+    def _physical_cores_from_wmic(self):
+        # windows
+        import subprocess
+        try:
+            p = subprocess.Popen('wmic cpu get NumberOfCores /value'.split(),
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        except (OSError, IOError):
+            return None
+
+        stdout, stderr = p.communicate()
+        if p.returncode:
+            return None
+
+        result = stdout.strip().split('=')
+        if result[0] != 'NumberOfCores':
+            # don't know what's wrong... should get back a result like:
+            # NumberOfCores=2
+            return None
+        return int(result[1])
+
+    def _physical_cores(self):
+        return self._physical_cores_from_wmic()
 
 
 # singleton

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -5,6 +5,7 @@ import os.path
 from rez.util import which
 from rez.utils.data_utils import cached_property
 from rez.exceptions import RezSystemError
+from tempfile import gettempdir
 
 
 class Platform(object):
@@ -96,7 +97,7 @@ class Platform(object):
         raise NotImplementedError
 
     def _tmpdir(self):
-        raise NotImplementedError
+        return gettempdir()
 
     def symlink(self, source, link_name):
         """Create a symbolic link pointing to source named link_name."""
@@ -108,8 +109,7 @@ class Platform(object):
 # -----------------------------------------------------------------------------
 
 class _UnixPlatform(Platform):
-    def _tmpdir(self):
-        return "/tmp"
+    pass
 
 
 # -----------------------------------------------------------------------------
@@ -282,12 +282,6 @@ class WindowsPlatform(Platform):
                 toks.append(item)
         final_version = str('.').join(toks)
         return "windows-%s" % final_version
-
-    def _tmpdir(self):
-        path = os.getenv("TEMP")
-        if path and os.path.isdir(path):
-            return path
-        return "C:/temp"
 
     def _image_viewer(self):
         # os.system("file.jpg") will open default viewer on windows

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -34,6 +34,44 @@ class _Comparable(_Common):
         raise NotImplementedError
 
 
+class _SortKeyComparable(_Comparable):
+    def _sort_key(self):
+        """Should return a tuple (sort_type, sort_key) used to determine
+        ordering
+
+        Both objects being compared must have the same sort_type, or else they
+        will return NotImplemented
+
+        If they have the same sort_type, then they are compared using the
+        sort_key
+        """
+        raise NotImplementedError
+
+    def __lt__(self, other):
+        this_type, this_key = self._sort_key()
+        other_type, other_key = other._sort_key()
+        if this_type != other_type:
+            return NotImplemented
+        return this_key < other_key
+
+    def __gt__(self, other):
+        this_type, this_key = self._sort_key()
+        other_type, other_key = other._sort_key()
+        if this_type != other_type:
+            return NotImplemented
+        return this_key > other_key
+
+    def __eq__(self, other):
+        this_type, this_key = self._sort_key()
+        other_type, other_key = other._sort_key()
+        if this_type != other_type:
+            return NotImplemented
+        return this_key == other_key
+
+    def __hash__(self):
+        return hash(self._sort_key())
+
+
 class VersionToken(_Comparable):
     """Token within a version number.
 
@@ -79,7 +117,7 @@ class VersionToken(_Comparable):
         return self.less_than(other)
 
     def __eq__(self, other):
-        return (not self < other) and (not other < self)
+        raise NotImplementedError
 
 
 class NumericToken(VersionToken):
@@ -102,6 +140,9 @@ class NumericToken(VersionToken):
 
     def __str__(self):
         return str(self.n)
+
+    def __eq__(self, other):
+        return self.n == other.n
 
     def less_than(self, other):
         return (self.n < other.n)
@@ -174,6 +215,9 @@ class AlphanumericVersionToken(VersionToken):
 
     def __str__(self):
         return ''.join(map(str, self.subtokens))
+
+    def __eq__(self, other):
+        return self.subtokens == other.subtokens
 
     def less_than(self, other):
         return (self.subtokens < other.subtokens)
@@ -254,7 +298,7 @@ class Version(_Comparable):
 
     def copy(self):
         """Returns a copy of the version."""
-        other = Version(None)
+        other = type(self)(None)
         other.tokens = self.tokens[:]
         other.seps = self.seps[:]
         return other
@@ -266,7 +310,7 @@ class Version(_Comparable):
             len_ (int): New version length. If >= current length, an
                 unchanged copy of the version is returned.
         """
-        other = Version(None)
+        other = type(self)(None)
         other.tokens = self.tokens[:len_]
         other.seps = self.seps[:len_ - 1]
         return other
@@ -279,7 +323,7 @@ class Version(_Comparable):
             other.tokens.append(tok.next())
             return other
         else:
-            return Version.inf
+            return type(self).inf
 
     def __len__(self):
         return len(self.tokens or [])
@@ -318,7 +362,7 @@ Version.inf = Version()
 Version.inf.tokens = None
 
 
-class _LowerBound(_Comparable):
+class _LowerBound(_SortKeyComparable):
     min = None
 
     def __init__(self, version, inclusive):
@@ -332,17 +376,8 @@ class _LowerBound(_Comparable):
         else:
             return '' if self.inclusive else ">"
 
-    def __eq__(self, other):
-        return (self.version == other.version) \
-            and (self.inclusive == other.inclusive)
-
-    def __lt__(self, other):
-        return (self.version < other.version) \
-            or ((self.version == other.version)
-                and (self.inclusive and not other.inclusive))
-
-    def __hash__(self):
-        return hash((self.version, self.inclusive))
+    def _sort_key(self):
+        return 'lower_bound', (self.version, -2 if self.inclusive else -1)
 
     def contains_version(self, version):
         return (version > self.version) \
@@ -351,7 +386,7 @@ class _LowerBound(_Comparable):
 _LowerBound.min = _LowerBound(Version(), True)
 
 
-class _UpperBound(_Comparable):
+class _UpperBound(_SortKeyComparable):
     inf = None
 
     def __init__(self, version, inclusive):
@@ -364,17 +399,8 @@ class _UpperBound(_Comparable):
         s = "<=%s" if self.inclusive else "<%s"
         return s % self.version
 
-    def __eq__(self, other):
-        return (self.version == other.version) \
-            and (self.inclusive == other.inclusive)
-
-    def __lt__(self, other):
-        return (self.version < other.version) \
-            or ((self.version == other.version)
-                and (not self.inclusive and other.inclusive))
-
-    def __hash__(self):
-        return hash((self.version, self.inclusive))
+    def _sort_key(self):
+        return 'upper_bound', (self.version, 2 if self.inclusive else 1)
 
     def contains_version(self, version):
         return (version < self.version) \
@@ -383,7 +409,7 @@ class _UpperBound(_Comparable):
 _UpperBound.inf = _UpperBound(Version.inf, True)
 
 
-class _Bound(_Comparable):
+class _Bound(_SortKeyComparable):
     any = None
 
     def __init__(self, lower=None, upper=None):
@@ -410,14 +436,8 @@ class _Bound(_Comparable):
         else:
             return "%s%s" % (self.lower, self.upper)
 
-    def __eq__(self, other):
-        return (self.lower == other.lower) and (self.upper == other.upper)
-
-    def __lt__(self, other):
-        return (self.lower, self.upper) < (other.lower, other.upper)
-
-    def __hash__(self):
-        return hash((self.lower, self.upper))
+    def _sort_key(self):
+        return 'bound', (self.lower, self.upper)
 
     def lower_bounded(self):
         return (self.lower != _LowerBound.min)

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -12,7 +12,6 @@ from rez.config import config
 from rez.backport.shutilwhich import which
 from rez.vendor.schema.schema import Or
 from rez.shells import create_shell
-from multiprocessing import cpu_count
 import functools
 import os.path
 import sys
@@ -176,7 +175,7 @@ class CMakeBuildSystem(BuildSystem):
         cmd += (self.child_build_args or [])
 
         if not any(x.startswith("-j") for x in (self.child_build_args or [])):
-            n = variant.config.build_thread_count or cpu_count()
+            n = variant.config.build_thread_count
             cmd.append("-j%d" % n)
 
         # execute make within the build env
@@ -208,7 +207,7 @@ class CMakeBuildSystem(BuildSystem):
         executor.env.CMAKE_MODULE_PATH.append(cmake_path)
         executor.env.REZ_BUILD_DOXYFILE = os.path.join(template_path, 'Doxyfile')
         executor.env.REZ_BUILD_VARIANT_INDEX = variant.index or 0
-        executor.env.REZ_BUILD_THREAD_COUNT = package.config.build_thread_count or cpu_count()
+        executor.env.REZ_BUILD_THREAD_COUNT = package.config.build_thread_count
         # build always occurs on a filesystem package, thus 'filepath' attribute
         # exists. This is not the case for packages in general.
         executor.env.REZ_BUILD_PROJECT_FILE = package.filepath

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -5,7 +5,7 @@ from rez.package_repository import PackageRepository
 from rez.package_resources_ import PackageFamilyResource, PackageResource, \
     VariantResourceHelper, PackageResourceHelper, package_pod_schema, \
     package_release_keys
-from rez.serialise import clear_file_caches
+from rez.serialise import clear_file_caches, open_file_for_write
 from rez.package_serialise import dump_package_data
 from rez.exceptions import PackageMetadataError, ResourceError, RezSystemError, \
     ConfigurationError, PackageRepositoryError
@@ -760,7 +760,7 @@ class FileSystemPackageRepository(PackageRepository):
                 package_data[key] = value
 
         filepath = os.path.join(path, "package.py")
-        with open(filepath, 'w') as f:
+        with open_file_for_write(filepath) as f:
             dump_package_data(package_data, buf=f, format_=package_format)
 
         # touch the family dir, this keeps memcached resolves updated properly

--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -47,6 +47,9 @@ class HgReleaseVCS(ReleaseVCS):
     def hg(self, *nargs, **kwargs):
         if kwargs.pop('patch', False):
             nargs += ('--mq',)
+        if ('-R' not in nargs and '--repository' not in nargs
+            and not any(x.startswith(('-R', '--repository=')) for x in nargs)):
+            nargs += ('--repository', self.vcs_root)
         if kwargs:
             raise HgReleaseVCSError("Unrecognized keyword args to hg command:"
                                     " %s" % ", ".join(kwargs))


### PR DESCRIPTION
This branch provides a way to specify a custom solver prioritization order for the versions of specific packages.

It can be thought of as similar to the REZ_RESOLVE_MODE setting from earlier versions of rez, except that instead of only allowing "latest" or "earliest," it allows custom orderings on a per-package basis.

It is also similar to package filters, in that it provides a means to alter which packages are picked when resolving solve, except that the packages are still available as an option.  This means that, for instance, if a deprioritized package is a requirement of another package, that other package can always still solve.  It also doesn't require explicit command line overrides if a user wishes to use a deprioritized package.

This make package priorities more suitable for use by end-users / artists, which are the primary target audience.  For instance, suppose version 3 of the Foo software package is released, but it's a major redesign, and some people love it, and some hate it. Package reprioritization will allow artists to use whichever package they feel most comfortable with.

For a simple example, consider you have a package foo with versions [1, 2, 3].  By default the prioritization (from highest to lowest) is [3, 2, 1].  But if you add this to your .rezconfig:

```yaml
version_priorities:
  foo: [2, 3, 1]
```

...then do "rez-env foo", you will get version 2.  Also, since non-matching packages are automatically appended to the priority list, the same thing could have been accomplished with:

```yaml
version_priorities:
  foo: [2]
```

See the notes in rezconfig.py for details of usage.

Lemme know what you think!

- Paul

PS - Assuming you're on board, I'm fine with this being scheduled as a post-2.0 feature

PPS - It does NOT change the sort order of versions in any other way - it only alters the prioritization used for picking packages when solving; so, for instance, if the priority mode is changed to (highest priority to lowest) [2, 3, 1], then version 2 will still match the version range 1+<3.
