### PR TITLE
Variant select mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Rez is a cross-platform software package management API and set of tools. Rez can
 build and install packages, and resolve environments at runtime that use a dependency
-resolution algorithm to avoid version conflicts. The main tools are:
+resolution algorithm to avoid version conflicts. Both third party and internally
+developed packages can be made into Rez packages, and any kind of package (python,
+compiled, etc) is supported.
+
+The main tools are:
 
 * **rez-env**: Creates a configured shell containing a set of requested packages.
   Supports *bash*, *tcsh* and *cmd* (Windows), and can be extended to other shells.

--- a/src/rez/cli/python.py
+++ b/src/rez/cli/python.py
@@ -13,6 +13,7 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "ARG", type=str, nargs='*',
         help='arguments to python script')
+    parser.add_argument('-c', help="python code to execute", dest='command')
 
     if completions:
         from rez.cli._complete_util import FilesCompleter
@@ -28,6 +29,9 @@ def command(opts, parser, extra_arg_groups=None):
 
     if opts.interactive:
         cmd.append("-i")
+
+    if opts.command:
+        cmd.extend(['-c', opts.command])
 
     if opts.FILE:
         cmd.append(opts.FILE)

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -214,6 +214,7 @@ config_schema = Schema({
     "rez_tools_visibility":                         RezToolsVisibility_,
     "suite_alias_prefix_char":                      Char,
     "tmpdir":                                       OptionalStr,
+    "context_tmpdir":                               OptionalStr,
     "default_shell":                                OptionalStr,
     "terminal_emulator_command":                    OptionalStr,
     "editor":                                       OptionalStr,
@@ -508,6 +509,10 @@ class Config(object):
     # -- dynamic defaults
 
     def _get_tmpdir(self):
+        from rez.utils.platform_ import platform_
+        return platform_.tmpdir
+
+    def _get_context_tmpdir(self):
         from rez.utils.platform_ import platform_
         return platform_.tmpdir
 

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -187,6 +187,30 @@ class RezToolsVisibility_(Str):
         return Or(*(x.name for x in RezToolsVisibility))
 
 
+class BuildThreadCount_(Setting):
+    # may be a positive int, or the values "physical" or "logical"
+
+    @cached_class_property
+    def schema(cls):
+        from rez.utils.platform_ import platform_
+
+        # Note that this bakes the physical / logical cores at the time the
+        # config is read... which should be fine
+        return Or(
+            And(int, lambda x: x > 0),
+            And("physical_cores", Use(lambda x: platform_.physical_cores)),
+            And("logical_cores", Use(lambda x: platform_.logical_cores)),
+        )
+
+    def _parse_env_var(self, value):
+        try:
+            return int(value)
+        except ValueError:
+            # wasn't a string - hopefully it's "physical" or "logical"...
+            # ...but this will be validated by the schema...
+            return value
+
+
 config_schema = Schema({
     "packages_path":                                PathList,
     "plugin_path":                                  PathList,
@@ -239,7 +263,7 @@ config_schema = Schema({
     "implicit_back":                                OptionalStr,
     "alias_fore":                                   OptionalStr,
     "alias_back":                                   OptionalStr,
-    "build_thread_count":                           Int,
+    "build_thread_count":                           BuildThreadCount_,
     "resource_caching_maxsize":                     Int,
     "max_package_changelog_chars":                  Int,
     "memcached_package_file_min_compress_len":      Int,

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -18,6 +18,8 @@ package_key_order = [
     'description',
     'authors',
     'tools',
+    'has_plugins',
+    'plugin_for',
     'requires',
     'build_requires',
     'private_build_requires',

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -107,7 +107,7 @@ class ResolvedContext(object):
     shell.
     """
     serialize_version = (4, 1)
-    tmpdir_manager = TempDirs(config.tmpdir, prefix="rez_context_")
+    tmpdir_manager = TempDirs(config.context_tmpdir, prefix="rez_context_")
 
     class Callback(object):
         def __init__(self, max_fails, time_limit, callback, buf=None):

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -328,10 +328,16 @@ catch_rex_errors = True
 # source directory (this is typically where temporary build files are written).
 build_directory = "build"
 
-# The number of threads a build system should use, eg the make '-j' option. If
-# zero, this is set to the number of processes on the build host. This setting
-# is exposed as the environment variable $REZ_BUILD_THREAD_COUNT during builds.
-build_thread_count = 0
+
+# The number of threads a build system should use, eg the make '-j' option.
+# If the string values "logical_cores" or "physical_cores", it is set to the
+# detected number of logical / physical cores on the host system.
+# (Logical cores are the number of cores reported to the OS, physical are the
+# number of actual hardware processor cores.  They may differ if, ie, the CPUs
+# support hyperthreading, in which case logical_cores == 2 * physical_cores).
+# This setting is exposed as the environment variable $REZ_BUILD_THREAD_COUNT
+# during builds.
+build_thread_count = "physical_cores"
 
 
 ###############################################################################

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -141,6 +141,26 @@ prune_failed_graph = True
 #   present in the request;
 # - intersection_priority: Prefer variants that contain the most number of
 #   packages that are present in the request.
+#
+# As an example, suppose you have a package foo which has two variants:
+#
+#    ["bar-3.0", "baz-2.1"], ["bar-2.8", "burgle-1.0"]
+# if you do:
+#
+#    rez-env foo bar
+#
+# ...then, in either variant_select_mode, it will prefer the first variant,
+# ["bar-3.0", "baz-2.1"], because it has a higher version of the first variant
+# requirement (bar). However, if we instead do:
+#
+#    rez-env foo bar burgle
+#
+# ...we get different behavior. version_priority mode will still return
+# ["bar-3.0", "baz-2.1"], because the first requirement's version is higher.
+#
+# However, intersection_priority mode will pick the second variant,
+# ["bar-2.8", "burgle-1.0"], because it contains more packages that were in the
+# original request (burgle).
 variant_select_mode = "version_priority"
 
 # Package filter. One or more filters can be listed, each with a list of

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -52,8 +52,18 @@ local_packages_path = "~/packages"
 release_packages_path = "~/.rez/packages/int"
 
 # Where temporary files go. Defaults to appropriate path depending on your
-# system - for example, *nix distributions will probably set this to "/tmp".
+# system - for example, *nix distributions will probably set this to "/tmp". It
+# is highly recommended that this be set to local storage, such as /tmp.
 tmpdir = None
+
+
+# Where temporary files for contexts go. Defaults to appropriate path depending
+# on your system - for example, *nix distributions will probably set this to "/tmp".
+# This is separate to 'tmpdir' because you sometimes might want to set this to an
+# NFS location - for example, perhaps rez is used during a render and you'd like
+# to store these tempfiles in the farm queuer's designated tempdir so they're
+# cleaned up when the render completes.
+context_tmpdir = None
 
 
 ###############################################################################

--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -4,15 +4,24 @@ Read and write data from file. File caching via a memcached server is supported.
 from rez.utils.scope import ScopeContext
 from rez.utils.data_utils import SourceCode
 from rez.utils.logging_ import print_debug
+from rez.utils.filesystem import TempDirs
 from rez.exceptions import ResourceError
 from rez.utils.memcached import memcached
 from rez.config import config
 from rez.vendor.enum import Enum
 from rez.vendor import yaml
+from contextlib import contextmanager
 from inspect import isfunction
+from StringIO import StringIO
 import sys
 import os
 import os.path
+
+
+tmpdir_manager = TempDirs(config.tmpdir, prefix="rez_write_")
+
+
+file_cache = {}
 
 
 class FileFormat(Enum):
@@ -26,8 +35,32 @@ class FileFormat(Enum):
         self.extension = extension
 
 
-def load_from_file(filepath, format_=FileFormat.py, update_data_callback=None,
-                   data_type=None):
+@contextmanager
+def open_file_for_write(filepath):
+    """Writes both to given filepath, and tmpdir location.
+
+    This is to get around the problem with some NFS's where immediately reading
+    a file that has jusr been written is problematic. Instead, any files that we
+    write, we also write to /tmp, and reads of these files are redirected there.
+    """
+    stream = StringIO()
+    yield stream
+    content = stream.getvalue()
+
+    filepath = os.path.realpath(filepath)
+    tmpdir = tmpdir_manager.mkdtemp()
+    cache_filepath = os.path.join(tmpdir, os.path.basename(filepath))
+
+    with open(filepath, 'w') as f:
+        f.write(content)
+
+    with open(cache_filepath, 'w') as f:
+        f.write(content)
+
+    file_cache[filepath] = cache_filepath
+
+
+def load_from_file(filepath, format_=FileFormat.py, update_data_callback=None):
     """Load data from a file.
 
     Note:
@@ -38,18 +71,23 @@ def load_from_file(filepath, format_=FileFormat.py, update_data_callback=None,
         format_ (`FileFormat`): Format of file contents.
         update_data_callback (callable): Used to change data before it is
             returned or cached.
-        data_type (`DataType`): Use if the data type being loaded is different
-            from the default (`DataType.package_file`).
 
     Returns:
         dict.
     """
-    kwargs = dict(filepath=os.path.realpath(filepath),
-                  format_=format_,
-                  update_data_callback=update_data_callback)
-    if data_type is not None:
-        kwargs["_data_type"] = data_type
-    return _load_from_file(**kwargs)
+    filepath = os.path.realpath(filepath)
+
+    cache_filepath = file_cache.get(filepath)
+    if cache_filepath:
+        # file has been written by this process, read it from /tmp to avoid
+        # potential write-then-read issues over NFS
+        return _load_file(filepath=cache_filepath,
+                          format_=format_,
+                          update_data_callback=update_data_callback)
+    else:
+        return _load_from_file(filepath=filepath,
+                               format_=format_,
+                               update_data_callback=update_data_callback)
 
 
 def _load_from_file__key(filepath, *nargs, **kwargs):
@@ -62,6 +100,10 @@ def _load_from_file__key(filepath, *nargs, **kwargs):
            key=_load_from_file__key,
            debug=config.debug_memcache)
 def _load_from_file(filepath, format_, update_data_callback):
+    return _load_file(filepath, format_, update_data_callback)
+
+
+def _load_file(filepath, format_, update_data_callback):
     load_func = load_functions[format_]
 
     if config.debug("file_loads"):
@@ -149,6 +191,7 @@ def load_yaml(stream, **kwargs):
                 if getattr(mark, 'name') == '<string>':
                     mark.name = stream.name
         raise e
+
 
 def load_txt(stream, **kwargs):
     """Load text data from a stream.

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -704,7 +704,8 @@ class _PackageVariantSlice(_Common):
                 if not request.conflict and request.name not in names:
                     additional_key.append((request.range, request.name))
 
-            if config.variant_select_mode == VariantSelectMode.version_priority:
+            if (VariantSelectMode[config.variant_select_mode] ==
+                    VariantSelectMode.version_priority):
                 k = (requested_key,
                      -len(additional_key),
                      additional_key,

--- a/src/rez/tests/data/solver/packages/pyvariants/2/package.py
+++ b/src/rez/tests/data/solver/packages/pyvariants/2/package.py
@@ -1,0 +1,4 @@
+name = "pyvariants"
+version = "2"
+
+variants = [["python-2.7.0"], ["python-2.6.8", "nada"]]

--- a/src/rez/tests/test_completion.py
+++ b/src/rez/tests/test_completion.py
@@ -48,9 +48,9 @@ class TestCompletion(TestBase):
 
         _eq("zzz", [])
         _eq("", ["bahish", "nada", "nopy", "pybah", "pydad", "pyfoo", "pymum",
-                 "pyodd", "pyson", "pysplit", "python"])
+                 "pyodd", "pyson", "pysplit", "python", "pyvariants"])
         _eq("py", ["pybah", "pydad", "pyfoo", "pymum", "pyodd", "pyson",
-            "pysplit", "python"])
+            "pysplit", "python", "pyvariants"])
         _eq("pys", ["pyson", "pysplit"])
         _eq("pyb", ["pybah", "pybah-4", "pybah-5"])
         _eq("pybah-", ["pybah-4", "pybah-5"])

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -27,6 +27,7 @@ ALL_PACKAGES = set([
     'pyson-1', 'pyson-2',
     'pysplit-5', 'pysplit-6', 'pysplit-7',
     'python-2.5.2', 'python-2.6.0', 'python-2.6.8', 'python-2.7.0',
+    'pyvariants-2',
     # packages from data/packages
     'unversioned',
     'unversioned_py',

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -3,6 +3,7 @@ test dependency resolving algorithm
 """
 from rez.vendor.version.requirement import Requirement
 from rez.solver import Solver, Cycle, SolverStatus
+from rez.config import config
 import rez.vendor.unittest2 as unittest
 from rez.tests.util import TestBase
 import itertools
@@ -92,7 +93,7 @@ class TestSolver(TestBase):
 
         return s1
 
-    def test_1(self):
+    def test_01(self):
         """Extremely basic solves involving a single package."""
         self._solve([],
                     [])
@@ -113,7 +114,7 @@ class TestSolver(TestBase):
         self._solve(["!python"],
                     [])
 
-    def test_2(self):
+    def test_02(self):
         """Basic solves involving a single package."""
         self._solve(["nada", "~nada"],
                     ["nada[]"])
@@ -134,24 +135,24 @@ class TestSolver(TestBase):
         self._solve(["!python-2.6+", "python"],
                     ["python-2.5.2[]"])
 
-    def test_3(self):
+    def test_03(self):
         """Failures in the initial request."""
         self._fail("nada", "!nada")
         self._fail("python-2.6", "~python-2.7")
         self._fail("pyfoo", "nada", "!nada")
 
-    def test_4(self):
+    def test_04(self):
         """Basic failures."""
         self._fail("pybah", "!python")
         self._fail("pyfoo-3.1", "python-2.7+")
         self._fail("pyodd<2", "python-2.7")
         self._fail("nopy", "python-2.5.2")
 
-    def test_5(self):
+    def test_05(self):
         """More complex failures."""
         self._fail("bahish", "pybah<5")
 
-    def test_6(self):
+    def test_06(self):
         """Basic solves involving multiple packages."""
         self._solve(["nada", "nopy"],
                     ["nada[]", "nopy-2.1[]"])
@@ -168,7 +169,7 @@ class TestSolver(TestBase):
         self._solve(["python", "pybah"],
                     ["python-2.6.8[]", "pybah-4[]"])
 
-    def test_7(self):
+    def test_07(self):
         """More complex solves."""
         self._solve(["python", "pyodd"],
                     ["python-2.6.8[]", "pybah-4[]", "pyodd-2[]"])
@@ -181,7 +182,7 @@ class TestSolver(TestBase):
         self._solve(["python", "bahish", "pybah"],
                     ["python-2.5.2[]", "pybah-5[]", "bahish-2[]"])
 
-    def test_8(self):
+    def test_08(self):
         """Cyclic failures."""
         def _test(*pkgs):
             s = self._fail(*pkgs)
@@ -195,6 +196,21 @@ class TestSolver(TestBase):
         s = self._fail("pymum-2")
         self.assertFalse(isinstance(s.failure_reason(), Cycle))
 
+    # variant tests
+
+    def test_09_version_priority_mode(self):
+        config.override("variant_select_mode", "version_priority")
+        self._solve(["pyvariants", "python"],
+                    ["python-2.7.0[]", "pyvariants-2[0]"])
+        self._solve(["pyvariants", "python", "nada"],
+                    ["python-2.7.0[]", "pyvariants-2[0]", "nada[]"])
+
+    def test_10_intersection_priority_mode(self):
+        config.override("variant_select_mode", "intersection_priority")
+        self._solve(["pyvariants", "python"],
+                    ["python-2.7.0[]", "pyvariants-2[0]"])
+        self._solve(["pyvariants", "python", "nada"],
+                    ["python-2.6.8[]", "nada[]", "pyvariants-2[1]"])
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,4 +1,4 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.0.rc1.28"
+_rez_version = "2.0.rc1.29"

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,4 +1,4 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.0.rc1.29"
+_rez_version = "2.0.rc1.30"

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -77,7 +77,13 @@ class Platform(object):
     @cached_property
     def physical_cores(self):
         """Return the number of physical cpu cores on the system."""
-        return self._physical_cores_base()
+        try:
+            return self._physical_cores_base()
+        except Exception as e:
+            from rez.utils.logging_ import print_error
+            print_error("Error detecting physical core count, defaulting to 1: %s"
+                        % str(e))
+        return 1
 
     @cached_property
     def logical_cores(self):
@@ -86,7 +92,13 @@ class Platform(object):
         May be different from physical_cores if, ie, intel's hyperthreading is
         enabled.
         """
-        return self._logical_cores()
+        try:
+            return self._logical_cores()
+        except Exception as e:
+            from rez.utils.logging_ import print_error
+            print_error("Error detecting logical core count, defaulting to 1: %s"
+                        % str(e))
+        return 1
 
     # -- implementation
 
@@ -142,6 +154,7 @@ class Platform(object):
     def _logical_cores(self):
         from multiprocessing import cpu_count
         return cpu_count()
+
 
 # -----------------------------------------------------------------------------
 # Unix (Linux and OSX)

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -2,6 +2,7 @@ import platform
 import sys
 import os
 import os.path
+import re
 from rez.util import which
 from rez.utils.data_utils import cached_property
 from rez.exceptions import RezSystemError
@@ -73,6 +74,20 @@ class Platform(object):
         """Return system default temporary directory path."""
         return self._tmpdir()
 
+    @cached_property
+    def physical_cores(self):
+        """Return the number of physical cpu cores on the system."""
+        return self._physical_cores_base()
+
+    @cached_property
+    def logical_cores(self):
+        """Return the number of cpu cores as reported to the os.
+
+        May be different from physical_cores if, ie, intel's hyperthreading is
+        enabled.
+        """
+        return self._logical_cores()
+
     # -- implementation
 
     def _arch(self):
@@ -103,6 +118,30 @@ class Platform(object):
         """Create a symbolic link pointing to source named link_name."""
         os.symlink(source, link_name)
 
+    def _physical_cores_base(self):
+        if self.logical_cores == 1:
+            # if we only have one core, we only have one core... no need to
+            # bother with platform-specific stuff...
+
+            # we do this check for all because on some platforms, the output
+            # of various commands (dmesg, lscpu, /proc/cpuinfo) can be
+            # very different if there's only one cpu, and don't want to have
+            # to deal with that case
+            return 1
+        cores = self._physical_cores()
+        if cores is None:
+            from rez.utils.logging_ import print_warning
+            print_warning("Could not determine number of physical cores - "
+                          "falling back on logical cores value")
+            cores = self.logical_cores
+        return cores
+
+    def _physical_cores(self):
+        raise NotImplementedError
+
+    def _logical_cores(self):
+        from multiprocessing import cpu_count
+        return cpu_count()
 
 # -----------------------------------------------------------------------------
 # Unix (Linux and OSX)
@@ -228,6 +267,100 @@ class LinuxPlatform(_UnixPlatform):
         from rez.util import which
         return which("kdiff3", "meld", "diff")
 
+    @classmethod
+    def _parse_colon_table_to_dict(cls, table_text):
+        '''Given a simple text output where each line gives a key-value pair
+      of the form "key: value", parse and return a dict'''
+        lines = [l.strip() for l in table_text.splitlines()]
+        lines = [l for l in lines if l]
+        pairs = [l.split(':', 1) for l in lines]
+        pairs = [(k.strip(), v.strip()) for k, v in pairs]
+        data = dict(pairs)
+        assert len(data) == len(pairs)
+        return data
+
+    def _physical_cores_from_cpuinfo(self):
+        cpuinfo = '/proc/cpuinfo'
+        if not os.path.isfile(cpuinfo):
+            return None
+
+        with open(cpuinfo) as f:
+            contents = f.read()
+
+        known_ids = set()
+
+        proc_re = re.compile('^processor\s*:\s+[0-9]+\s*$', re.MULTILINE)
+        procsplit = proc_re.split(contents)
+
+        if len(procsplit) <= 1:
+            # no procs found... give up
+            return None
+        elif len(procsplit) == 2:
+            # if there's only two entries - the first is the stuff before the
+            # processor, and can be ingored... which means there's only one
+            # proc
+
+            # besides, if there's only one proc, the output changes - ie, no
+            # "core id", etc
+            return 1
+
+        # the first result is the stuff before the first processor line -
+        # ignore it...
+        for proc in procsplit[1:]:
+            proc = self._parse_colon_table_to_dict(proc)
+            # physical id corresponds to the socket, and core id to the
+            # physical core number on that socket
+            p_id = proc.get('physical id')
+            c_id = proc.get('core id')
+            if p_id is None or c_id is None:
+                # something is screwy, we weren't able to parse correctly...
+                return None
+
+            # hyperthreaded procs will share the same physical_id + core id...
+            # so if we just throw them all in a set, duplicates will be
+            # ignored, and we'll know the total number of "real" cores
+            known_ids.add((int(p_id), int(c_id)))
+        return len(known_ids)
+
+    def _physical_cores_from_lscpu(self):
+        import subprocess
+        try:
+            p = subprocess.Popen(['lscpu'], stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        except (OSError, IOError):
+            return None
+
+        stdout, stderr = p.communicate()
+        if p.returncode:
+            return None
+
+        data = self._parse_colon_table_to_dict(stdout)
+
+        # lscpu gives output like this:
+        #
+        # CPU(s):                24
+        # On-line CPU(s) list:   0-23
+        # Thread(s) per core:    2
+        # Core(s) per socket:    6
+        # Socket(s):             2
+
+        # we want to take sockets * cores, and ignore threads...
+
+        # some versions of lscpu format the sockets line differently...
+        sockets = data.get('Socket(s)', data.get('CPU socket(s)'))
+        if not sockets:
+            return None
+        cores = data.get('Core(s) per socket')
+        if not cores:
+            return None
+        return int(sockets) * int(cores)
+
+    def _physical_cores(self):
+        cores = self._physical_cores_from_cpuinfo()
+        if cores is not None:
+            return cores
+        return self._physical_cores_from_lscpu()
+
 
 # -----------------------------------------------------------------------------
 # OSX
@@ -257,6 +390,23 @@ class OSXPlatform(_UnixPlatform):
     def _editor(self):
         return "open"
 
+    def _physical_cores_from_osx_sysctl(self):
+        import subprocess
+        try:
+            p = subprocess.Popen(['sysctl', '-n', 'hw.physicalcpu'],
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        except (OSError, IOError):
+            return None
+
+        stdout, stderr = p.communicate()
+        if p.returncode:
+            return None
+
+        return int(stdout.strip())
+
+    def _physical_cores(self):
+        return self._physical_cores_from_osx_sysctl()
 
 # -----------------------------------------------------------------------------
 # Windows
@@ -314,6 +464,30 @@ class WindowsPlatform(Platform):
 
     def _terminal_emulator_command(self):
         return "CMD.exe /Q /K"
+
+    def _physical_cores_from_wmic(self):
+        # windows
+        import subprocess
+        try:
+            p = subprocess.Popen('wmic cpu get NumberOfCores /value'.split(),
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        except (OSError, IOError):
+            return None
+
+        stdout, stderr = p.communicate()
+        if p.returncode:
+            return None
+
+        result = stdout.strip().split('=')
+        if result[0] != 'NumberOfCores':
+            # don't know what's wrong... should get back a result like:
+            # NumberOfCores=2
+            return None
+        return int(result[1])
+
+    def _physical_cores(self):
+        return self._physical_cores_from_wmic()
 
 
 # singleton

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -5,6 +5,7 @@ import os.path
 from rez.util import which
 from rez.utils.data_utils import cached_property
 from rez.exceptions import RezSystemError
+from tempfile import gettempdir
 
 
 class Platform(object):
@@ -96,7 +97,7 @@ class Platform(object):
         raise NotImplementedError
 
     def _tmpdir(self):
-        raise NotImplementedError
+        return gettempdir()
 
     def symlink(self, source, link_name):
         """Create a symbolic link pointing to source named link_name."""
@@ -108,8 +109,7 @@ class Platform(object):
 # -----------------------------------------------------------------------------
 
 class _UnixPlatform(Platform):
-    def _tmpdir(self):
-        return "/tmp"
+    pass
 
 
 # -----------------------------------------------------------------------------
@@ -282,12 +282,6 @@ class WindowsPlatform(Platform):
                 toks.append(item)
         final_version = str('.').join(toks)
         return "windows-%s" % final_version
-
-    def _tmpdir(self):
-        path = os.getenv("TEMP")
-        if path and os.path.isdir(path):
-            return path
-        return "C:/temp"
 
     def _image_viewer(self):
         # os.system("file.jpg") will open default viewer on windows

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -12,7 +12,6 @@ from rez.config import config
 from rez.backport.shutilwhich import which
 from rez.vendor.schema.schema import Or
 from rez.shells import create_shell
-from multiprocessing import cpu_count
 import functools
 import os.path
 import sys
@@ -176,7 +175,7 @@ class CMakeBuildSystem(BuildSystem):
         cmd += (self.child_build_args or [])
 
         if not any(x.startswith("-j") for x in (self.child_build_args or [])):
-            n = variant.config.build_thread_count or cpu_count()
+            n = variant.config.build_thread_count
             cmd.append("-j%d" % n)
 
         # execute make within the build env
@@ -208,7 +207,7 @@ class CMakeBuildSystem(BuildSystem):
         executor.env.CMAKE_MODULE_PATH.append(cmake_path)
         executor.env.REZ_BUILD_DOXYFILE = os.path.join(template_path, 'Doxyfile')
         executor.env.REZ_BUILD_VARIANT_INDEX = variant.index or 0
-        executor.env.REZ_BUILD_THREAD_COUNT = package.config.build_thread_count or cpu_count()
+        executor.env.REZ_BUILD_THREAD_COUNT = package.config.build_thread_count
         # build always occurs on a filesystem package, thus 'filepath' attribute
         # exists. This is not the case for packages in general.
         executor.env.REZ_BUILD_PROJECT_FILE = package.filepath

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -5,7 +5,7 @@ from rez.package_repository import PackageRepository
 from rez.package_resources_ import PackageFamilyResource, PackageResource, \
     VariantResourceHelper, PackageResourceHelper, package_pod_schema, \
     package_release_keys
-from rez.serialise import clear_file_caches
+from rez.serialise import clear_file_caches, open_file_for_write
 from rez.package_serialise import dump_package_data
 from rez.exceptions import PackageMetadataError, ResourceError, RezSystemError, \
     ConfigurationError, PackageRepositoryError
@@ -760,7 +760,7 @@ class FileSystemPackageRepository(PackageRepository):
                 package_data[key] = value
 
         filepath = os.path.join(path, "package.py")
-        with open(filepath, 'w') as f:
+        with open_file_for_write(filepath) as f:
             dump_package_data(package_data, buf=f, format_=package_format)
 
         # touch the family dir, this keeps memcached resolves updated properly

--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -47,6 +47,9 @@ class HgReleaseVCS(ReleaseVCS):
     def hg(self, *nargs, **kwargs):
         if kwargs.pop('patch', False):
             nargs += ('--mq',)
+        if ('-R' not in nargs and '--repository' not in nargs
+            and not any(x.startswith(('-R', '--repository=')) for x in nargs)):
+            nargs += ('--repository', self.vcs_root)
         if kwargs:
             raise HgReleaseVCSError("Unrecognized keyword args to hg command:"
                                     " %s" % ", ".join(kwargs))


### PR DESCRIPTION
fixes a bug where variant_select_mode was always using intersection_priority mode, regardless of what the setting was

Also added some more clarification / examples to the description in rezconfig

The source of the problem was a comparison of a string to the VariantSelectMode enum, which always returns False. Would like to protect against future problems of this sort by modifying the __eq__ for the enum to either error or do a "real" comparison against strings and integers.