### PR TITLE
Allow to rez-release without releasing tags

### DIFF
--- a/src/rez/cli/release.py
+++ b/src/rez/cli/release.py
@@ -7,8 +7,8 @@ import os
 def setup_parser(parser, completions=False):
     from rez.cli.build import setup_parser_common
     from rez.release_vcs import get_release_vcs_types
+    from rez.vendor.argparse import SUPPRESS
     vcs_types = get_release_vcs_types()
-
     parser.add_argument(
         "-m", "--message", type=str,
         help="release message")
@@ -18,6 +18,9 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "--no-latest", dest="no_latest", action="store_true",
         help="allows release of version earlier than the latest release.")
+    parser.add_argument(
+        "--no-update-repo", dest="no_update_repo", default=False, action="store_true",
+        help=SUPPRESS)
     setup_parser_common(parser)
 
 
@@ -48,6 +51,7 @@ def command(opts, parser, extra_arg_groups=None):
                                    build_system=buildsys,
                                    vcs=vcs,
                                    ensure_latest=(not opts.no_latest),
+                                   no_update_repo=opts.no_update_repo,
                                    verbose=True)
 
     builder.release(release_message=opts.message,

--- a/src/rez/release_vcs.py
+++ b/src/rez/release_vcs.py
@@ -66,7 +66,7 @@ class ReleaseVCS(object):
         """Return True if this release mode works with the given root path."""
         raise NotImplementedError
 
-    def validate_repostate(self):
+    def validate_repostate(self, no_update_repo=False):
         """Ensure that the VCS working copy is up-to-date."""
         raise NotImplementedError
 

--- a/src/rezplugins/release_vcs/git.py
+++ b/src/rezplugins/release_vcs/git.py
@@ -77,7 +77,7 @@ class GitReleaseVCS(ReleaseVCS):
                 raise e
         return (None, None)
 
-    def validate_repostate(self):
+    def validate_repostate(self, no_update_repo=False):
         b = self.git("rev-parse", "--is-bare-repository")
         if b == "true":
             raise ReleaseVCSError("Could not release: bare git repository")
@@ -85,12 +85,13 @@ class GitReleaseVCS(ReleaseVCS):
         remote, remote_branch = self.get_tracking_branch()
 
         # check for upstream branch
-        if remote is None and not self.settings.allow_no_upstream:
-            raise ReleaseVCSError(
-                "Release cancelled: there is no upstream branch (git cannot see "
-                "a remote repo - you should probably FIX THIS FIRST!). To allow "
-                "the release, set the config entry "
-                "'plugins.release_vcs.git.allow_no_upstream' to true.")
+        if not no_update_repo:
+            if remote is None and (not self.settings.allow_no_upstream):
+                raise ReleaseVCSError(
+                    "Release cancelled: there is no upstream branch (git cannot see "
+                    "a remote repo - you should probably FIX THIS FIRST!). To allow "
+                    "the release, set the config entry "
+                    "'plugins.release_vcs.git.allow_no_upstream' to true.")
 
         # check we are releasing from a valid branch
         releasable_branches = self.type_settings.releasable_branches

--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -51,7 +51,7 @@ class HgReleaseVCS(ReleaseVCS):
         else:
             self.hg('tag', '-f', tag_name)
 
-    def validate_repostate(self):
+    def validate_repostate(self, no_update_repo=False):
         def _check(modified, path):
             if modified:
                 modified = [line.split()[-1] for line in modified]

--- a/src/rezplugins/release_vcs/stub.py
+++ b/src/rezplugins/release_vcs/stub.py
@@ -27,7 +27,7 @@ class StubReleaseVCS(ReleaseVCS):
     def is_valid_root(cls, path):
         return os.path.exists(os.path.join(path, '.stub'))
 
-    def validate_repostate(self):
+    def validate_repostate(self, no_update_repo=False):
         pass
 
     def get_current_revision(self):

--- a/src/rezplugins/release_vcs/svn.py
+++ b/src/rezplugins/release_vcs/svn.py
@@ -72,7 +72,7 @@ class SvnReleaseVCS(ReleaseVCS):
     def is_valid_root(cls, path):
         return os.path.isdir(os.path.join(path, '.svn'))
 
-    def validate_repostate(self):
+    def validate_repostate(self, no_update_repo=False):
         status_list = self.svnc.status(self.path, get_all=False, update=True)
         status_list_known = []
 


### PR DESCRIPTION
allow to rez-release without releasing the tag, and without getting the changelog.
Actually in the  code there is still no logic for not getting the changelog, so this needs to be implemented.