### PR TITLE
Allow the repository for the release package to live at a higher level

### DIFF
--- a/src/rez/build_process_.py
+++ b/src/rez/build_process_.py
@@ -70,7 +70,7 @@ class BuildProcess(object):
         self.vcs = vcs
         self.ensure_latest = ensure_latest
 
-        if vcs and vcs.path != working_dir:
+        if vcs and vcs.pkg_root != working_dir:
             raise BuildProcessError(
                 "Build process was instantiated with a mismatched VCS instance")
 

--- a/src/rez/release_vcs.py
+++ b/src/rez/release_vcs.py
@@ -2,6 +2,7 @@ from rez.exceptions import ReleaseVCSError
 from rez.packages_ import get_developer_package
 from rez.util import which
 from rez.utils.logging_ import print_debug
+from rez.utils.filesystem import walk_up_dirs
 import subprocess
 
 
@@ -21,30 +22,58 @@ def create_release_vcs(path, vcs_name=None):
         cls = plugin_manager.get_plugin_class('release_vcs', vcs_name)
         return cls(path)
 
-    clss = []
+    classes_by_level = {}
     for vcs_name in vcs_types:
         cls = plugin_manager.get_plugin_class('release_vcs', vcs_name)
-        if cls.is_valid_root(path):
-            clss.append(cls)
+        result = cls.find_vcs_root(path)
+        if not result:
+            continue
+        vcs_path, levels_up = result
+        classes_by_level.setdefault(levels_up, []).append((cls, vcs_path))
+
+    if not classes_by_level:
+        raise ReleaseVCSError("No version control system for package "
+                      "releasing is associated with the path %s" % path)
+
+    # it's ok to have multiple results, as long as there is only one at the
+    # "closest" directory up from this dir - ie, if we start at:
+    #    /blah/foo/pkg_root
+    # and these dirs exist:
+    #    /blah/.hg
+    #    /blah/foo/.git
+    # ...then this is ok, because /blah/foo/.git is "closer" to the original
+    # dir, and will be picked. However, if these two directories exist:
+    #    /blah/foo/.git
+    #    /blah/foo/.hg
+    # ...then we error, because we can't decide which to use
+
+    lowest_level = sorted(classes_by_level)[0]
+    clss = classes_by_level[lowest_level]
     if len(clss) > 1:
-        clss_str = ", ".join(x.name() for x in clss)
+        clss_str = ", ".join(x[0].name() for x in clss)
         raise ReleaseVCSError("Several version control systems are associated "
                               "with the path %s: %s. Use rez-release --vcs to "
                               "choose." % (path, clss_str))
-    elif not clss:
-        raise ReleaseVCSError("No version control system for package "
-                              "releasing is associated with the path %s" % path)
     else:
-        return clss[0](path)
+        cls, vcs_root = clss[0]
+        return cls(pkg_root=path, vcs_root=vcs_root)
 
 
 class ReleaseVCS(object):
     """A version control system (VCS) used to release Rez packages.
     """
-    def __init__(self, path):
-        assert(self.is_valid_root(path))
-        self.path = path
-        self.package = get_developer_package(path)
+    def __init__(self, pkg_root, vcs_root=None):
+        if vcs_root is None:
+            result = self.find_vcs_root(pkg_root)
+            if not result:
+                raise ReleaseVCSError("Could not find %s repository for the "
+                                      "path %s" % (self.name(), pkg_root))
+            vcs_root = result[0]
+        else:
+            assert(self.is_valid_root(vcs_root))
+        self.vcs_root = vcs_root
+        self.pkg_root = pkg_root
+        self.package = get_developer_package(pkg_root)
         self.type_settings = self.package.config.plugins.release_vcs
         self.settings = self.type_settings.get(self.name())
 
@@ -63,8 +92,40 @@ class ReleaseVCS(object):
 
     @classmethod
     def is_valid_root(cls, path):
-        """Return True if this release mode works with the given root path."""
+        """Return True if the given path is a valid root directory for this
+        version control system.
+
+        Note that this is different than whether the path is under the
+        control of this type of vcs; to answer that question,
+        use find_vcs_root"""
         raise NotImplementedError
+
+    @classmethod
+    def search_parents_for_root(cls):
+        """Return True if this vcs type should check parent directories to
+        find the root directory
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def find_vcs_root(cls, path):
+        """Try to find a version control root directory of this type for the
+        given path.
+
+        If successful, returns (vcs_root, levels_up), where vcs_root is the
+        path to the version control root directory it found, and levels_up is an
+        integer indicating how many parent directories it had to search through
+        to find it, where 0 means it was found in the indicated path, 1 means it
+        was found in that path's parent, etc. If not sucessful, returns None
+        """
+        if cls.search_parents_for_root():
+            valid_dirs = walk_up_dirs(path)
+        else:
+            valid_dirs = [path]
+        for i, current_path in enumerate(valid_dirs):
+            if cls.is_valid_root(current_path):
+                return current_path, i
+        return None
 
     def validate_repostate(self):
         """Ensure that the VCS working copy is up-to-date."""
@@ -131,7 +192,7 @@ class ReleaseVCS(object):
             print_debug("Running command: %s" % cmd_str)
 
         p = subprocess.Popen(nargs, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, cwd=self.path)
+                             stderr=subprocess.PIPE, cwd=self.pkg_root)
         out, err = p.communicate()
         if p.returncode:
             raise ReleaseVCSError("command failed: %s\n%s" % (cmd_str, err))

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -273,3 +273,13 @@ def test_encode_decode():
 
     # u'\u20ac' == Euro symbol
     do_test(u"\u20ac3 ~= $4.06", '_3e282ac3_020_07e_03d_020_0244.06')
+
+def walk_up_dirs(path):
+    """Yields absolute directories starting with the given path, and iterating
+    up through all it's parents, until it reaches a root directory"""
+    prev_path = None
+    current_path = os.path.abspath(path)
+    while current_path != prev_path:
+        yield current_path
+        prev_path = current_path
+        current_path = os.path.dirname(prev_path)

--- a/src/rezplugins/release_vcs/git.py
+++ b/src/rezplugins/release_vcs/git.py
@@ -24,18 +24,23 @@ class GitReleaseVCS(ReleaseVCS):
     def name(cls):
         return 'git'
 
-    def __init__(self, path):
-        super(GitReleaseVCS, self).__init__(path)
+    def __init__(self, pkg_root, vcs_root=None):
+        super(GitReleaseVCS, self).__init__(pkg_root, vcs_root=vcs_root)
         self.executable = self.find_executable('git')
 
         try:
             self.git("rev-parse")
         except ReleaseVCSError:
-            raise GitReleaseVCSError("%s is not a git repository" % path)
+            raise GitReleaseVCSError("%s is not a git repository" %
+                                     self.vcs_root)
 
     @classmethod
     def is_valid_root(cls, path):
         return os.path.isdir(os.path.join(path, '.git'))
+
+    @classmethod
+    def search_parents_for_root(cls):
+        return True
 
     def git(self, *nargs):
         return self._cmd(self.executable, *nargs)

--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -16,19 +16,19 @@ class HgReleaseVCS(ReleaseVCS):
     def name(cls):
         return 'hg'
 
-    def __init__(self, path):
-        super(HgReleaseVCS, self).__init__(path)
+    def __init__(self, pkg_root, vcs_root=None):
+        super(HgReleaseVCS, self).__init__(pkg_root, vcs_root=vcs_root)
         self.executable = self.find_executable('hg')
 
-        hgdir = os.path.join(self.path, '.hg')
+        hgdir = os.path.join(self.vcs_root, '.hg')
         if not os.path.isdir(hgdir):
             raise HgReleaseVCSError(
-                "'%s' is not a mercurial working copy" % self.path)
+                "'%s' is not a mercurial working copy" % self.vcs_root)
         try:
-            assert self.hg('root')[0] == self.path
+            assert self.hg('root')[0] == self.vcs_root
         except AssertionError:
             raise HgReleaseVCSError(
-                "'%s' is not the root of a mercurial working copy" % self.path)
+                "'%s' is not the root of a mercurial working copy" % self.vcs_root)
         except Exception, err:
             raise HgReleaseVCSError("failed to call hg binary: " + str(err))
 
@@ -39,6 +39,10 @@ class HgReleaseVCS(ReleaseVCS):
     @classmethod
     def is_valid_root(cls, path):
         return os.path.isdir(os.path.join(path, '.hg'))
+
+    @classmethod
+    def search_parents_for_root(cls):
+        return True
 
     def hg(self, *nargs, **kwargs):
         if kwargs.pop('patch', False):
@@ -75,7 +79,7 @@ class HgReleaseVCS(ReleaseVCS):
                     "%s is not in a state to release - please commit outstanding "
                     "changes: %s" % (path, ', '.join(modified)))
 
-        _check(self.hg('status', '-m', '-a'), self.path)
+        _check(self.hg('status', '-m', '-a'), self.vcs_root)
         if self.patch_path:
             _check(self.hg('status', '-m', '-a', '--mq'), self.patch_path)
 

--- a/src/rezplugins/release_vcs/stub.py
+++ b/src/rezplugins/release_vcs/stub.py
@@ -15,8 +15,8 @@ class StubReleaseVCS(ReleaseVCS):
     A writable '.stub' file must be present in the project root. Any created
     tags are written to this yaml file.
     """
-    def __init__(self, path):
-        super(StubReleaseVCS, self).__init__(path)
+    def __init__(self, pkg_root, vcs_root=None):
+        super(StubReleaseVCS, self).__init__(pkg_root, vcs_root=vcs_root)
         self.time = int(time.time())
 
     @classmethod
@@ -26,6 +26,10 @@ class StubReleaseVCS(ReleaseVCS):
     @classmethod
     def is_valid_root(cls, path):
         return os.path.exists(os.path.join(path, '.stub'))
+
+    @classmethod
+    def search_parents_for_root(cls):
+        return False
 
     def validate_repostate(self):
         pass
@@ -56,11 +60,11 @@ class StubReleaseVCS(ReleaseVCS):
         self._write_stub(data)
 
     def _read_stub(self):
-        with open(os.path.join(self.path, '.stub')) as f:
+        with open(os.path.join(self.vcs_root, '.stub')) as f:
             return yaml.load(f.read()) or {}
 
     def _write_stub(self, data):
-        with open(os.path.join(self.path, '.stub'), 'w') as f:
+        with open(os.path.join(self.vcs_root, '.stub'), 'w') as f:
             f.write(dump_yaml(data))
 
 


### PR DESCRIPTION
This way, the repo can be at, for instance, the package family level, instead of at the versioned package level.  ie, right now, you are required to have:

my_package/1.1.0/.git
my_package/1.1.2/.git
my_package/2.0.0/.git
my_package/2.0.1/.git
my_package/3.5.1/.git

However, it's fairly frequent that you might have a change which you will need to be applied to all 5 versions.  In this case, you then need to also make 5 separate commits, which seems both more work, and organizes the repository information in a less useful way.  With this commit, you can instead have:

my_package/.git

...and make only one commit, containing the changes to all 5 versions.

(FYI, This pull request also contains the commit from my other hg_vcs pull request...)