### PR TITLE
  plugin_managers: don't reload plugin modules

### DIFF
--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -9,6 +9,7 @@ from rez.utils.data_utils import LazySingleton, cached_property
 from rez.utils.logging_ import print_debug, print_warning
 from rez.exceptions import RezPluginError
 import os.path
+import sys
 
 
 # modified from pkgutil standard library:
@@ -117,7 +118,11 @@ class RezPluginType(object):
                         print_debug("loading %s plugin at %s: %s..."
                                     % (self.type_name, path, modname))
                     try:
-                        module = loader.find_module(modname).load_module(modname)
+                        # load_module will force reload the module if it's
+                        # already loaded, so check for that
+                        module = sys.modules.get(modname)
+                        if module is None:
+                            module = loader.find_module(modname).load_module(modname)
                         if hasattr(module, 'register_plugin') and \
                                 hasattr(module.register_plugin, '__call__'):
                             plugin_class = module.register_plugin()


### PR DESCRIPTION
This fixes an issue where the plugin manager will always force-reload plugin modules, even if they've already loaded. This can crate issues with, ie, inheritance + object comparison