### PR TITLE
fix for config.py

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -489,7 +489,8 @@ class Config(object):
         filepaths = []
         filepaths.append(get_module_root_config())
         filepath = os.getenv("REZ_CONFIG_FILE")
-        filepaths.append(filepath)
+        if filepath:
+            filepaths.append(filepath)
 
         filepath = os.path.expanduser("~/.rezconfig")
         filepaths.append(filepath)


### PR DESCRIPTION
Commit 7d03a1bd9b371f8decadd42c075936531f8d9209 broke rez if REZ_CONFIG_FILE env var was not set - this restores the check that it exists before adding to the filepaths