### PR TITLE
checking if packages path item exists before call to get_repository

### DIFF
--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -326,6 +326,8 @@ def iter_package_families(paths=None):
         `PackageFamily` iterator.
     """
     for path in (paths or config.packages_path):
+        if not os.path.isdir(path):
+            continue
         repo = package_repository_manager.get_repository(path)
         for resource in repo.iter_package_families():
             yield PackageFamily(resource)


### PR DESCRIPTION
A fix for Issue 225.

Unsure if it would be better to catch this deeper in. It feels wrong for the package repository module to not deal better with this case.
