### PR TITLE
Cli callbacks

### DIFF
--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -80,7 +80,10 @@ def _add_common_args(parser):
                              "successfully, and None if it did not; "
                              "error - None if the command completed "
                              "succesfully, and the exception instance if it "
-                             "did not")
+                             "did not. Note that for commands which can "
+                             "start interactive shells, such as rez-env, "
+                             "this command will not be run until after the "
+                             "shell exits")
 
 
 class InfoAction(_StoreTrueAction):
@@ -177,7 +180,10 @@ def run(command=None):
             returncode = opts.func(opts, opts.parser, arg_groups[1:])
         except Exception as e:
             do_post_callback(None, e)
-            raise e
+            raise
+        except SystemExit as e:
+            do_post_callback(e.code, None)
+            raise
         else:
             do_post_callback(returncode, None)
         return returncode

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -290,6 +290,8 @@ config_schema = Schema({
     "variant_select_mode":                          VariantSelectMode_,
     "package_filter":                               OptionalDictOrDictList,
     "new_session_popen_args":                       OptionalDict,
+    "pre_callbacks":                                Or({}, {str: basestring}),
+    "post_callbacks":                               Or({}, {str: basestring}),
 
     # GUI settings
     "use_pyside":                                   Bool,

--- a/src/rez/exceptions.py
+++ b/src/rez/exceptions.py
@@ -162,3 +162,13 @@ class RezGuiQTImportError(ImportError):
     """A special case - see cli/gui.py
     """
     pass
+
+class CallbackAbort(RezError):
+    """Raised to signal that a pre-callback should abort execution; the
+    message will be printed, but no traceback will be (by default).  A custom
+    returncode that the process should return on exit may also be specified.
+    """
+
+    def __init__(self, value=None, returncode=200):
+        self.returncode = value
+        super(CallbackAbort, self).__init__(value=value)

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -429,6 +429,8 @@ pre_callbacks = {}
 #       and None if it did not
 #   error - None if the command completed succesfully, and the exception
 #       instance if it did not
+# Note that for commands which can start interactive shells, such as rez-env,
+# this command will not be run until after the shell exits
 
 post_callbacks = {}
 

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -402,6 +402,38 @@ max_package_changelog_chars = 1024
 
 
 ###############################################################################
+# Callbacks
+###############################################################################
+
+# Callbacks to execute before a command is executed - stored as a dict,
+# indexed by rez-command, with values that should be python code strings to
+# exec. You may raise a CallbackAbort to signal that the command should not
+# be run (other exceptions will also cancel the command, but will also print
+# a traceback). The callback is executed in a context where the following
+# names are available:
+#   opts - the parsed command-line options
+#   arg_groups - the args, separated into different groups by '--'
+#       characters
+#   CallbackAbort - the error to raise to signal early termination, provided
+#       in the namespace for convenience
+
+pre_callbacks = {}
+
+# Callbacks to execute after a command is executed - stored as a dict,
+# indexed by rez-command, with values that should be python code strings to
+# exec. the command obviously can't be cancelled, but you may still raise a
+# CallbackAbort to cause the command to return a non-zero exitcode if desired.
+# The callback is executed in a context with all the names available in the
+# pre-callback, in addition to the following:
+#   returncode - the returncode of the command, if it completed successfully,
+#       and None if it did not
+#   error - None if the command completed succesfully, and the exception
+#       instance if it did not
+
+post_callbacks = {}
+
+
+###############################################################################
 # Colorization
 ###############################################################################
 


### PR DESCRIPTION
We wanted a way to run some checks before allowing rez-release to run, so I added a configurable callback system for cli commands

basically, you can set arbitrary python code to run before or after specific commands (and the pre-callbacks have a chance to abort)