### PR TITLE
In combined package yaml files, allow versions to be given with ints or floats

### DIFF
--- a/src/rez/package_maker__.py
+++ b/src/rez/package_maker__.py
@@ -18,7 +18,8 @@ package_schema = Schema({
     Required("name"):                   basestring,
     Optional("base"):                   basestring,
     Optional("version"):                Or(basestring,
-                                           And(Version, Use(str))),
+                                           And(Or(Version, int, float),
+                                               Use(str))),
     Optional('description'):            basestring,
     Optional('authors'):                [basestring],
 

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -4,7 +4,7 @@ Filesystem-based package repository
 from rez.package_repository import PackageRepository
 from rez.package_resources_ import PackageFamilyResource, PackageResource, \
     VariantResourceHelper, PackageResourceHelper, package_pod_schema, \
-    package_release_keys
+    version_pod_schema, version_range_pod_schema, package_release_keys
 from rez.serialise import clear_file_caches
 from rez.package_serialise import dump_package_data
 from rez.exceptions import PackageMetadataError, ResourceError, RezSystemError, \
@@ -217,10 +217,8 @@ class FileSystemCombinedPackageFamilyResource(PackageFamilyResource):
     repository_type = "filesystem"
 
     schema = Schema({
-        Optional("versions"):               [And(basestring,
-                                                 Use(Version))],
-        Optional("version_overrides"):      {And(basestring,
-                                                 Use(VersionRange)): dict}
+        Optional("versions"):               [version_pod_schema],
+        Optional("version_overrides"):      {version_range_pod_schema: dict}
     })
 
     @property


### PR DESCRIPTION
is particularly nice for yaml files, since you can now do, ie:
  versions: [1.5]
...instead of:
  versions: ['1.5']
...which feels more consistent, since you can also do:
  versions [1.5.3]