### PR TITLE
Physical cpus

### DIFF
--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -318,10 +318,16 @@ catch_rex_errors = True
 # source directory (this is typically where temporary build files are written).
 build_directory = "build"
 
-# The number of threads a build system should use, eg the make '-j' option. If
-# zero, this is set to the number of processes on the build host. This setting
-# is exposed as the environment variable $REZ_BUILD_THREAD_COUNT during builds.
-build_thread_count = 0
+
+# The number of threads a build system should use, eg the make '-j' option.
+# If the string values "logical_cores" or "physical_cores", it is set to the
+# detected number of logical / physical cores on the host system.
+# (Logical cores are the number of cores reported to the OS, physical are the
+# number of actual hardware processor cores.  They may differ if, ie, the CPUs
+# support hyperthreading, in which case logical_cores == 2 * physical_cores).
+# This setting is exposed as the environment variable $REZ_BUILD_THREAD_COUNT
+# during builds.
+build_thread_count = "physical_cores"
 
 
 ###############################################################################

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -12,7 +12,6 @@ from rez.config import config
 from rez.backport.shutilwhich import which
 from rez.vendor.schema.schema import Or
 from rez.shells import create_shell
-from multiprocessing import cpu_count
 import functools
 import os.path
 import sys
@@ -176,7 +175,7 @@ class CMakeBuildSystem(BuildSystem):
         cmd += (self.child_build_args or [])
 
         if not any(x.startswith("-j") for x in (self.child_build_args or [])):
-            n = variant.config.build_thread_count or cpu_count()
+            n = variant.config.build_thread_count
             cmd.append("-j%d" % n)
 
         # execute make within the build env
@@ -208,7 +207,7 @@ class CMakeBuildSystem(BuildSystem):
         executor.env.CMAKE_MODULE_PATH.append(cmake_path)
         executor.env.REZ_BUILD_DOXYFILE = os.path.join(template_path, 'Doxyfile')
         executor.env.REZ_BUILD_VARIANT_INDEX = variant.index or 0
-        executor.env.REZ_BUILD_THREAD_COUNT = package.config.build_thread_count or cpu_count()
+        executor.env.REZ_BUILD_THREAD_COUNT = package.config.build_thread_count
         # build always occurs on a filesystem package, thus 'filepath' attribute
         # exists. This is not the case for packages in general.
         executor.env.REZ_BUILD_PROJECT_FILE = package.filepath


### PR DESCRIPTION
Allow setting of build_thread_count to either number of physical cores, or logical cores.
Will differ if hyperthreading is enabled, in which case logical_cores == 2 * physical_cores

My personal experience has been that setting to number of physical_cores leaves the system more responsive, at minimal loss of compilation time...