### PR TITLE
release_vcs.hg: hg method should always operate on the fed repo

### DIFF
--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -47,6 +47,9 @@ class HgReleaseVCS(ReleaseVCS):
     def hg(self, *nargs, **kwargs):
         if kwargs.pop('patch', False):
             nargs += ('--mq',)
+        if ('-R' not in nargs and '--repository' not in nargs
+            and not any(x.startswith(('-R', '--repository=')) for x in nargs)):
+            nargs += ('--repository', self.vcs_root)
         if kwargs:
             raise HgReleaseVCSError("Unrecognized keyword args to hg command:"
                                     " %s" % ", ".join(kwargs))


### PR DESCRIPTION
simple fix, fairly self-explanatory..