### PR TITLE
when using rez-build --ba pass the string to bez as well

### DIFF
--- a/src/rez/cli/_bez.py
+++ b/src/rez/cli/_bez.py
@@ -39,12 +39,13 @@ def run():
     stream=open("%(buildfile)s")
     env={}
     exec stream in env
-    env["build"]("%(srcpath)s","%(bldpath)s","%(instpath)s",%(targets)s)
+    env["build"]("%(srcpath)s","%(bldpath)s","%(instpath)s",%(targets)s,%(build_args)s)
     """ % dict(buildfile=buildfile,
                srcpath=source_path,
                bldpath=doc["build_path"],
                instpath=doc["install_path"],
-               targets=str(opts.TARGET or None))
+               targets=str(opts.TARGET or None),
+               build_args=doc["build_args"])
 
     cli_code = textwrap.dedent(code).replace("\\", "\\\\")
 

--- a/src/rezplugins/build_system/bez.py
+++ b/src/rezplugins/build_system/bez.py
@@ -47,7 +47,9 @@ class BezBuildSystem(BuildSystem):
         doc = dict(
             source_path=self.working_dir,
             build_path=build_path,
-            install_path=install_path)
+            install_path=install_path,
+            build_args=self.build_args)
+
 
         ret = {}
         content = dump_yaml(doc)
@@ -63,7 +65,8 @@ class BezBuildSystem(BuildSystem):
                                      module=("build_system", "bez"),
                                      func_name="_FWD__spawn_build_shell",
                                      working_dir=self.working_dir,
-                                     build_dir=build_path)
+                                     build_dir=build_path,
+                                     build_args=self.build_args)
             ret["success"] = True
             ret["build_env_script"] = build_env_script
             return ret


### PR DESCRIPTION
like the title says.
Currently this change would make all the previous bez build fail, as the arguments to bez's build function has one more argument. Also it would be up to the implementer of rezbuild.py to re-build arguments as they would get as a string, ie build_args="foo=1 bar=cat".