### PR TITLE
Variant select mode

### DIFF
--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -141,6 +141,26 @@ prune_failed_graph = True
 #   present in the request;
 # - intersection_priority: Prefer variants that contain the most number of
 #   packages that are present in the request.
+#
+# As an example, suppose you have a package foo which has two variants:
+#
+#    ["bar-3.0", "baz-2.1"], ["bar-2.8", "burgle-1.0"]
+# if you do:
+#
+#    rez-env foo bar
+#
+# ...then, in either variant_select_mode, it will prefer the first variant,
+# ["bar-3.0", "baz-2.1"], because it has a higher version of the first variant
+# requirement (bar). However, if we instead do:
+#
+#    rez-env foo bar burgle
+#
+# ...we get different behavior. version_priority mode will still return
+# ["bar-3.0", "baz-2.1"], because the first requirement's version is higher.
+#
+# However, intersection_priority mode will pick the second variant,
+# ["bar-2.8", "burgle-1.0"], because it contains more packages that were in the
+# original request (burgle).
 variant_select_mode = "version_priority"
 
 # Package filter. One or more filters can be listed, each with a list of

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -704,7 +704,8 @@ class _PackageVariantSlice(_Common):
                 if not request.conflict and request.name not in names:
                     additional_key.append((request.range, request.name))
 
-            if config.variant_select_mode == VariantSelectMode.version_priority:
+            if (VariantSelectMode[config.variant_select_mode] ==
+                    VariantSelectMode.version_priority):
                 k = (requested_key,
                      -len(additional_key),
                      additional_key,

--- a/src/rez/tests/data/solver/packages/pyvariants/2/package.py
+++ b/src/rez/tests/data/solver/packages/pyvariants/2/package.py
@@ -1,0 +1,4 @@
+name = "pyvariants"
+version = "2"
+
+variants = [["python-2.7.0"], ["python-2.6.8", "nada"]]

--- a/src/rez/tests/test_completion.py
+++ b/src/rez/tests/test_completion.py
@@ -48,9 +48,9 @@ class TestCompletion(TestBase):
 
         _eq("zzz", [])
         _eq("", ["bahish", "nada", "nopy", "pybah", "pydad", "pyfoo", "pymum",
-                 "pyodd", "pyson", "pysplit", "python"])
+                 "pyodd", "pyson", "pysplit", "python", "pyvariants"])
         _eq("py", ["pybah", "pydad", "pyfoo", "pymum", "pyodd", "pyson",
-            "pysplit", "python"])
+            "pysplit", "python", "pyvariants"])
         _eq("pys", ["pyson", "pysplit"])
         _eq("pyb", ["pybah", "pybah-4", "pybah-5"])
         _eq("pybah-", ["pybah-4", "pybah-5"])

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -27,6 +27,7 @@ ALL_PACKAGES = set([
     'pyson-1', 'pyson-2',
     'pysplit-5', 'pysplit-6', 'pysplit-7',
     'python-2.5.2', 'python-2.6.0', 'python-2.6.8', 'python-2.7.0',
+    'pyvariants-2',
     # packages from data/packages
     'unversioned',
     'unversioned_py',

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -3,6 +3,7 @@ test dependency resolving algorithm
 """
 from rez.vendor.version.requirement import Requirement
 from rez.solver import Solver, Cycle, SolverStatus
+from rez.config import config
 import rez.vendor.unittest2 as unittest
 from rez.tests.util import TestBase
 import itertools
@@ -92,7 +93,7 @@ class TestSolver(TestBase):
 
         return s1
 
-    def test_1(self):
+    def test_01(self):
         """Extremely basic solves involving a single package."""
         self._solve([],
                     [])
@@ -113,7 +114,7 @@ class TestSolver(TestBase):
         self._solve(["!python"],
                     [])
 
-    def test_2(self):
+    def test_02(self):
         """Basic solves involving a single package."""
         self._solve(["nada", "~nada"],
                     ["nada[]"])
@@ -134,24 +135,24 @@ class TestSolver(TestBase):
         self._solve(["!python-2.6+", "python"],
                     ["python-2.5.2[]"])
 
-    def test_3(self):
+    def test_03(self):
         """Failures in the initial request."""
         self._fail("nada", "!nada")
         self._fail("python-2.6", "~python-2.7")
         self._fail("pyfoo", "nada", "!nada")
 
-    def test_4(self):
+    def test_04(self):
         """Basic failures."""
         self._fail("pybah", "!python")
         self._fail("pyfoo-3.1", "python-2.7+")
         self._fail("pyodd<2", "python-2.7")
         self._fail("nopy", "python-2.5.2")
 
-    def test_5(self):
+    def test_05(self):
         """More complex failures."""
         self._fail("bahish", "pybah<5")
 
-    def test_6(self):
+    def test_06(self):
         """Basic solves involving multiple packages."""
         self._solve(["nada", "nopy"],
                     ["nada[]", "nopy-2.1[]"])
@@ -168,7 +169,7 @@ class TestSolver(TestBase):
         self._solve(["python", "pybah"],
                     ["python-2.6.8[]", "pybah-4[]"])
 
-    def test_7(self):
+    def test_07(self):
         """More complex solves."""
         self._solve(["python", "pyodd"],
                     ["python-2.6.8[]", "pybah-4[]", "pyodd-2[]"])
@@ -181,7 +182,7 @@ class TestSolver(TestBase):
         self._solve(["python", "bahish", "pybah"],
                     ["python-2.5.2[]", "pybah-5[]", "bahish-2[]"])
 
-    def test_8(self):
+    def test_08(self):
         """Cyclic failures."""
         def _test(*pkgs):
             s = self._fail(*pkgs)
@@ -195,6 +196,21 @@ class TestSolver(TestBase):
         s = self._fail("pymum-2")
         self.assertFalse(isinstance(s.failure_reason(), Cycle))
 
+    # variant tests
+
+    def test_09_version_priority_mode(self):
+        config.override("variant_select_mode", "version_priority")
+        self._solve(["pyvariants", "python"],
+                    ["python-2.7.0[]", "pyvariants-2[0]"])
+        self._solve(["pyvariants", "python", "nada"],
+                    ["python-2.7.0[]", "pyvariants-2[0]", "nada[]"])
+
+    def test_10_intersection_priority_mode(self):
+        config.override("variant_select_mode", "intersection_priority")
+        self._solve(["pyvariants", "python"],
+                    ["python-2.7.0[]", "pyvariants-2[0]"])
+        self._solve(["pyvariants", "python", "nada"],
+                    ["python-2.6.8[]", "nada[]", "pyvariants-2[1]"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
redo of:

https://github.com/nerdvegas/rez/pull/208

...to set target branch to master.

Original desc:

fixes a bug where variant_select_mode was always using intersection_priority mode, regardless of what the setting was

Also added some more clarification / examples to the description in rezconfig

The source of the problem was a comparison of a string to the VariantSelectMode enum, which always returns False. Would like to protect against future problems of this sort by modifying the eq for the enum to either error or do a "real" comparison against strings and integers.