### PR TITLE
rez-python: return exitcode returned by python subproc

### DIFF
--- a/src/rez/cli/python.py
+++ b/src/rez/cli/python.py
@@ -38,4 +38,4 @@ def command(opts, parser, extra_arg_groups=None):
         cmd.extend(opts.ARG or [])
 
     p = subprocess.Popen(cmd)
-    p.wait()
+    sys.exit(p.wait())


### PR DESCRIPTION
quick fix to make rez-python return an appropriate exitcode