### PR TITLE
Remove use of --target in favour alternate installation paths

### DIFF
--- a/src/rezplugins/build_system/cmake_files/RezPipInstall.cmake
+++ b/src/rezplugins/build_system/cmake_files/RezPipInstall.cmake
@@ -54,6 +54,16 @@ macro (rez_pip_install)
         set(bindir "bin")
     endif(NOT bindir)
 
+    list(GET PIPINST_INCLUDEDIR 0 incdir)
+    if(NOT incdir)
+        set(incdir "include")
+    endif(NOT incdir)
+
+    list(GET PIPINST_DATADIR 0 datadir)
+    if(NOT datadir)
+        set(datadir "")
+    endif(NOT datadir)
+
     # --------------------------------------------------------------------------
     # build/install
     #
@@ -61,8 +71,12 @@ macro (rez_pip_install)
     # --------------------------------------------------------------------------
 
     set(stagingpath "${CMAKE_BINARY_DIR}/staging")
+
     set(destpath "${stagingpath}/${pydir}")
     set(destbinpath "${stagingpath}/${bindir}")
+    set(destincpath "${stagingpath}/${incdir}")
+    set(destdatapath "${stagingpath}/${datadir}")
+
 
     if(${REZ_BUILD_INSTALL})
         set(install_cmd ${CMAKE_COMMAND} -E copy_directory ${stagingpath} ${CMAKE_INSTALL_PREFIX} )
@@ -81,11 +95,13 @@ macro (rez_pip_install)
         BUILD_COMMAND
             COMMAND ${CMAKE_COMMAND} -E make_directory ${destpath}
             COMMAND ${CMAKE_COMMAND} -E make_directory ${destbinpath}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${destincpath}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${destdatapath}
 
             # Note the lack of double quotes where you would expect around --install-scripts=.
             # CMake escapes the quotes if I try; fortunately it works without.
             #
-            COMMAND pip install --no-deps --target ${destpath} --install-option=--install-scripts=${destbinpath} .
+            COMMAND pip install --no-deps --install-option=--install-scripts=${destbinpath} --install-option=--install-lib=${destpath} --install-option=--install-headers=${destincpath} --install-option=--install-data=${destdatapath} .
     )
 
 endmacro (rez_pip_install)


### PR DESCRIPTION
Removed use of --target in favour of specifying each of the alternate installation paths when calling pip. This is a workaround for a bug in pip on RHEL linux distros. Fixes #274 
