### PR TITLE
rex: recursive formatting of namespace vars

### DIFF
--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -866,6 +866,13 @@ class NamespaceFormatter(Formatter):
         format_string_ = re.sub(self.ENV_VAR_REGEX, escape_envvar, format_string)
         return Formatter.format(self, format_string_, *args, **kwargs)
 
+    def format_field(self, value, format_spec):
+            if isinstance(value, EscapedString):
+                value = str(value.formatted(str))
+            if isinstance(value, str):
+                return self.format(value)
+            return format(value, format_spec)
+
     def get_value(self, key, args, kwds):
         if isinstance(key, str):
             if key:

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -867,11 +867,11 @@ class NamespaceFormatter(Formatter):
         return Formatter.format(self, format_string_, *args, **kwargs)
 
     def format_field(self, value, format_spec):
-            if isinstance(value, EscapedString):
-                value = str(value.formatted(str))
-            if isinstance(value, str):
-                return self.format(value)
-            return format(value, format_spec)
+        if isinstance(value, EscapedString):
+            value = str(value.formatted(str))
+        if isinstance(value, str):
+            return self.format(value)
+        return format(value, format_spec)
 
     def get_value(self, key, args, kwds):
         if isinstance(key, str):

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -870,7 +870,7 @@ class NamespaceFormatter(Formatter):
         if isinstance(value, EscapedString):
             value = str(value.formatted(str))
         if isinstance(value, str):
-            return self.format(value)
+            value = self.format(value)
         return format(value, format_spec)
 
     def get_value(self, key, args, kwds):

--- a/src/rez/tests/test_formatter.py
+++ b/src/rez/tests/test_formatter.py
@@ -258,6 +258,21 @@ class TestFormatter(TestBase):
         self.assert_formatter_raises("{0:-s}", ValueError, '')
         self.assert_formatter_raises("{0:=s}", ValueError, '')
 
+    def test_formatter_recurse(self):
+        self.assert_formatter_equal('Hello {0}!', 'Hello Earth!', '{world}',
+                                    world='Earth')
+
+        self.assert_formatter_equal('Hello {greeted}!', 'Hello Timmy the Trex!',
+                                    greeted='{dinosaur}', person='{Bob}',
+                                    Bob='Fabulous Bobby', dinosaur='{Trex}',
+                                    Trex='Timmy the Trex')
+        self.formatter.namespace.update(greeted='{dinosaur}', person='{Bob}',
+                                        Bob='Fabulous Bobby', dinosaur='{Trex}',
+                                        Trex='Timmy the Trex')
+        self.assert_formatter_equal('Hello {greeted}!',
+                                    'Hello Timmy the Trex!')
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
ie, if you do this in a package:

```
base_dir = '/where/it/starts'
py_dir = '{base_dir}/python'
env.MODULE_DIR = '{py_dir}/module'
```

...then $MODULE_DIR will be '{base_dir}/python/module', which is probably not what is desired. This makes format do recursive formatting, so it is '/where/it/starts/python/module'