### PR TITLE
bind can fail if not all dirs exist at time of bind;

### DIFF
--- a/src/rez/vendor/lockfile/mkdirlockfile.py
+++ b/src/rez/vendor/lockfile/mkdirlockfile.py
@@ -36,7 +36,7 @@ class MkdirLockFile(LockBase):
 
         while True:
             try:
-                os.mkdir(self.lock_file)
+                os.makedirs(self.lock_file)
             except OSError:
                 err = sys.exc_info()[1]
                 if err.errno == errno.EEXIST:


### PR DESCRIPTION
os.makedirs gives mkdir -p functionality