### PR TITLE
Windows Fixes

### DIFF
--- a/src/rez/backport/shutilwhich.py
+++ b/src/rez/backport/shutilwhich.py
@@ -36,7 +36,9 @@ def which(cmd, mode=os.F_OK | os.X_OK, env=None):
             path.insert(0, os.curdir)
 
         # PATHEXT is necessary to check on Windows.
-        pathext = env.get("PATHEXT", "").split(os.pathsep)
+        default_pathext = \
+            '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC'
+        pathext = env.get("PATHEXT", default_pathext).split(os.pathsep)
         # See if the given file matches any of the expected path extensions.
         # This will allow us to short circuit when given "python.exe".
         matches = [cmd for ext in pathext if cmd.lower().endswith(ext.lower())]

--- a/src/rez/bind/cmake.py
+++ b/src/rez/bind/cmake.py
@@ -18,10 +18,10 @@ def setup_parser(parser):
 def commands():
     env.PATH.append('{this.root}/bin')
 
-
 def bind(path, version_range=None, opts=None, parser=None):
     exepath = find_exe("cmake", getattr(opts, "exe", None))
-    version = extract_version(exepath, "--version")
+    version = extract_version(exepath, "--version",
+                              word_index=2 if os.name == "nt" else -1)
     check_version(version, version_range)
 
     def make_root(variant, root):

--- a/src/rez/utils/formatting.py
+++ b/src/rez/utils/formatting.py
@@ -9,6 +9,7 @@ from pprint import pformat
 import os
 import re
 import time
+import posixpath
 
 
 PACKAGE_NAME_REGSTR = "[a-zA-Z_0-9](\.?[a-zA-Z0-9_]+)*"
@@ -461,7 +462,11 @@ def expanduser(path):
         if i < 0:
             i = len(path)
         if i != 1:
-            return path
+            i = path.find(posixpath.sep, 1)
+            if i < 0:
+                i = len(path)
+            if i != 1:
+                return path
 
         if 'HOME' in os.environ:
             userhome = os.environ['HOME']

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -481,6 +481,10 @@ class WindowsPlatform(Platform):
     def _terminal_emulator_command(self):
         return "CMD.exe /Q /K"
 
+    def _difftool(self):
+        from rez.util import which
+        return which("meld", "fc")
+
     def _physical_cores_from_wmic(self):
         # windows
         import subprocess

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -120,7 +120,8 @@ class CMakeBuildSystem(BuildSystem):
         cmd += (self.build_args or [])
 
         cmd.append("-DCMAKE_INSTALL_PREFIX=%s" % install_path)
-        cmd.append("-DCMAKE_MODULE_PATH=%s" % sh.get_key_token("CMAKE_MODULE_PATH"))
+        cmd.append("-DCMAKE_MODULE_PATH=%s" %
+                   sh.get_key_token("CMAKE_MODULE_PATH").replace('\\','/'))
         cmd.append("-DCMAKE_BUILD_TYPE=%s" % self.build_target)
         cmd.append("-DREZ_BUILD_TYPE=%s" % build_type.name)
         cmd.append("-DREZ_BUILD_INSTALL=%d" % (1 if install else 0))
@@ -174,9 +175,11 @@ class CMakeBuildSystem(BuildSystem):
             cmd = ["make"]
         cmd += (self.child_build_args or [])
 
-        if not any(x.startswith("-j") for x in (self.child_build_args or [])):
-            n = variant.config.build_thread_count
-            cmd.append("-j%d" % n)
+        # nmake has no -j
+        if self.settings.make_binary != 'nmake':
+            if not any(x.startswith("-j") for x in (self.child_build_args or [])):
+                n = variant.config.build_thread_count
+                cmd.append("-j%d" % n)
 
         # execute make within the build env
         _pr("\nExecuting: %s" % ' '.join(cmd))
@@ -204,7 +207,7 @@ class CMakeBuildSystem(BuildSystem):
         cmake_path = os.path.join(os.path.dirname(__file__), "cmake_files")
         template_path = os.path.join(os.path.dirname(__file__), "template_files")
 
-        executor.env.CMAKE_MODULE_PATH.append(cmake_path)
+        executor.env.CMAKE_MODULE_PATH.append(cmake_path.replace('\\','/'))
         executor.env.REZ_BUILD_DOXYFILE = os.path.join(template_path, 'Doxyfile')
         executor.env.REZ_BUILD_VARIANT_INDEX = variant.index or 0
         executor.env.REZ_BUILD_THREAD_COUNT = package.config.build_thread_count

--- a/src/rezplugins/build_system/cmake_files/RezPipInstall.cmake
+++ b/src/rezplugins/build_system/cmake_files/RezPipInstall.cmake
@@ -70,6 +70,9 @@ macro (rez_pip_install)
         set(install_cmd "")
     endif()
 
+    # PIP on Windows doesn't like forward slashes for the --install-scripts argument.
+    file(TO_NATIVE_PATH ${destbinpath} destbinpath)
+
     ExternalProject_add(
         ${label}
         URL ${url}

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -93,7 +93,7 @@ class CMD(Shell):
     def _bind_interactive_rez(self):
         if config.set_prompt and self.settings.prompt:
             stored_prompt = os.getenv("REZ_STORED_PROMPT")
-            curr_prompt = stored_prompt or os.getenv("PROMPT", "foobar")
+            curr_prompt = stored_prompt or os.getenv("PROMPT", "")
             if not stored_prompt:
                 self.setenv("REZ_STORED_PROMPT", curr_prompt)
 


### PR DESCRIPTION
Fixes to get rez to work more smoothly on Windows. Some of these changes are based on changes from holofermes (thank you).
- Tilde and path separator on Windows
- Removed "foobar" from cmd prompt on Windows
- Updated version extraction in bind for CMake on Windows
- CMake doesn't like backward slashes in CMAKE_MODULE_PATH so we replace them to be safe
- Sensible defaults for difftool on Windows.
- Not passing -j to NMake on Windows
- Pass native slashes to Pip in CMake template. Otherwise Pip doesn't write the executable files on Windows.
- Default PATHEXT on Windows otherwise which('cmake') can fail if the environment was empty.