### PR TITLE
Issue 309 osmap

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -216,6 +216,7 @@ config_schema = Schema({
     "plugin_path":                                  PathList,
     "bind_module_path":                             PathList,
     "implicit_packages":                            StrList,
+    "platform_map":                                 OptionalDict,
     "parent_variables":                             StrList,
     "resetting_variables":                          StrList,
     "release_hooks":                                StrList,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -129,6 +129,24 @@ implicit_packages = [
     "~os=={system.os}",
 ]
 
+# Override platform values from Platform.os and arch.
+# This is useful as Platform.os might show different
+# values depending on the availability of lsb-release on the system.
+# The map supports regular expression e.g. to keep versions.
+# Please note that following examples are not necessarily recommendations.
+#
+# platform_map = {
+#     "os": {
+#         r"Scientific Linux-(.*)": r"Scientific-\1",    # Scientific Linux-x.x -> Scientific-x.x
+#         r"Ubuntu-14.\d": r"Ubuntu-14,                  # Any Ubuntu-14.x      -> Ubuntu-14
+#     },
+#     "arch": {
+#         "x86_64": "64bit",                             # Maps both x86_64 and amd64 -> 64bit
+#         "amd64": "64bit",
+#     },
+# }
+platform_map = {}
+
 # If true, then when a resolve graph is generated during a failed solve, packages
 # unrelated to the failure are pruned from the graph. An "unrelated" package is
 # one that is not a dependency ancestor of any packages directly involved in the

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -138,7 +138,8 @@ implicit_packages = [
 # platform_map = {
 #     "os": {
 #         r"Scientific Linux-(.*)": r"Scientific-\1",    # Scientific Linux-x.x -> Scientific-x.x
-#         r"Ubuntu-14.\d": r"Ubuntu-14,                  # Any Ubuntu-14.x      -> Ubuntu-14
+#         r"Ubuntu-14.\d": r"Ubuntu-14",                  # Any Ubuntu-14.x      -> Ubuntu-14
+#         r'CentOS Linux-(\d+)\.(\d+)(\.(\d+))?': r'CentOS-\1.\2', '# Centos Linux-X.Y.Z -> CentOS-X.Y
 #     },
 #     "arch": {
 #         "x86_64": "64bit",                             # Maps both x86_64 and amd64 -> 64bit

--- a/src/rez/tests/test_platform.py
+++ b/src/rez/tests/test_platform.py
@@ -68,10 +68,9 @@ class TestPlatformMap(TestBase):
     def tearDown(self):
         pass
 
-    def test_os(self):
-        """Test platform_map for os"""
+    def test_platform_map(self):
+        """Test platform_map"""
 
-        # overrides set to bad types
         platform_map = {
             "os": {
                 r"An Linux": "Changed",

--- a/src/rez/tests/test_platform.py
+++ b/src/rez/tests/test_platform.py
@@ -1,0 +1,105 @@
+"""
+text platform
+"""
+import os
+import sys
+
+from rez.tests.util import TestBase
+from rez.config import Config, get_module_root_config
+import imp
+
+from rez.utils.platform_ import Platform
+
+
+class MockPlatform(Platform):
+    """
+    Platform that returns os and arch given in constructor
+    As it overrides Platform the decorators still will kick-in.
+    """
+
+    def __init__(self, os, arch):
+        self.mock_os = os
+        self.mock_arch = arch
+
+    def _os(self):
+        return self.mock_os
+
+    def _arch(self):
+        return self.mock_arch
+
+
+class MockConfigImporter(object):
+    """
+    In order to get different values we import all modules except for rez.config.
+    In latter case the config from the constructor is returned.
+    """
+
+    modules__ = {}
+
+    def __init__(self, config):
+        self.config = config
+
+    def find_module(self, module_name, package_path):
+        self.modules__[module_name] = package_path[0]
+        return self
+
+    def load_module(self, module_name):
+        if module_name == 'rez.config':
+            return self
+
+        with open(os.path.join(self.modules__[module_name], module_name.split('.')[-1]+".py"), "r") as fh:
+            module = imp.load_module(module_name, fh, module_name+".py", ('.py','r', imp.PY_SOURCE))
+
+        return module
+
+
+class ConfigStub(object):
+
+    def __init__(self, platform_map):
+        self.platform_map = platform_map
+
+
+class TestPlatformMap(TestBase):
+
+    def setUp(self):
+        if 'rez.config' in sys.modules:
+            del sys.modules['rez.config']
+
+    def tearDown(self):
+        pass
+
+    def test_os(self):
+        """Test platform_map for os"""
+
+        # overrides set to bad types
+        platform_map = {
+            "os": {
+                r"An Linux": "Changed",
+                r"Something Linux-(.*)": r"Changed-\1",
+            },
+            "arch": {
+                "amd_64": "Changed",
+                "x(86)_(\d)": r"Changed-\1-\2"
+            }
+        }
+
+        # Use MockConfigImporter and replace our config.platform_map
+        sys.meta_path.append(MockConfigImporter(ConfigStub(platform_map)))
+
+        # This is probably already cached, so reload.
+        import rez.utils.platform_ as rez_platform
+        reload(rez_platform)
+
+        # Test platform_map
+        l = MockPlatform('An Linux', 'amd_64')
+        self.assertEqual(l.os, 'Changed', 'Replacing os')
+        self.assertEqual(l.arch, 'Changed', 'Replacing arch')
+
+        l = MockPlatform('Something Linux-3.2', 'x86_64')
+        self.assertEqual(l.os, 'Changed-3.2', 'Regular expressions on os')
+        self.assertEqual(l.arch, 'Changed-86-64', 'Regular expressions on arch')
+
+        l = MockPlatform('Not in dict', 'arm')
+        self.assertEqual(l.os, 'Not in dict', 'Not in dict')
+        self.assertEqual(l.arch, 'arm', 'Not in dict')
+

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -5,6 +5,7 @@ import os.path
 import re
 from rez.util import which
 from rez.utils.data_utils import cached_property
+from rez.utils.platform_mapped import platform_mapped
 from rez.exceptions import RezSystemError
 from tempfile import gettempdir
 
@@ -18,11 +19,13 @@ class Platform(object):
         pass
 
     @cached_property
+    @platform_mapped
     def arch(self):
         """Returns the name of the architecture."""
         return self._arch()
 
     @cached_property
+    @platform_mapped
     def os(self):
         """Returns the name of the operating system."""
         return self._os()

--- a/src/rez/utils/platform_mapped.py
+++ b/src/rez/utils/platform_mapped.py
@@ -2,8 +2,8 @@ import re
 
 
 def platform_mapped(func):
-    """
-    Decorates functions for lookups within a config.platform_map dictionary.
+    """Decorates functions for lookups within a config.platform_map dictionary.
+
     The first level key is mapped to the func.__name__ of the decorated function.
     Regular expressions are used on the second level key, values.
     Note that there is no guaranteed order within the dictionary evaluation. Only the first matching
@@ -13,10 +13,10 @@ def platform_mapped(func):
     config.platform_map = {
         "os": {
             r"Scientific Linux-(.*)": r"Scientific-\1",    # Scientific Linux-x.x -> Scientific-x.x
-            r"Ubuntu-14.\d": r"Ubuntu-14,                  # Any Ubuntu-14.x      -> Ubuntu-14
+            r"Ubuntu-14.\d": r"Ubuntu-14",                 # Any Ubuntu-14.x      -> Ubuntu-14
         },
         "arch": {
-            "x86_64": "64bit",                             # Maps both x86_64 and amd64 -> 64bit
+            "x86_64": "64bit",                             # Maps both x86_64 and amd64 -> 64bit (don't)
             "amd64": "64bit",
         },
     }

--- a/src/rez/utils/platform_mapped.py
+++ b/src/rez/utils/platform_mapped.py
@@ -1,0 +1,42 @@
+import re
+
+
+def platform_mapped(func):
+    """
+    Decorates functions for lookups within a config.platform_map dictionary.
+    The first level key is mapped to the func.__name__ of the decorated function.
+    Regular expressions are used on the second level key, values.
+    Note that there is no guaranteed order within the dictionary evaluation. Only the first matching
+    regular expression is being used.
+    For example:
+
+    config.platform_map = {
+        "os": {
+            r"Scientific Linux-(.*)": r"Scientific-\1",    # Scientific Linux-x.x -> Scientific-x.x
+            r"Ubuntu-14.\d": r"Ubuntu-14,                  # Any Ubuntu-14.x      -> Ubuntu-14
+        },
+        "arch": {
+            "x86_64": "64bit",                             # Maps both x86_64 and amd64 -> 64bit
+            "amd64": "64bit",
+        },
+    }
+    """
+    def inner(*args, **kwargs):
+
+        # Since platform is being used within config lazy import config to prevent circular dependencies
+        from rez.config import config
+
+        # Original result
+        result = func(*args, **kwargs)
+
+        # The function name is used as primary key
+        if func.__name__ in config.platform_map:
+            for key, value in config.platform_map[func.__name__].iteritems():
+                result, changes = re.subn(key, value, result)
+                if changes > 0:
+                    break
+            return result
+
+        return result
+    return inner
+


### PR DESCRIPTION
So here is the suggested dictionary for issue #309 

The way it works is you add something like this to your rezconfig.py:

```
platform_map = {
  "os": {
        r"Scientific Linux-(.*)": r"Scientific-\1",
        r"Ubuntu-14.\d": r"Ubuntu-14",
        r"CentOS Linux-(\d+)\.(\d+)(\.(\d+))?": r"CentOS-\1.\2",
    },
}
```
The example would remap: 
* Scientific Linux-6.4 -> Scientific-6.4
* Ubuntu-14.2 -> Ubuntu-14
* CentOS Linux-7.2.1522 -> CentOS-7.2

This gives much more control over the os string and also can fix mismatches between platform.linux_distribution and lsb_release.

It is a pretty basic decorator.
I applied it to os and arch. I doubt there is a usecase for plaform_.name.

It works quite well.
Currently I see following optional improvements:
- The unit test works but is very hacky, do you know an easier way to mock the config?
- The dictionary has an undefined order. Probably should be a list of tuples in case someone goes crazy but I felt usually you can model everything with a single regexp.

Let me know what you think.