### PR TITLE
Fixes Windows issue when running rez-env with quiet flag (-q)

### DIFF
--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -117,11 +117,8 @@ class CMD(Shell):
             if bind_rez:
                 ex.interpreter._bind_interactive_rez()
             if print_msg and not quiet:
-#                ex.info('')
-#                ex.info('You are now in a rez-configured environment.')
-#                ex.info('')
                 if system.is_production_rez_install:
-                    ex.command("cmd /Q /K rezolve context")
+                    ex.command("cmd /Q /C rezolve context")
 
         def _create_ex():
             return RexExecutor(interpreter=self.new_shell(),
@@ -143,7 +140,6 @@ class CMD(Shell):
 
         if shell_command:
             executor.command(shell_command)
-        executor.command('exit %errorlevel%')
 
         code = executor.get_output()
         target_file = os.path.join(tmpdir, "rez-shell.%s"


### PR DESCRIPTION
Removed exit command in order to run "rez-env -q" otherwise rez doesn't stay in the environment but exits right away if run with quiet flag.
Updated context call to exit the shell it is run in. Bringing us straight back to where we left off.
Removed commented info calls.

Steps to reproduce on Windows:
works: rez-env cmake
fails: rez-env -q cmake