### PR TITLE
rex_bindings: '0' should convert to digit (though '00' or '01' don't)

### DIFF
--- a/src/rez/rex_bindings.py
+++ b/src/rez/rex_bindings.py
@@ -77,7 +77,7 @@ class VersionBinding(Binding):
     def __getitem(self, i):
         def _convert(t):
             s = str(t)
-            if s.isdigit() and s[0] != '0':
+            if s.isdigit() and (s[0] != '0' or s == '0'):
                 return int(s)
             else:
                 return s


### PR DESCRIPTION
Will make it so that, if in the package.py you do:
   version.as_tuple() >= (5, 2)
we won't get an unexpected result if the version is 5.0.

Will still be potential confusion / problems if the version is "5.00" - but that's likely a less common case, and at least they now have to the option of using 5.0 if they want to ensure easy numeric comparision.

Would eventually like to override > / < / == comparison to automatically convert the other side to a Version object if it's a string, and then compare using it's more sophisticated logic... but this is a quick fix for now