### PR TITLE
Minimum Windows Fixes

### DIFF
--- a/src/rez/utils/formatting.py
+++ b/src/rez/utils/formatting.py
@@ -453,13 +453,14 @@ def expanduser(path):
     `expanduser` method which can only expand '~'.  Others the path is returned
     without expansion applied."""
     if os.name == "nt":
-        userpath = path
         if not path.startswith('~'):
             return path
 
-        i = path.find(os.path.sep, 1)
+        # normalize the path to avoid having to check for os.altsep as well
+        userpath = os.path.normpath(path)
+        i = userpath.find(os.path.sep, 1)
         if i < 0:
-            i = len(path)
+            i = len(userpath)
         if i != 1:
             return path
 
@@ -475,7 +476,7 @@ def expanduser(path):
             except KeyError:
                 drive = ''
             userhome = os.path.join(drive, os.environ['HOMEPATH'])
-        userpath = userhome + path[i:]
+        userpath = userhome + userpath[i:]
 
     else:
         userpath = os.path.expanduser(path)


### PR DESCRIPTION
Hi,

The master branch currently fails or warns on its own tests out of the box on Windows due to 4 issues.

1) bug in  '~' expansion
2) missing diff tool default - this is addressed in another PR as well, but it's significant because it appears Rez is broken on first blush without it
3) bug in physical core determination on multi-CPU machines
4) risky use of __del__ overload on TmpDirs results in noisy and obscure AttributeError warning, and also leaves the temp directories created on disk after shutdown

This pull request addresses all 4.