### PR TITLE
Minimum Windows Fixes

### DIFF
--- a/src/rez/backport/shutilwhich.py
+++ b/src/rez/backport/shutilwhich.py
@@ -36,7 +36,9 @@ def which(cmd, mode=os.F_OK | os.X_OK, env=None):
             path.insert(0, os.curdir)
 
         # PATHEXT is necessary to check on Windows.
-        pathext = env.get("PATHEXT", "").split(os.pathsep)
+        default_pathext = \
+            '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC'
+        pathext = env.get("PATHEXT", default_pathext).split(os.pathsep)
         # See if the given file matches any of the expected path extensions.
         # This will allow us to short circuit when given "python.exe".
         matches = [cmd for ext in pathext if cmd.lower().endswith(ext.lower())]

--- a/src/rez/bind/cmake.py
+++ b/src/rez/bind/cmake.py
@@ -21,7 +21,8 @@ def commands():
 
 def bind(path, version_range=None, opts=None, parser=None):
     exepath = find_exe("cmake", getattr(opts, "exe", None))
-    version = extract_version(exepath, "--version")
+    version = extract_version(exepath, "--version",
+                              word_index=2 if os.name == 'nt' else -1)
     check_version(version, version_range)
 
     def make_root(variant, root):

--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -22,9 +22,9 @@ def command(opts, parser, extra_arg_groups=None):
     from rez.pip import pip_install_package
 
     if opts.py_ver:
-        pyvers = opts.py_ver.strip(',').split(',')
+        py_vers = opts.py_ver.strip(',').split(',')
     else:
-        pyvers = None
+        py_vers = None
 
     pip_install_package(opts.PACKAGE,
                         pip_version=opts.pip_ver,

--- a/src/rez/utils/formatting.py
+++ b/src/rez/utils/formatting.py
@@ -453,13 +453,14 @@ def expanduser(path):
     `expanduser` method which can only expand '~'.  Others the path is returned
     without expansion applied."""
     if os.name == "nt":
-        userpath = path
         if not path.startswith('~'):
             return path
 
-        i = path.find(os.path.sep, 1)
+        # normalize the path to avoid having to check for os.altsep as well
+        userpath = os.path.normpath(path)
+        i = userpath.find(os.path.sep, 1)
         if i < 0:
-            i = len(path)
+            i = len(userpath)
         if i != 1:
             return path
 
@@ -475,7 +476,7 @@ def expanduser(path):
             except KeyError:
                 drive = ''
             userhome = os.path.join(drive, os.environ['HOMEPATH'])
-        userpath = userhome + path[i:]
+        userpath = userhome + userpath[i:]
 
     else:
         userpath = os.path.expanduser(path)

--- a/src/rezplugins/build_system/cmake_files/RezPipInstall.cmake
+++ b/src/rezplugins/build_system/cmake_files/RezPipInstall.cmake
@@ -70,6 +70,9 @@ macro (rez_pip_install)
         set(install_cmd "")
     endif()
 
+    # PIP on Windows doesn't like forward slashes for the --install-scripts argument
+    file(TO_NATIVE_PATH ${destbinpath} destbinpath)
+
     ExternalProject_add(
         ${label}
         URL ${url}

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -121,7 +121,11 @@ class CMD(Shell):
 #                ex.info('You are now in a rez-configured environment.')
 #                ex.info('')
                 if system.is_production_rez_install:
-                    ex.command("cmd /Q /K rezolve context")
+                    # previously this was called with the /K flag, however
+                    # that would leave spawn_shell hung on a blocked call
+                    # waiting for the user to type "exit" into the shell that
+                    # was spawned to run the rez context printout
+                    ex.command("cmd /Q /C rez context")
 
         def _create_ex():
             return RexExecutor(interpreter=self.new_shell(),

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -93,7 +93,7 @@ class CMD(Shell):
     def _bind_interactive_rez(self):
         if config.set_prompt and self.settings.prompt:
             stored_prompt = os.getenv("REZ_STORED_PROMPT")
-            curr_prompt = stored_prompt or os.getenv("PROMPT", "foobar")
+            curr_prompt = stored_prompt or os.getenv("PROMPT", "")
             if not stored_prompt:
                 self.setenv("REZ_STORED_PROMPT", curr_prompt)
 


### PR DESCRIPTION
Hi,

The master branch currently fails or warns on its own tests out of the box on Windows due to 4 issues.

1) bug in '~' expansion
2) missing diff tool default - this is addressed in another PR as well, but it's significant because it appears Rez is broken on first blush without it
3) bug in physical core determination on multi-CPU machines
4) risky use of del overload on TmpDirs results in noisy and obscure AttributeError warning, and also leaves the temp directories created on disk after shutdown

This pull request addresses all 4.