### PR TITLE
add shotgun toolkit support for tk-nuke, tk-houdini and tk-katana engine

### DIFF
--- a/src/support/shotgun_toolkit/rez_app_launch.py
+++ b/src/support/shotgun_toolkit/rez_app_launch.py
@@ -54,8 +54,14 @@ class AppLaunch(tank.Hook):
             from rez.resolved_context import ResolvedContext
             from rez.config import config
 
+            # Define variables used to bootstrap tank from overwrite on first reference
+            # PYTHONPATH is used by tk-maya
+            # NUKE_PATH is used by tk-nuke
+            # HIERO_PLUGIN_PATH is used by tk-nuke (nukestudio)
+            # KATANA_RESOURCES is used by tk-katana
+            config.parent_variables = ["PYTHONPATH", "HOUDINI_PATH", "NUKE_PATH", "HIERO_PLUGIN_PATH", "KATANA_RESOURCES"]
+
             rez_packages = extra["rez_packages"]
-            config.parent_variables = ["PYTHONPATH"]
             context = ResolvedContext(rez_packages)
 
             use_rez = True


### PR DESCRIPTION
Some parent_variables are missing to properly bootstrap tank using rez and could easily be overwritten by a package.

Fore more information:
PYTHON_PATH: https://github.com/shotgunsoftware/tk-multi-launchapp/blob/master/app.py#L578
NUKE_PATH: https://github.com/shotgunsoftware/tk-nuke/blob/master/python/startup/bootstrap.py#L31
HIERO_PLUGIN_PATH: https://github.com/shotgunsoftware/tk-nuke/blob/master/python/startup/bootstrap.py#L27
HOUDINI_PATH: https://github.com/shotgunsoftware/tk-houdini/blob/master/python/tk_houdini/bootstrap.py#L37
KATANA_RESOURCES: https://github.com/robblau/tk-katana/blob/master/python/startup/bootstrap.py#L25
