### PR TITLE
New test breaks unittests if install has not yet occured

### DIFF
--- a/src/rez/tests/test_release.py
+++ b/src/rez/tests/test_release.py
@@ -165,6 +165,8 @@ class TestRelease(TestBase, TempdirMixin):
         qnames = set(x.qualified_name for x in it)
         self.assertEqual(qnames, expected_value)
 
+    @shell_dependent()
+    @install_dependent
     def test_2_variant_add(self):
         """Test variant installation on release
         """


### PR DESCRIPTION
The addition of "test_2_variant_add" broke tests if run BEFORE installation; this test, as with test_1, is shell and install dependent, but the decorators were not present in the recent merge.