### PR TITLE
Adds JSON formatting as an output option on "rez context"

### DIFF
--- a/src/rez/cli/context.py
+++ b/src/rez/cli/context.py
@@ -20,9 +20,9 @@ def setup_parser(parser, completions=False):
 
     formats = get_shell_types()
     if json is None:
-        format.extend(['dict', 'table'])
+        formats.extend(['dict', 'table'])
     else:
-        format.extend(['dict', 'json', 'table'])
+        formats.extend(['dict', 'json', 'table'])
 
     output_styles = [e.name for e in OutputStyle]
 

--- a/src/rez/cli/context.py
+++ b/src/rez/cli/context.py
@@ -4,12 +4,26 @@ Print information about the current rez context, or a given context file.
 import sys
 from rez.rex import OutputStyle
 
+try:
+    # part of Python since 2.6
+    import json
+except ImportError:
+    try:
+        # for Python < 2.6
+        import simplejson as json
+    except ImportError:
+        json = None
 
 def setup_parser(parser, completions=False):
     from rez.system import system
     from rez.shells import get_shell_types
 
-    formats = get_shell_types() + ['dict', 'table']
+    formats = get_shell_types()
+    if json is None:
+        format.extend(['dict', 'table'])
+    else:
+        format.extend(['dict', 'json', 'table'])
+
     output_styles = [e.name for e in OutputStyle]
 
     parser.add_argument(
@@ -151,6 +165,9 @@ def command(opts, parser, extra_arg_groups=None):
     elif opts.format == 'dict':
         env = rc.get_environ(parent_environ=parent_env)
         print pformat(env)
+    elif json is not None and opts.format == 'json':
+        env = rc.get_environ(parent_environ=parent_env)
+        print json.dumps(env, sort_keys=True, indent=4)
     else:
         code = rc.get_shell_code(shell=opts.format,
                                  parent_environ=parent_env,

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.0.rc1.43"
+_rez_version = "2.0.rc1.44"
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
I'm in a situation where I need to pipe data from "rez context -i" into another program, and the "dict" option is nice if you've got python (and ideally know about ast.literal_eval), but that's not always true.  JSON makes the world a lot easier.

It'll fallback to simplejson for Python < 2.6, and if it can't find that it'll just not even offer the option.

Also, bumped the version number, as that didn't happen in the last merge request and we need to release with versioned.