### PR TITLE
Restores correct "rez env" behavior on Windows, and allows curated $PATH

### DIFF
--- a/src/rez/bind/hello_world.py
+++ b/src/rez/bind/hello_world.py
@@ -16,6 +16,7 @@ import os.path
 
 def commands():
     env.PATH.append('{this.root}/bin')
+    env.OH_HAI_WORLD = "hello"
 
 
 def hello_world_source():

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1035,15 +1035,17 @@ class ResolvedContext(object):
     def apply(self, parent_environ=None):
         """Apply the context to the current python session.
 
-        Note that this updates os.environ and possibly sys.path.
+        Note that this updates os.environ and possibly sys.path, if
+        `parent_environ` is not provided.
 
-        @param environ Environment to interpret the context within, defaults to
-            os.environ if None.
+        Args:
+            parent_environ: Environment to interpret the context within,
+                defaults to os.environ if None.
         """
         interpreter = Python(target_environ=os.environ)
         executor = self._create_executor(interpreter, parent_environ)
         self._execute(executor)
-        executor.get_output()
+        interpreter.apply_environ()
 
     @_on_success
     def which(self, cmd, parent_environ=None, fallback=False):

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1093,7 +1093,13 @@ class ResolvedContext(object):
         Note:
             This does not alter the current python session.
         """
-        interpreter = Python(target_environ={})
+        if parent_environ in (None, os.environ):
+            target_environ = {}
+        else:
+            target_environ = parent_environ.copy()
+
+        interpreter = Python(target_environ=target_environ)
+
         executor = self._create_executor(interpreter, parent_environ)
         self._execute(executor)
         return interpreter.subprocess(args, **subprocess_kwargs)

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1043,6 +1043,7 @@ class ResolvedContext(object):
         interpreter = Python(target_environ=os.environ)
         executor = self._create_executor(interpreter, parent_environ)
         self._execute(executor)
+        executor.get_output()
 
     @_on_success
     def which(self, cmd, parent_environ=None, fallback=False):

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -541,7 +541,8 @@ class Python(ActionInterpreter):
         target_environ: dict
             If target_environ is None or os.environ, interpreted actions are
             applied to the current python interpreter. Otherwise, changes are
-            only applied to target_environ.
+            only applied to target_environ. In either case you must call
+            `apply_environ` to flush all changes to the target environ dict.
 
         passive: bool
             If True, commands that do not update the environment (such as info)
@@ -559,12 +560,17 @@ class Python(ActionInterpreter):
     def set_manager(self, manager):
         self.manager = manager
 
-    def get_output(self, style=OutputStyle.file):
+    def apply_environ(self):
+        """Apply changes to target environ.
+        """
         if self.manager is None:
             raise RezSystemError("You must call 'set_manager' on a Python rex "
                                  "interpreter before using it.")
 
         self.target_environ.update(self.manager.environ)
+
+    def get_output(self, style=OutputStyle.file):
+        self.apply_environ()
         return self.manager.environ
 
     def setenv(self, key, value):

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -58,6 +58,25 @@ class TestContext(TestBase, TempdirMixin):
         stdout = stdout.strip()
         self.assertEqual(stdout, "Hello Rez World!")
 
+    def test_execute_command_environ(self):
+        """Test that execute_command properly sets environ dict."""
+        parent_environ = {"BIGLY": "covfefe"}
+        r = ResolvedContext(["hello_world"])
+
+        pycode = ("import os; "
+                  "print os.getenv(\"BIGLY\"); "
+                  "print os.getenv(\"OH_HAI_WORLD\")")
+
+        args = ["python", "-c", pycode]
+
+        p = r.execute_command(args, parent_environ=parent_environ,
+                              stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        stdout = stdout.strip()
+        parts = [x.strip() for x in stdout.split('\n')]
+
+        self.assertEqual(parts, ["covfefe", "hello"])
+
     def test_serialize(self):
         """Test save/load of context."""
         # save

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -39,6 +39,12 @@ class TestContext(TestBase, TempdirMixin):
         r = ResolvedContext(["hello_world"])
         r.print_info()
 
+    def test_apply(self):
+        """Test apply() function."""
+        r = ResolvedContext(["hello_world"])
+        r.apply()
+        self.assertEqual(os.environ.get("OH_HAI_WORLD"), "hello")
+
     def test_execute_command(self):
         """Test command execution in context."""
         if platform_.name == "windows":

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.13.0"
+_rez_version = "2.13.1"
 
 try:
     from rez.vendor.version.version import Version


### PR DESCRIPTION
@nerdvegas 

This fixes #336 by reverting an earlier change made by **skrall** (which replaced /C with /K).  

Additionally it adds a configuration variable and logic to allow an organization that has a curated $PATH (ie they already know the exact list of directories and **do not** wish to gather them from the -- at that point incorrect -- Windows registry or __PATHS_ var) to specify that path list and have it respected.

This is primarily of use to those (like me) who are building a configuration management wrapper for Rez, and who -- for better or worse -- do not have the ability to reliably assume that the system registry $PATH set on each and every Windows workstation is (remotely) the same.
