### PR TITLE
Fixes postfix prompt and cleans whitespace to be more controllable.

### DIFF
--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -95,7 +95,7 @@ class SH(UnixShell):
             if config.prefix_prompt:
                 cmd = 'export PS1="%s $REZ_STORED_PROMPT"'
             else:
-                cmd = 'export PS1="$REZ_STORED_PROMPT" %s'
+                cmd = 'export PS1="$REZ_STORED_PROMPT%s "'
             self._addline(cmd % "\[\e[1m\]$REZ_ENV_PROMPT\[\e[0m\]")
 
     def setenv(self, key, value):


### PR DESCRIPTION
First the postfix prompt did not work as it was not inside the quotes.

Then I decided to make the whitespace at the end of the postfix version because this seems to be typically what you want.

If your regular prompt is "...$ " it becomes "...$ > " in the first rez-env level and "...$ >> " in the second etc.  
