### PR TITLE
build_process.local: _build_variant_base - if shutil.copy fails, try replacing

### DIFF
--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -128,11 +128,43 @@ class LocalBuildProcess(BuildProcessHelper):
         if not build_result.get("success"):
             raise BuildError("The %s build system failed" % build_system_name)
 
+        def copy_or_replace(src, dst):
+            '''try to copy with mode, and if it fails, try replacing
+            '''
+            try:
+                shutil.copy(src, dst)
+            except (OSError, IOError), e:
+                # It's possible that the file existed, but was owned by someone
+                # else - in that situation, shutil.copy might then fail when it
+                # tries to copy perms.
+                # However, it's possible that we have write perms to the dir -
+                # in which case, we can just delete and replace
+                import errno
+                if e.errno == errno.EPERM:
+                    import tempfile
+                    # try copying into a temporary location beside the old
+                    # file - if we have perms to do that, we should have perms
+                    # to then delete the old file, and move the new one into
+                    # place
+                    if os.path.isdir(dst):
+                        dst = os.path.join(dst, os.path.basename(src))
+
+                    dst_dir, dst_name = os.path.split(dst)
+                    dst_temp = tempfile.mktemp(prefix=dst_name + '.',
+                                               dir=dst_dir)
+                    shutil.copy(src, dst_temp)
+                    if not os.path.isfile(dst_temp):
+                        raise RuntimeError(
+                            "shutil.copy completed successfully, but path"
+                            " '%s' still did not exist" % dst_temp)
+                    os.remove(dst)
+                    shutil.move(dst_temp, dst)
+
         if install:
             # install some files for debugging purposes
             extra_files = build_result.get("extra_files", []) + [rxt_filepath]
             for file_ in extra_files:
-                shutil.copy(file_, variant_install_path)
+                copy_or_replace(file_, variant_install_path)
 
         return build_result
 


### PR DESCRIPTION
When installing files, this will allow installation to succeed in cases where the current user does not have write permissions to an already-existing file, but DOES have write permissions to the directory.
