### PR TITLE
add CustomPackageOrder

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -210,6 +210,23 @@ class BuildThreadCount_(Setting):
             return value
 
 
+class PackageOrderers(Setting):
+    @cached_class_property
+    def schema(cls):
+        return Or(Schema([Use(cls.to_orderer)]), None)
+
+    @classmethod
+    def to_orderer(cls, data):
+        import rez.package_order
+        # make a copy, since we're modifying
+        data = dict(data)
+        cls_name = data.pop("type")
+        return rez.package_order.from_pod((cls_name, data))
+
+
+    _env_var_name = None
+
+
 config_schema = Schema({
     "packages_path":                                PathList,
     "plugin_path":                                  PathList,
@@ -316,6 +333,7 @@ config_schema = Schema({
     "env_var_separators":                           Dict,
     "variant_select_mode":                          VariantSelectMode_,
     "package_filter":                               OptionalDictOrDictList,
+    "package_orderers":                             PackageOrderers,
     "new_session_popen_args":                       OptionalDict,
 
     # GUI settings

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -53,7 +53,8 @@ class PackageOrder(object):
     def __str__(self):
         return str(self.to_pod())
 
-class DefaultAppliesToMixin(object):
+
+class DefaultAppliesOrder(PackageOrder):
     def init_packages(self, packages):
         if packages == "*":
             self.packages = packages
@@ -80,7 +81,33 @@ class DefaultAppliesToMixin(object):
             return True
         return package_name in self.packages
 
-class TimestampPackageOrder(PackageOrder, DefaultAppliesToMixin):
+
+class ReversedPackageOrder(DefaultAppliesOrder):
+    """Package orderer that sorts in reverse version order"""
+    name = "reversed"
+
+    def __init__(self, packages):
+        """Create a reorderer.
+
+        Args:
+            packages: (str or list of str): packages that this orderer should apply to
+        """
+        self.init_packages(packages)
+
+    def reorder(self, iterable, key=None):
+        key = key or (lambda x: x)
+        # all we need to do is NOT reverse - we will get lowest version first
+        return sorted(iterable, key=lambda x: key(x).version)
+
+    def to_pod(self):
+        return dict(packages=self.packages)
+
+    @classmethod
+    def from_pod(cls, data):
+        return cls(packages=data["packages"])
+
+
+class TimestampPackageOrder(DefaultAppliesOrder):
     """A timestamp order function.
 
     Given a time T, this orderer returns packages released before T, in descending

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -197,7 +197,7 @@ class ResolvedContext(object):
         self.package_filter = (PackageFilterList.singleton if package_filter is None
                                else package_filter)
 
-        self.package_orderers = package_orderers
+        self.package_orderers = package_orderers or config.package_orderers
 
         # patch settings
         self.default_patch_lock = PatchLock.no_lock

--- a/src/rez/resolver.py
+++ b/src/rez/resolver.py
@@ -54,7 +54,7 @@ class Resolver(object):
         self.package_paths = package_paths
         self.timestamp = timestamp
         self.callback = callback
-        self.package_orderers = package_orderers
+        self.package_orderers = package_orderers or config.package_orderers
         self.package_load_callback = package_load_callback
         self.building = building
         self.verbosity = verbosity

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -242,6 +242,28 @@ variant_select_mode = "version_priority"
 # foo-5+              | Same as range(foo-5+)
 package_filter = None
 
+# Package orderers. One or more objects which can re-order the package's
+# priority when resolving - ie, if we know that a group of package versions
+# can all satisfy a request, this can affect which of those package versions is
+# returned in the resolved context.
+# You can specify multiple orderers; each orderer in turn is tested against
+# a given package to see if it applies to it (usually this is controlled through
+# the "packages" config item in the orderer's config). The first orderer that
+# applies is then used to reorder that package's versions.
+#
+# Here's an example:
+#
+#     package_orderers:
+#     - type: custom
+#       packages:
+#         gcc: ['3.7', '2.8']
+#         foo: ['2.6', '2.8']
+#     - type: soft_timestamp
+#       packages: "*"
+#       timestamp: 1429830188
+
+package_orderers = None
+
 # If True, unversioned packages are allowed. Solve times are slightly better if
 # this value is False.
 allow_unversioned_packages = True

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -890,6 +890,8 @@ class _PackageVariantSlice(_Common):
             return
 
         for orderer in (self.solver.package_orderers or []):
+            if not orderer.applies_to(self.package_name):
+                continue
             entries = orderer.reorder(self.entries, key=lambda x: x.package)
             if entries is not None:
                 self.entries = entries
@@ -1781,7 +1783,7 @@ class Solver(_Common):
         """
         self.package_paths = package_paths
         self.package_filter = package_filter
-        self.package_orderers = package_orderers
+        self.package_orderers = package_orderers or config.package_orderers
         self.pr = _Printer(verbosity, buf=buf)
         self.optimised = optimised
         self.callback = callback

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -4,6 +4,7 @@ test dependency resolving algorithm
 from rez.vendor.version.requirement import Requirement
 from rez.solver import Solver, Cycle, SolverStatus
 from rez.config import config
+from rez.exceptions import ConfigurationError
 import rez.vendor.unittest2 as unittest
 from rez.tests.util import TestBase
 import itertools
@@ -211,6 +212,229 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "pyvariants-2[0]"])
         self._solve(["pyvariants", "python", "nada"],
                     ["python-2.6.8[]", "nada[]", "pyvariants-2[1]"])
+
+    # re-prioritization tests
+
+    def test_11_direct_complete(self):
+        """Test setting of the version_priority in simple situations, where
+        the altered package is a direct request
+        """
+        # test a complete ordering
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.0", "2.5.2", "2.7.0", "2.6.8"]}}])
+        self._solve(["python"],
+                    ["python-2.6.0[]"])
+        self._solve(["python", "!python-2.6.0"],
+                    ["python-2.5.2[]"])
+        self._solve(["python", "!python<=2.6.0"],
+                    ["python-2.7.0[]"])
+        self._solve(["python", "!python-2.6.0", "!python-2.5.2",
+                     "!python-2.7.0"],
+                    ["python-2.6.8[]"])
+
+        # check that we can still request a lower-priority version
+        self._solve(["python-2.6.8"],
+                    ["python-2.6.8[]"])
+
+
+    def test_12_direct_single(self):
+        """check that if you specify only one version, that version is highest
+        priority, rest are normal
+        """
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.8"]}}])
+        self._solve(["python"],
+                    ["python-2.6.8[]"])
+        self._solve(["python", "!python-2.6.8"],
+                    ["python-2.7.0[]"])
+        self._solve(["python<2.6.8"],
+                    ["python-2.6.0[]"])
+        self._solve(["python<2.6"],
+                    ["python-2.5.2[]"])
+
+        # confirm that sorting for version ranges is still normal
+        self._solve(["python-2.6+<2.7"],
+                    ["python-2.6.8[]"])
+        self._solve(["python>2.6.8"],
+                    ["python-2.7.0[]"])
+
+
+    def test_13_empty_string(self):
+        """confirm that we can use empty string to match unmatched versions"""
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["", "2.7.0"]}}])
+        self._solve(["python"],
+                    ["python-2.6.8[]"])
+        self._solve(["python", "!python-2.6.8"],
+                    ["python-2.6.0[]"])
+        self._solve(["python", "!python-2.6"],
+                    ["python-2.5.2[]"])
+        self._solve(["python>2.6.8"],
+                    ["python-2.7.0[]"])
+
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.0", "", "2.7.0"]}}])
+        self._solve(["python"],
+                    ["python-2.6.0[]"])
+        self._solve(["python", "!python-2.6.0"],
+                    ["python-2.6.8[]"])
+        self._solve(["python", "!python-2.6"],
+                    ["python-2.5.2[]"])
+        self._solve(["python>2.6.8"],
+                    ["python-2.7.0[]"])
+
+
+    def test_14_false(self):
+        """confirm that we can use False to match unmatched versions"""
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": [False, "2.7.0"]}}])
+        self._solve(["python"],
+                    ["python-2.6.8[]"])
+        self._solve(["python", "!python-2.6.8"],
+                    ["python-2.6.0[]"])
+        self._solve(["python", "!python-2.6"],
+                    ["python-2.5.2[]"])
+        self._solve(["python>2.6.8"],
+                    ["python-2.7.0[]"])
+
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.0", False, "2.7.0"]}}])
+        self._solve(["python"],
+                    ["python-2.6.0[]"])
+        self._solve(["python", "!python-2.6.0"],
+                    ["python-2.6.8[]"])
+        self._solve(["python", "!python-2.6"],
+                    ["python-2.5.2[]"])
+        self._solve(["python>2.6.8"],
+                    ["python-2.7.0[]"])
+
+
+    def test_15_requirement_1_deep(self):
+        """Test setting of the version_priority for a required package 1 level
+        deep
+        """
+        # python 2.5 is preferred...
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": [2.5]}}])
+
+        # # so if we request python directly, we get 2.5...
+        self._solve(["python"],
+                    ["python-2.5.2[]"])
+
+        # ...but if we request pyfoo, IT'S version is more important, and we
+        # get 2.6
+        self._solve(["pyfoo"],
+                    ["python-2.6.8[]", "pyfoo-3.1.0[]"])
+
+        # but if we make specifically python-2.6.0 prioritized, it will be used
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.0"]}}])
+        self._solve(["pyfoo"],
+                    ["python-2.6.0[]", "pyfoo-3.1.0[]"])
+
+
+    def test_16_requirement_2_deep(self):
+        """Test setting of the version_priority for a required package 2
+        levels deep
+        """
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.0", "2.5"]}}])
+        self._solve(["pyodd"],
+                    ["python-2.5.2[]", "pybah-5[]", "pyodd-2[]"])
+        self._solve(["pyodd-2"],
+                    ["python-2.5.2[]", "pybah-5[]", "pyodd-2[]"])
+        self._solve(["pyodd-1"],
+                    ["python-2.6.0[]", "pyfoo-3.1.0[]", "pyodd-1[]"])
+
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"pybah": ["4"],
+                                             "pyfoo": ["3.0.0"],
+                                             "python": ["2.6.0"]}}])
+        self._solve(["pyodd"],
+                    ["python-2.6.0[]", "pybah-4[]", "pyodd-2[]"])
+        self._solve(["pyodd-2"],
+                    ["python-2.6.0[]", "pybah-4[]", "pyodd-2[]"])
+        self._solve(["pyodd-1"],
+                    ["python-2.5.2[]", "pyfoo-3.0.0[]", "pyodd-1[]"])
+
+
+    def test_17_multiple_false(self):
+        """Make sure that multiple False / empty values raises an error
+        """
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.0", False, False,
+                                                        "2.5"]}}])
+        self.assertRaises(ConfigurationError,
+                          self._solve, ["python"], ["python-2.6.0[]"])
+
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.0", "", "",
+                                                        "2.5"]}}])
+        self.assertRaises(ConfigurationError,
+                          self._solve, ["python"], ["python-2.6.0[]"])
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.6.0", "", False,
+                                                        "2.5"]}}])
+        self.assertRaises(ConfigurationError,
+                          self._solve, ["python"], ["python-2.6.0[]"])
+
+
+    def test_18_multiple_matches(self):
+        """Test that if matches more than one, higher-priority is used
+        """
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": ["2.7.0|2.6.8",
+                                                        "2.5",
+                                                        "2.6.8|2.6.0"]}}])
+        self._solve(["python<2.7"],
+                    ["python-2.6.8[]"])
+
+
+    def test_19_latest(self):
+        """Test setting a package to latest version_priority
+        """
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {}}])
+        self._solve(["python"],
+                    ["python-2.7.0[]"])
+        self._solve(["python", "!python-2.7.0"],
+                    ["python-2.6.8[]"])
+        self._solve(["python-2.6"],
+                    ["python-2.6.8[]"])
+        self._solve(["python-2.6+<2.7"],
+                    ["python-2.6.8[]"])
+        self._solve(["python<2.6"],
+                    ["python-2.5.2[]"])
+
+        config.override("package_orderers",
+                        [{"type": "custom",
+                          "packages": {"python": "latest"}}])
+        self._solve(["python"],
+                    ["python-2.7.0[]"])
+        self._solve(["python", "!python-2.7.0"],
+                    ["python-2.6.8[]"])
+        self._solve(["python-2.6"],
+                    ["python-2.6.8[]"])
+        self._solve(["python-2.6+<2.7"],
+                    ["python-2.6.8[]"])
+        self._solve(["python<2.6"],
+                    ["python-2.5.2[]"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -403,37 +403,84 @@ class TestSolver(TestBase):
         self._solve(["python<2.7"],
                     ["python-2.6.8[]"])
 
-
-    def test_19_latest(self):
-        """Test setting a package to latest version_priority
+    def test_19_reversed_str(self):
+        """Test setting a package to reversed version_priority
         """
         config.override("package_orderers",
-                        [{"type": "custom",
-                          "packages": {}}])
+                        [{"type": "reversed",
+                          "packages": "python"}])
         self._solve(["python"],
-                    ["python-2.7.0[]"])
+                    ["python-2.5.2[]"])
         self._solve(["python", "!python-2.7.0"],
-                    ["python-2.6.8[]"])
+                    ["python-2.5.2[]"])
+        self._solve(["python", "!python-2.5.2"],
+                    ["python-2.6.0[]"])
         self._solve(["python-2.6"],
-                    ["python-2.6.8[]"])
+                    ["python-2.6.0[]"])
         self._solve(["python-2.6+<2.7"],
-                    ["python-2.6.8[]"])
+                    ["python-2.6.0[]"])
         self._solve(["python<2.6"],
                     ["python-2.5.2[]"])
 
+    def test_20_reversed_list(self):
+        """Test setting a package to reversed version_priority
+        """
         config.override("package_orderers",
-                        [{"type": "custom",
-                          "packages": {"python": "latest"}}])
+                        [{"type": "reversed",
+                          "packages": ["python"]}])
         self._solve(["python"],
-                    ["python-2.7.0[]"])
+                    ["python-2.5.2[]"])
         self._solve(["python", "!python-2.7.0"],
-                    ["python-2.6.8[]"])
+                    ["python-2.5.2[]"])
+        self._solve(["python", "!python-2.5.2"],
+                    ["python-2.6.0[]"])
         self._solve(["python-2.6"],
-                    ["python-2.6.8[]"])
+                    ["python-2.6.0[]"])
         self._solve(["python-2.6+<2.7"],
-                    ["python-2.6.8[]"])
+                    ["python-2.6.0[]"])
         self._solve(["python<2.6"],
                     ["python-2.5.2[]"])
+
+    def test_21_reversed_is_requirement(self):
+        """Test setting a package to reversed version_priority, when it is a
+        requirement
+        """
+        config.override("package_orderers",
+                        [{"type": "reversed",
+                          "packages": "python"}])
+        self._solve(["pyfoo"],
+                    ["python-2.6.0[]", "pyfoo-3.1.0[]"])
+        self._solve(["pyfoo-3.0"],
+                    ["python-2.5.2[]", "pyfoo-3.0.0[]"])
+        self._solve(["pyfoo-3.1"],
+                    ["python-2.6.0[]", "pyfoo-3.1.0[]"])
+        self._solve(["pybah"],
+                    ["python-2.5.2[]", "pybah-5[]"])
+        self._solve(["pybah-4"],
+                    ["python-2.6.0[]", "pybah-4[]"])
+        self._solve(["pybah-5"],
+                    ["python-2.5.2[]", "pybah-5[]"])
+
+
+    def test_22_reversed_has_requirement(self):
+        """Test setting a package to reversed version_priority, when it has a
+        requirement
+        """
+        config.override("package_orderers",
+                        [{"type": "reversed",
+                          "packages": ["pyfoo", "pybah"]}])
+        self._solve(["pyfoo"],
+                    ["python-2.5.2[]", "pyfoo-3.0.0[]"])
+        self._solve(["pyfoo-3.0"],
+                    ["python-2.5.2[]", "pyfoo-3.0.0[]"])
+        self._solve(["pyfoo-3.1"],
+                    ["python-2.6.8[]", "pyfoo-3.1.0[]"])
+        self._solve(["pybah"],
+                    ["python-2.6.8[]", "pybah-4[]"])
+        self._solve(["pybah-4"],
+                    ["python-2.6.8[]", "pybah-4[]"])
+        self._solve(["pybah-5"],
+                    ["python-2.5.2[]", "pybah-5[]"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a new package orderer, which allows the user to specify and explit ordering for versions in the package, using standard version-range strings.  It also provides an easy way to specify a "default" version.  See the docstring for CustomPackageOrder for more details.

The first commit adds the ability to configure which orderers you want using the standard rezconfig mechanisms; the last also adds a ReversePackageOrder, which does exactly what you'd think it does. ;)