### PR TITLE
hg: print log from most recent to oldest, so don't truncate current commit

### DIFF
--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -212,7 +212,15 @@ class HgReleaseVCS(ReleaseVCS):
         if prev_commit:
             # git behavior is to simply print the log from the last common
             # ancsestor... which is apparently desired. so we'll mimic that
-            commit_range = "ancestor(%s, .)::." % prev_commit
+
+            # however, we want to print in order from most recent to oldest,
+            # because:
+            #    a) if the log gets truncated, we want to cut off the
+            #       oldest commits, not the current one, and
+            #    b) this mimics the order they're printed in git
+            #    c) this mimics the order they're printed if  you have no
+            #       previous_revision, and just do "hg log"
+            commit_range = "reverse(ancestor(%s, .)::.)" % prev_commit
             stdout = self.hg("log", "-r", commit_range)
         else:
             stdout = self.hg("log")


### PR DESCRIPTION
Right now, the hg log in the package.py is printed from oldest to newest (if there was a previous revision), which means that if it is truncated, the changelog for the current commit is lost.

This reverses the order that the log is printed to be newest to oldest, so that the current commit is not lost.  This also matches the behavior of git.
