### PR TITLE
even if there are no memcached servers, DoNotCache results are unwrapped

### DIFF
--- a/src/rez/utils/memcached.py
+++ b/src/rez/utils/memcached.py
@@ -353,7 +353,10 @@ def memcached(servers, key=None, from_cache=None, to_cache=None, time=0,
                     return result
         else:
             def wrapper(*nargs, **kwargs):
-                return func(*nargs, **kwargs)
+                result = func(*nargs, **kwargs)
+                if isinstance(result, DoNotCache):
+                    return result.result
+                return result
 
         def forget():
             """Forget entries in the cache.


### PR DESCRIPTION
memcached-wrapped functions are supposed to be able to return DoNotCache if they don't want their results to be cached.  This works, EXCEPT if there are no servers configured, in which case the "raw" DoNotCache object is returned from the function.  This fixes that bug.