### PR TITLE
Ability for a package to declare it shouldn't be cached

### DIFF
--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -120,6 +120,9 @@ def _load_file(filepath, format_, update_data_callback):
 
     if update_data_callback:
         result = update_data_callback(format_, result)
+
+    if format_ == FileFormat.py and result.get("DO_NOT_CACHE", False):
+        return DoNotCache(result)
     return result
 
 

--- a/src/rez/utils/memcached.py
+++ b/src/rez/utils/memcached.py
@@ -353,7 +353,10 @@ def memcached(servers, key=None, from_cache=None, to_cache=None, time=0,
                     return result
         else:
             def wrapper(*nargs, **kwargs):
-                return func(*nargs, **kwargs)
+                result = func(*nargs, **kwargs)
+                if isinstance(result, DoNotCache):
+                    return result.result
+                return result
 
         def forget():
             """Forget entries in the cache.


### PR DESCRIPTION
This allows a package to declare that it's results shouldn't be cached; this can be handy if you want to declare different values for a package depending on context; for instance, if you have a "gitkraken" package, and you want it's tools to be ["gitkraken"] on Linux, but ["GitKraken"] on OSX, you can do this pretty easily in a package.py by checking the current OS... but if it's memcached, then this result will be "baked" and returned to all machines using that memcache server, regardless of OS.

By allowing the gitkraken's package.py to set DO_NOT_CACHE = True, we can keep the proper branching behavior by OS.