### PR TITLE
allow configuration of truncate cap for shell error output

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -297,6 +297,7 @@ config_schema = Schema({
     "quiet":                                        Bool,
     "show_progress":                                Bool,
     "catch_rex_errors":                             Bool,
+    "shell_error_truncate_cap":                     Int,
     "set_prompt":                                   Bool,
     "prefix_prompt":                                Bool,
     "warn_old_commands":                            Bool,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -379,6 +379,10 @@ debug_none = False
 # are left uncaught, which can be useful for debugging purposes.
 catch_rex_errors = True
 
+# Sets the maximum number of characters printed from the stdout / stderr of some
+# shell commands when they fail. If 0, then the output is not truncated
+shell_error_truncate_cap = 750
+
 
 ###############################################################################
 # Build

--- a/src/rez/vendor/sh/__init__.py
+++ b/src/rez/vendor/sh/__init__.py
@@ -1,0 +1,6 @@
+# putting rez-specific code here, because this file wouldn't exist in a
+# "normal" distribution of sh
+
+from rez.config import config
+from . import sh
+sh.ErrorReturnCode.truncate_cap = config.shell_error_truncate_cap

--- a/src/rez/vendor/sh/sh.py
+++ b/src/rez/vendor/sh/sh.py
@@ -132,20 +132,23 @@ class ErrorReturnCode(Exception):
         self.stdout = stdout
         self.stderr = stderr
 
+        def truncate(output, name):
+            if not self.truncate_cap:
+                return output
+            truncated_output = output[:self.truncate_cap]
+            delta = len(output) - len(truncated_output)
+            if delta:
+                truncated_output += (
+                "... (%d more, please see e.%s)" % (delta, name)).encode()
+            return truncated_output
 
         if self.stdout is None: exc_stdout = "<redirected>"
         else:
-            exc_stdout = self.stdout[:self.truncate_cap]
-            out_delta = len(self.stdout) - len(exc_stdout)
-            if out_delta:
-                exc_stdout += ("... (%d more, please see e.stdout)" % out_delta).encode()
+            exc_stdout = truncate(self.stdout, 'stdout')
 
         if self.stderr is None: exc_stderr = "<redirected>"
         else:
-            exc_stderr = self.stderr[:self.truncate_cap]
-            err_delta = len(self.stderr) - len(exc_stderr)
-            if err_delta:
-                exc_stderr += ("... (%d more, please see e.stderr)" % err_delta).encode()
+            exc_stderr = truncate(self.stderr, 'stderr')
 
         msg = "\n\n  RAN: %r\n\n  STDOUT:\n%s\n\n  STDERR:\n%s" % \
             (full_cmd, exc_stdout.decode(DEFAULT_ENCODING, "replace"),


### PR DESCRIPTION
Make the length at which stdout/stderr is truncated in error reports configurable in .rezconfig