### PR TITLE
rex: don't let packages pollute namespace of future packages

### DIFF
--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -1169,9 +1169,20 @@ class RexExecutor(object):
             code (str): Rex code to execute.
             filename (str): Filename to report if there are syntax errors.
         """
-        self.compile_code(code=code,
-                          filename=filename,
-                          exec_namespace=self.globals)
+        # we want to execute the code using self.globals - if for no other
+        # reason that self.formatter is pointing at self.globals, so if we
+        # passed in a copy, we would also need to make self.formatter "look" at
+        # the same copy - but we don't want to "pollute" our namespace, because
+        # the same executor may be used to run multiple packages. Therefore,
+        # we save a copy of self.globals before execution, and restore it after
+        saved_globals = dict(self.globals)
+        try:
+            self.compile_code(code=code,
+                              filename=filename,
+                              exec_namespace=self.globals)
+        finally:
+            self.globals.clear()
+            self.globals.update(saved_globals)
 
     def execute_function(self, func, *nargs, **kwargs):
         """


### PR DESCRIPTION
The package executor currently has a bug where the global namespace is shared when multiple packages are executed when setting up a context.  This can create differing behavior depending on the order of execution of packages, which is clearly undesired.

This fix patches the behavior, so that the global namespace in which each package executes is "reset" after each package runs.