### PR TITLE
added option to force color output, even if not a tty

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -126,6 +126,7 @@ class Bool(Setting):
     schema = Schema(bool)
     true_words = frozenset(["1", "true", "yes", "y", "on"])
     false_words = frozenset(["0", "false", "no", "n", "off"])
+    all_words = true_words | false_words
 
     def _parse_env_var(self, value):
         value = value.lower()
@@ -134,10 +135,22 @@ class Bool(Setting):
         elif value in self.false_words:
             return False
         else:
-            words = self.true_words | self.false_words
             raise ConfigurationError(
                 "expected $%s to be one of: %s"
-                % (self._env_var_name, ", ".join(words)))
+                % (self._env_var_name, ", ".join(self.all_words)))
+
+
+class ForceOrBool(Bool):
+    FORCE_STR = "force"
+
+    # need force first, or Bool.schema will coerce "force" to True
+    schema = Or(FORCE_STR, Bool.schema)
+    all_words = Bool.all_words | frozenset([FORCE_STR])
+
+    def _parse_env_var(self, value):
+        if value == self.FORCE_STR:
+            return value
+        super(ForceOrBool, self)._parse_env_var(value)
 
 
 class Dict(Setting):
@@ -272,7 +285,7 @@ config_schema = Schema({
     "memcached_resolve_min_compress_len":           Int,
     "allow_unversioned_packages":                   Bool,
     "rxt_as_yaml":                                  Bool,
-    "color_enabled":                                Bool,
+    "color_enabled":                                ForceOrBool,
     "resolve_caching":                              Bool,
     "cache_package_files":                          Bool,
     "cache_listdir":                                Bool,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -586,6 +586,11 @@ documentation_url = " http://nerdvegas.github.io/rez/"
 # Enables/disables colorization globally.
 # Note: Turned off for Windows currently as there seems to be a problem with
 # the Colorama module.
+# May also set to the string "force", which will make rez output color styling
+# information, even if the the output streams are not ttys. Useful if you are
+# piping the output of rez, but will eventually be printing to a tty later.
+# When force is used, will generally be set through an environemnt variable, ie,
+#    echo $(REZ_COLOR_ENABLED=force python -c "from rez.utils.colorize import Printer, local; Printer()('foo', local)")
 color_enabled = (os.name == "posix")
 
 ### Do not move or delete this comment (__DOC_END__)


### PR DESCRIPTION
Currently, whether or not rez outputs color is purely determined by whether or not the current stdout is a tty; unfortunately, that means that when doing things like using the output of rez in pipes, etc, color is always disabled.

This fix provides a means to force color output on, so that things like this will work:

echo $(REZ_COLOR_ENABLED=force python -c "from rez.utils.colorize import Printer, local; Printer()('foo', local)")
