### PR TITLE
Taggable versions that sort BEFORE non-tagged versions

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -316,6 +316,7 @@ config_schema = Schema({
     "env_var_separators":                           Dict,
     "variant_select_mode":                          VariantSelectMode_,
     "package_filter":                               OptionalDictOrDictList,
+    "version_token":                                Str,
     "new_session_popen_args":                       OptionalDict,
 
     # GUI settings
@@ -757,6 +758,16 @@ def get_module_root_config():
 
 # singleton
 config = Config._create_main_config()
+
+# Set version.default_make_token
+import rez.vendor.version.version
+if '_ContainsVersionIterator' in rez.vendor.version.version.__dict__:
+    rez.vendor.version.version.default_make_token = \
+        getattr(rez.vendor.version.version, config.version_token)
+else:
+    # we're in the middle of importing rez.vendor.version.version - if this is
+    # the case, we have code at the end of rez.vendor.version to set this...
+    pass
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -242,6 +242,14 @@ variant_select_mode = "version_priority"
 # foo-5+              | Same as range(foo-5+)
 package_filter = None
 
+# Change the default token used in Version objects - can be used to change the
+# way that versions are ordered.  May be the name of any Token subclass in
+# rez.vender.version.version.
+# For instance, you can set it to "TaggableAlphanumericVersionToken" to allow
+#  adding of "tags", specified after a double underscore, that will sort
+# BEFORE the untagged version - ie, so that 1.3__forBrian will come before 1.3
+version_token = "AlphanumericVersionToken"
+
 # If True, unversioned packages are allowed. Solve times are slightly better if
 # this value is False.
 allow_unversioned_packages = True

--- a/src/rez/tests/test_version.py
+++ b/src/rez/tests/test_version.py
@@ -2,11 +2,7 @@
 unit tests for 'version' module
 """
 import rez.vendor.unittest2 as unittest
-from rez.vendor.version.test import TestVersionSchema
-
-
-class TestVersions(TestVersionSchema):
-    pass
+from rez.vendor.version.test import *
 
 
 if __name__ == '__main__':

--- a/src/rez/vendor/version/__init__.py
+++ b/src/rez/vendor/version/__init__.py
@@ -1,0 +1,13 @@
+# putting rez-specific code here, because this file wouldn't exist in a
+# "normal" distribution of sh
+
+from . import version
+
+try:
+    from rez.config import config
+except ImportError:
+    # if there's an ImportError, we're in the middle of importing config - if
+    # this is the case, we have code at the end of config to set this...
+    pass
+else:
+    version.default_make_token = getattr(version, config.version_token)

--- a/src/rez/vendor/version/test.py
+++ b/src/rez/vendor/version/test.py
@@ -567,6 +567,24 @@ class TestTaggedVersionSchema(TestVersionSchema):
         ]
         self._test_ordered([Version(x) for x in ascending])
 
+    def test_version_range_tagged(self):
+        vr = VersionRange('1.0')
+        self.assertTrue(vr.contains_version(Version('1.0')))
+        self.assertFalse(vr.contains_version(Version('1.0_')))
+        self.assertFalse(vr.contains_version(Version('1.0__tag')))
+        self.assertFalse(vr.contains_version(Version('1.0__tag_')))
+        self.assertFalse(vr.contains_version(Version('1.0__tag__more')))
+        self.assertTrue(vr.contains_version(Version('1.0.blah')))
+        self.assertTrue(vr.contains_version(Version('1.0.blah__tag')))
+
+        vr = VersionRange('1.0__tag')
+        self.assertFalse(vr.contains_version(Version('1.0')))
+        self.assertFalse(vr.contains_version(Version('1.0_')))
+        self.assertTrue(vr.contains_version(Version('1.0__tag')))
+        self.assertFalse(vr.contains_version(Version('1.0__tag_')))
+        self.assertFalse(vr.contains_version(Version('1.0__tag__more')))
+        self.assertTrue(vr.contains_version(Version('1.0__tag.blah')))
+        self.assertTrue(vr.contains_version(Version('1.0__tag.blah__tag')))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -316,6 +316,9 @@ class TaggableAlphanumericVersionToken(AlphanumericVersionToken):
         else:
             return super(TaggableAlphanumericVersionToken, self).less_than(other)
 
+    def __eq__(self, other):
+        return (self.subtokens == other.subtokens) and self.tags == other.tags
+
     def next(self):
         if not self.tags:
             return super(TaggableAlphanumericVersionToken, self).next()

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -179,7 +179,7 @@ class AlphanumericVersionToken(VersionToken):
         return (self.subtokens < other.subtokens)
 
     def next(self):
-        other = AlphanumericVersionToken(None)
+        other = type(self)(None)
         other.subtokens = self.subtokens[:]
         subtok = other.subtokens[-1]
         if subtok.n is None:
@@ -209,6 +209,7 @@ class AlphanumericVersionToken(VersionToken):
 
         return subtokens
 
+default_make_token = AlphanumericVersionToken
 
 class Version(_Comparable):
     """Version object.
@@ -223,7 +224,7 @@ class Version(_Comparable):
     """
     inf = None
 
-    def __init__(self, ver_str='', make_token=AlphanumericVersionToken):
+    def __init__(self, ver_str='', make_token=None):
         """Create a Version object.
 
         Args:
@@ -231,6 +232,8 @@ class Version(_Comparable):
             make_token: Callable that creates a VersionToken subclass from a
                 string.
         """
+        if make_token is None:
+            make_token = default_make_token
         self.tokens = []
         self.seps = []
         self._str = None
@@ -698,7 +701,7 @@ class VersionRange(_Comparable):
     with a comma, eg ">=2,<=6". The comma is purely cosmetic and is dropped in
     the string representation.
     """
-    def __init__(self, range_str='', make_token=AlphanumericVersionToken):
+    def __init__(self, range_str='', make_token=None):
         """Create a VersionRange object.
 
         Args:
@@ -707,6 +710,8 @@ class VersionRange(_Comparable):
                 may not match range_str. For example, "3+<6|4+<8" == "3+<8".
             make_token: Version token class to use.
         """
+        if make_token is None:
+            make_token = default_make_token
         self._str = None
         self.bounds = []
         if range_str is None:

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -296,9 +296,14 @@ class TaggableAlphanumericVersionToken(AlphanumericVersionToken):
             return super(TaggableAlphanumericVersionToken, self).less_than(other)
 
     def next(self):
-        result = super(TaggableAlphanumericVersionToken, self).next()
-        result.tags = self.tags
-        return result
+        if not self.tags:
+            return super(TaggableAlphanumericVersionToken, self).next()
+
+        other = type(self)(None)
+        other.subtokens = self.subtokens[:]
+        other.tags = self.tags[:]
+        other.tags[-1] = other.tags[-1].next()
+        return other
 
 
 default_make_token = AlphanumericVersionToken


### PR DESCRIPTION
It's come up a number of times that we need to release a "special" version of some already-released version... however, we it to come before the already released version in priority / version sorting.  

To use a real-life example, suppose we initially have:

boost-1.55.0

...which is statically linked.  We now want to release a dynamically-linked version of that. But if we were to just create:

boost-1.55.0.dynamic

...then this will be detected by boost as a "higher" version, since in rez, "1.foo.anything" is always higher than "1.foo".

However, if we add a "__dynamic" tag (tags are indicated by preceding with a double underscore), then it will sort BEFORE boost-1.55.0.  So, to summarize, the sort order would be:

LOWEST version / priority:
boost-1.55.0__dynamic
boost-1.55.0
boost-1.55.0.dynamic
HIGEST version / priority

This behavior is configurable in the .rezconfig.  As a bonus, since it's actually implemented as a new type of VersionToken, .rezconfig now allows choosing a custom Token class for your version objects to use.