### PR TITLE
add ability to modify lists in .rezconfig, instead of overriding

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -357,7 +357,7 @@ class ListModify(object):
     If you're using a python config file, you need to use this object, like so:
 
         ListModify("mysetting").before = ["new first entry", "new second entry"]
-        ListModify("othersetting").after = ["new first entry", "new second entry"]
+        ListModify("othersetting").after = ["new second-to-last entry", "new last entry"]
     '''
 
     def __init__(self, key):

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -749,7 +749,7 @@ def _load_config_py(filepath):
                                      % (filepath, str(e)))
 
     for k, v in globs.iteritems():
-        if k != '__builtins__' and not ismodule(v):
+        if k != '__builtins__' and not ismodule(v) and v is not ListModify:
             result[k] = v
     return result
 

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -178,7 +178,16 @@ def deep_update(dict1, dict2):
     Note that `dict2` and any nested dicts are unchanged.
     """
     for k, v in dict2.iteritems():
-        if k in dict1 and isinstance(v, dict) and isinstance(dict1[k], dict):
+        if k.endswith(('.before', '.after')):
+            k, suffix = k.rsplit('.', 1)
+            if k not in dict1 or dict1[k] is None:
+                dict1[k] = copy.deepcopy(v)
+            else:
+                if suffix == 'before':
+                    dict1[k] = copy.deepcopy(v) + dict1[k]
+                else:
+                    dict1[k] = dict1[k] + copy.deepcopy(v)
+        elif k in dict1 and isinstance(v, dict) and isinstance(dict1[k], dict):
             deep_update(dict1[k], v)
         else:
             dict1[k] = copy.deepcopy(v)


### PR DESCRIPTION
Like the title says - similar to how dicts in ~/.rezconfig are merged, it's frequently handy to add items to lists instead of overwriting. This PR gives that ability (ie, you can prepend/append to the implicit_packages, etc).