### PR TITLE
Add rule to match requirement intersections, filters in rez-search

### DIFF
--- a/src/rez/package_filter.py
+++ b/src/rez/package_filter.py
@@ -506,29 +506,36 @@ class RequiresRule(Rule):
             `bool`: True if range intersects self._requirement.range.
         """
         pkg = get_package(package.name, package.version)
+
         if not pkg.requires:
             return False
+
         if self._families and pkg.name not in self._families:
             return False
+
         for request in pkg.requires:
+
             if request.name != self._requirement.name:
                 continue
+
             overlap = request.range.intersection(self._requirement.range)
+
             if overlap and self._action:
                 meth = getattr(self, 'match_%s' % self._action)
                 meth(package, str(request))
+
             return overlap
         return False
 
     def match_warning(self, package, request):
         """Called when the filter matches and self._action is 'warning'."""
         fmt = package.name, package.version, self, request
-        print_warning("(%s-%s|%s) intersected by %s" % fmt)
+        print_warning("%s-%s matched %s with request %s" % fmt)
 
     def match_error(self, package, request):
         """Called when the filter matches and self._action is 'error'."""
         fmt = package.name, package.version, self, request
-        msg = "(%s-%s|%s) intersected by %s" % fmt
+        msg = "%s-%s matched %s with request %s" % fmt
         raise PackageRequestError(msg)
 
     def family(self):


### PR DESCRIPTION
#383 

This PR proposes adding a Rule called 'requires', capable of matching requirement intersections.

### Introduction

Given `api-0.10` introducing breaking changes, it should be possible to guarantee that no package requests for api are bounded around the new feature, as in `my_tool.requires api-0.5+<1`, where a gray area exists between `0 < 0.10 < 1` (It is unclear whether or not the package will be affected by the 0.10 release).

### Usage

`exclude: requires(api<0.10)`

Will exclude packages that include requests that intersect with the range of `0 .. 0.10`, requiring my_tool to request at least `0.10+<1` to remain unfiltered, while all previous versions would not be allowed.

The requires rule takes additional arguments. An action to take on match `(None|warning|error)`, and if additionally specified, an explicit list of package families to match.

A complex example would be `requires(api<0.10,warning,tool_a,tool_b)` where warnings will be printed on matches with `tool_a` and `tool_b`.

### Additional

Finally, `rez-search` includes command line arguments for filters, allowing for warnings to be printed when investigating how a particular package family responds to a given requirement.