### PR TITLE
Fix: query the specified python when bind to.

### DIFF
--- a/src/rez/bind/python.py
+++ b/src/rez/bind/python.py
@@ -51,7 +51,7 @@ def bind(path, version_range=None, opts=None, parser=None):
     for dirname, module_name in entries:
         success, out, err = run_python_command([
             "import %s" % module_name,
-            "print %s.__file__" % module_name])
+            "print %s.__file__" % module_name], exe=exepath)
 
         if success:
             pypath = os.path.dirname(out)


### PR DESCRIPTION
Hi,

when rez-bind with --exe specified I found that rez actually copied the python files from my system python instead of the one specified.

This fix the problem.
