### PR TITLE
Add support for multiple paths for REZ_CONFIG_FILE

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -541,7 +541,7 @@ class Config(object):
         filepaths.append(get_module_root_config())
         filepath = os.getenv("REZ_CONFIG_FILE")
         if filepath:
-            filepaths.append(filepath)
+            filepaths.extend(filepath.split(os.pathsep))
 
         filepath = os.path.expanduser("~/.rezconfig")
         filepaths.append(filepath)


### PR DESCRIPTION
Add support for multiple paths in REZ_CONFIG_FILE. Paths are simply appended. Basically the last path wins as far as my testing went. I hope this is the intended behaviour?