### PR TITLE
allow yaml2py to take an explicit filename

### DIFF
--- a/src/rez/cli/yaml2py.py
+++ b/src/rez/cli/yaml2py.py
@@ -6,12 +6,14 @@ Print a package.yaml file in package.py format.
 def setup_parser(parser, completions=False):
     PKG_action = parser.add_argument(
         "PATH", type=str, nargs='?',
-        help="path to search for package.yaml, cwd if not provided")
+        help="path to yaml to convert, or directory to search for package.yaml;"
+            " cwd if not provided")
 
 
 def command(opts, parser, extra_arg_groups=None):
     from rez.packages_ import get_developer_package
     from rez.serialise import FileFormat
+    from rez.exceptions import PackageMetadataError
     import os.path
     import os
     import sys
@@ -20,17 +22,14 @@ def command(opts, parser, extra_arg_groups=None):
         path = os.path.expanduser(opts.PATH)
     else:
         path = os.getcwd()
-    if os.path.basename(path) == "package.yaml":
-        path = os.path.dirname(path)
 
-    filepath_yaml = os.path.join(path, "package.yaml")
-    if not os.path.isfile(filepath_yaml):
-        print >> sys.stderr, "Expected file '%s'" % filepath_yaml
-        sys.exit(1)
+    try:
+        package = get_developer_package(path, format=FileFormat.yaml)
+    except PackageMetadataError:
+        package = None
 
-    package = get_developer_package(path)
     if package is None:
-        print >> sys.stderr, "Couldn't load the package at %r" % cwd
+        print >> sys.stderr, "Couldn't load the package at %r" % path
         sys.exit(1)
 
     package.print_info(format_=FileFormat.py)

--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -541,9 +541,9 @@ def get_package_from_string(txt, paths=None):
     return get_package(o.name, o.version, paths=paths)
 
 
-def get_developer_package(path):
+def get_developer_package(path, format=None):
     from rez.developer_package import DeveloperPackage
-    return DeveloperPackage.from_path(path)
+    return DeveloperPackage.from_path(path, format=format)
 
 
 def create_package(name, data, package_cls=None):


### PR DESCRIPTION
This will allow you to do, ie, "rez yaml2py foo.yaml"

Handy for package-family fles (ie, maya.yaml), or anything not named package.yaml