### PR TITLE
Orderer fixes

### DIFF
--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -1,6 +1,8 @@
 from inspect import isclass
 from hashlib import sha1
 
+from rez.vendor.version.version import Version
+
 
 class PackageOrder(object):
     """Package reorderer base class."""
@@ -40,6 +42,9 @@ class PackageOrder(object):
 
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, str(self))
+
+    def __eq__(self, other):
+        return type(self) == type(other) and str(self) == str(other)
 
 
 class NullPackageOrder(PackageOrder):
@@ -245,11 +250,11 @@ class VersionSplitPackageOrder(PackageOrder):
             type: version_split
             first_version: "3.0.0"
         """
-        return dict(first_version=self.first_version)
+        return dict(first_version=str(self.first_version))
 
     @classmethod
     def from_pod(cls, data):
-        return cls(data["first_version"])
+        return cls(Version(data["first_version"]))
 
 
 class TimestampPackageOrder(PackageOrder):

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -5,6 +5,7 @@ from rez.tests.util import TestBase, TempdirMixin
 from rez.resolved_context import ResolvedContext
 from rez.bind import hello_world
 from rez.utils.platform_ import platform_
+from rez.config import config
 import rez.vendor.unittest2 as unittest
 import subprocess
 import os.path
@@ -61,6 +62,27 @@ class TestContext(TestBase, TempdirMixin):
         # load
         r2 = ResolvedContext.load(file)
         self.assertEqual(r.resolved_packages, r2.resolved_packages)
+
+    def test_orderer(self):
+        """Test a resolve with an orderer"""
+        from rez.package_order import VersionSplitPackageOrder
+        from rez.vendor.version.version import Version
+        path = os.path.dirname(__file__)
+        packages_path = os.path.join(path, "data", "solver", "packages")
+        config.override("packages_path",
+                        [packages_path])
+        orderers = [VersionSplitPackageOrder(first_version=Version("2.6"))]
+        r = ResolvedContext(["python", "!python-2.6"],
+                            package_orderers=orderers)
+        resolved = [x.qualified_package_name for x in r.resolved_packages]
+        self.assertEqual(resolved, ["python-2.5.2"])
+
+        # make sure serializing the orderer works
+        file = os.path.join(self.root, "test_orderers.rxt")
+        r.save(file)
+        r2 = ResolvedContext.load(file)
+        self.assertEqual(r, r2)
+        self.assertEqual(r.package_orderers, r2.package_orderers)
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -326,11 +326,24 @@ class TestPackages(TestBase, TempdirMixin):
             to_pod, from_pod
 
         def _test(orderer, package_name, expected_order):
+            from rez.vendor import simplejson
+            from rez.utils.yaml import dump_yaml
+            from rez.vendor import yaml
+
             it = iter_packages(package_name)
             descending = sorted(it, key=lambda x: x.version, reverse=True)
 
             pod = to_pod(orderer)
-            orderer2 = from_pod(pod)
+
+            # ResolvedContext.write_to_buffer will require conversion to both
+            # json and yaml, so test both
+            as_json = simplejson.dumps(pod)
+            from_json = simplejson.loads(as_json)
+            as_yaml = dump_yaml(pod)
+            from_yaml = yaml.load(as_yaml)
+            self.assertEqual(from_yaml, from_json)
+
+            orderer2 = from_pod(from_yaml)
 
             for orderer_ in (orderer, orderer2):
                 ordered = orderer_.reorder(descending)

--- a/src/rez/tests/test_version.py
+++ b/src/rez/tests/test_version.py
@@ -4,11 +4,6 @@ unit tests for 'version' module
 import rez.vendor.unittest2 as unittest
 from rez.vendor.version.test import TestVersionSchema
 
-
-class TestVersions(TestVersionSchema):
-    pass
-
-
 if __name__ == '__main__':
     unittest.main()
 

--- a/src/rez/vendor/version/test.py
+++ b/src/rez/vendor/version/test.py
@@ -481,6 +481,31 @@ class TestVersionSchema(unittest.TestCase):
         _confl(["foo", "~bah-5+", "bah-7..12", "bah-2"],
                "bah-7..12", "bah-2")
 
+    def test_reversed_sort_key(self):
+        # self.assertEqual(reverse_sort_key(5), reverse_sort_key(5))
+        self.assertLessEqual(reverse_sort_key(Version("1.3")),
+                             reverse_sort_key(Version("1.3")))
+        self.assertLessEqual(reverse_sort_key(VersionRange("1.2+")),
+                             reverse_sort_key(VersionRange("<0.8")))
+        self.assertGreaterEqual(reverse_sort_key(VersionRange("1+<2.4")),
+                                reverse_sort_key(VersionRange("1+<2.4")))
+        self.assertGreaterEqual(reverse_sort_key(VersionRange("1+<2.4")),
+                                reverse_sort_key(VersionRange("2.0+<3.5")))
+        l = [3, 5, 6, 2, 8, 1, 4, 7, 9, 10, 0, 4]
+        self.assertEqual(sorted(l, key=reverse_sort_key),
+                         [10, 9, 8, 7, 6, 5, 4, 4, 3, 2, 1, 0])
+        self.assertEqual(sorted(l, key=reverse_sort_key, reverse=True),
+                         [0, 1, 2, 3, 4, 4, 5, 6, 7, 8, 9, 10])
+
+        self.assertEqual(str(reverse_sort_key("foo")),
+                         "reverse(foo)")
+        self.assertEqual(repr(reverse_sort_key("foo")),
+                         "reverse('foo')")
+        self.assertEqual(str(reverse_sort_key((3, 'foo'))),
+                         "reverse((3, 'foo'))")
+        self.assertEqual(repr(reverse_sort_key((3, 'foo'))),
+                         "reverse((3, 'foo'))")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -40,13 +40,18 @@ class _ReversedComparable(_Common):
         self.value = value
 
     def __lt__(self, other):
-        return not (self.value < other.value)
+        return self.value > other.value
+
+    def __eq__(self, other):
+        return self.value == other.value
 
     def __str__(self):
-        return "reverse(%s)" % str(self.value)
+        # enclose self.value in a tuple in case it IS a tuple
+        return "reverse(%s)" % (self.value,)
 
     def __repr__(self):
-        return "reverse(%r)" % self.value
+        # enclose self.value in a tuple in case it IS a tuple
+        return "reverse(%r)" % (self.value,)
 
 
 class VersionToken(_Comparable):


### PR DESCRIPTION
A bugfix for a few issues with orderers:

- fix for the ordering done by _ReversedComparable
- fix for serialzing / deserializing of contexts which are using a VersionSplitPackageOrder