### PR TITLE
Implements #426: Allow to define multiple local/release folders

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -244,8 +244,9 @@ config_schema = Schema({
     "implicit_styles":                              OptionalStrList,
     "alias_styles":                                 OptionalStrList,
     "memcached_uri":                                OptionalStrList,
-    "local_packages_path":                          Str,
-    "release_packages_path":                        Str,
+    "local_packages_paths":                         StrList,
+    "release_packages_paths":                       StrList,
+    "packages_index":                               Int,
     "dot_image_format":                             Str,
     "build_directory":                              Str,
     "documentation_url":                            Str,
@@ -475,11 +476,22 @@ class Config(object):
         return d
 
     @property
+    def local_packages_path(self):
+        """Returns the local_package_path based on the index"""
+        return self.local_packages_paths[self.packages_index]
+
+    @property
+    def release_packages_path(self):
+        """Returns the release_package_path based on the index"""
+        return self.release_packages_paths[self.packages_index]
+
+    @property
     def nonlocal_packages_path(self):
         """Returns package search paths with local path removed."""
         paths = self.packages_path[:]
-        if self.local_packages_path in paths:
-            paths.remove(self.local_packages_path)
+        for local_packages_path in self.local_packages_paths:
+            if local_packages_path in paths:
+                paths.remove(self.local_packages_path)
         return paths
 
     def get_completions(self, prefix):

--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -92,9 +92,12 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
     @cached_property
     def is_local(self):
         """Returns True if the package is in the local package repository"""
-        local_repo = package_repository_manager.get_repository(
-            self.config.local_packages_path)
-        return (self.resource._repository.uid == local_repo.uid)
+        for local_packages_path in self.config.local_packages_paths:
+            local_repo = package_repository_manager.get_repository(
+                local_packages_path)
+            if self.resource._repository.uid == local_repo.uid:
+                return True
+        return False
 
     def print_info(self, buf=None, format_=FileFormat.yaml,
                    skip_attributes=None, include_release=False):

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -51,11 +51,17 @@ packages_path = [
 ]
 
 # The path that Rez will locally install packages to when rez-build is used
-local_packages_path = "~/packages"
+# This uses the package_index to identify which path to use.
+local_packages_paths = ["~/packages"]
 
 # The path that Rez will deploy packages to when rez-release is used. For
 # production use, you will probably want to change this to a site-wide location.
-release_packages_path = "~/.rez/packages/int"
+# This uses the package_index to identify which path to use.
+release_packages_paths = ["~/.rez/packages/int"]
+
+# Defines which local/release_packages_paths are enabled
+# Feel free to override this within a package to release to different locations.
+packages_index = 0
 
 # Where temporary files go. Defaults to appropriate path depending on your
 # system - for example, *nix distributions will probably set this to "/tmp". It

--- a/src/rez/tests/test_release.py
+++ b/src/rez/tests/test_release.py
@@ -36,7 +36,7 @@ class TestRelease(TestBase, TempdirMixin):
         cls.settings = dict(
             packages_path=[cls.install_root],
             package_filter=None,
-            release_packages_path=cls.install_root,
+            release_packages_paths=[cls.install_root],
             resolve_caching=False,
             warn_untimestamped=False,
             implicit_packages=[])


### PR DESCRIPTION
Based on the request at #426.

All tests pass.
For the sake of clean implementation it does break config compatibility (to some little degree).
For example:
~~~python
local_packages_path = "~/packages"
release_packages_path = "~/.rez/packages/int"
~~~
Becomes:
~~~python
local_packages_paths = ["~/packages"]
release_packages_paths = ["~/.rez/packages/int"]
packages_index = 0
~~~