### PR TITLE
Ensure that "{install}" placeholder is properly expanded in package "build_commands".

### DIFF
--- a/src/rezplugins/build_system/custom.py
+++ b/src/rezplugins/build_system/custom.py
@@ -112,7 +112,7 @@ class CustomBuildSystem(BuildSystem):
 
         def expand(txt):
             root = self.package.root
-            install_ = "install" if install else ''
+            install_ = install_path if install else ''
             return txt.format(root=root, install=install_).strip()
 
         if isinstance(command, basestring):


### PR DESCRIPTION
References https://github.com/nerdvegas/rez/issues/431#issuecomment-305647516

This ensures that the `{install}` placeholder is formatted correctly instead of using `"install"` string in current implementation.

I have tested and it does fix the issue I had with `rez-build -i` and `rez-release`.