### PR TITLE
solver fix for variant splitting

### DIFF
--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -833,7 +833,7 @@ class _PackageVariantSlice(_Common):
             if result:
                 entry, next_entry = result
                 entries = self.entries[:i_entry] + [entry]
-                next_entries = [next_entry] + self.entries[i_entry:]
+                next_entries = [next_entry] + self.entries[i_entry + 1:]
             else:
                 entries = self.entries[:i_entry + 1]
                 next_entries = self.entries[i_entry + 1:]

--- a/src/rez/tests/data/solver/packages/test_variant_split_end/1.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_end/1.0/package.py
@@ -1,0 +1,5 @@
+name = "test_variant_split_end"
+version = "1.0"
+
+variants = [["!test_variant_split_mid2"], ["!test_variant_split_start-2"]]
+

--- a/src/rez/tests/data/solver/packages/test_variant_split_end/2.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_end/2.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_end"
+version = "2.0"
+
+variants = [["!test_variant_split_start"], ["!test_variant_split_mid1"]]

--- a/src/rez/tests/data/solver/packages/test_variant_split_end/3.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_end/3.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_end"
+version = "3.0"
+
+variants = [["!test_variant_split_start"], ["!test_variant_split_mid2"]]

--- a/src/rez/tests/data/solver/packages/test_variant_split_end/4.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_end/4.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_end"
+version = "4.0"
+
+variants = [["!test_variant_split_start"], ["!test_variant_split_mid1"]]

--- a/src/rez/tests/data/solver/packages/test_variant_split_mid1/1.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_mid1/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_mid1"
+version = "1.0"
+
+variants = [["test_variant_split_end-2"], ["test_variant_split_end-1"]]

--- a/src/rez/tests/data/solver/packages/test_variant_split_mid1/2.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_mid1/2.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_mid1"
+version = "2.0"
+
+variants = [["test_variant_split_end-2"], ["test_variant_split_end-4"]]

--- a/src/rez/tests/data/solver/packages/test_variant_split_mid2/1.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_mid2/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_mid2"
+version = "1.0"
+
+variants = [["test_variant_split_end-3"], ["test_variant_split_end-1"]]

--- a/src/rez/tests/data/solver/packages/test_variant_split_mid2/2.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_mid2/2.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_mid2"
+version = "2.0"
+
+variants = [["test_variant_split_end-1"], ["test_variant_split_end-3"]]

--- a/src/rez/tests/data/solver/packages/test_variant_split_start/1.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_start/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_start"
+version = "1.0"
+
+variants = [["test_variant_split_mid1-1"], ["test_variant_split_mid2-2"]]

--- a/src/rez/tests/data/solver/packages/test_variant_split_start/2.0/package.py
+++ b/src/rez/tests/data/solver/packages/test_variant_split_start/2.0/package.py
@@ -1,0 +1,4 @@
+name = "test_variant_split_start"
+version = "2.0"
+
+variants = [["test_variant_split_mid1-2"], ["test_variant_split_mid2-2"]]

--- a/src/rez/tests/test_completion.py
+++ b/src/rez/tests/test_completion.py
@@ -48,7 +48,9 @@ class TestCompletion(TestBase):
 
         _eq("zzz", [])
         _eq("", ["bahish", "nada", "nopy", "pybah", "pydad", "pyfoo", "pymum",
-                 "pyodd", "pyson", "pysplit", "python", "pyvariants"])
+                 "pyodd", "pyson", "pysplit", "python", "pyvariants",
+                 "test_variant_split_start", "test_variant_split_mid1",
+                 "test_variant_split_mid2", "test_variant_split_end"])
         _eq("py", ["pybah", "pydad", "pyfoo", "pymum", "pyodd", "pyson",
             "pysplit", "python", "pyvariants"])
         _eq("pys", ["pyson", "pysplit"])

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -30,6 +30,11 @@ ALL_PACKAGES = set([
     'pysplit-5', 'pysplit-6', 'pysplit-7',
     'python-2.5.2', 'python-2.6.0', 'python-2.6.8', 'python-2.7.0',
     'pyvariants-2',
+    'test_variant_split_start-1.0', 'test_variant_split_start-2.0',
+    'test_variant_split_mid1-1.0', 'test_variant_split_mid1-2.0',
+    'test_variant_split_mid2-1.0', 'test_variant_split_mid2-2.0',
+    'test_variant_split_end-1.0', 'test_variant_split_end-2.0',
+    'test_variant_split_end-3.0', 'test_variant_split_end-4.0',
     # packages from data/packages/py_packages and .../yaml_packages
     'unversioned',
     'unversioned_py',

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -212,6 +212,13 @@ class TestSolver(TestBase):
         self._solve(["pyvariants", "python", "nada"],
                     ["python-2.6.8[]", "nada[]", "pyvariants-2[1]"])
 
+    def test_11_variant_splitting(self):
+        self._solve(["test_variant_split_start"],
+                    ["test_variant_split_end-1.0[1]",
+                     "test_variant_split_mid2-2.0[0]",
+                     "test_variant_split_start-1.0[1]"])
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
A fix for the core solver that I'm surprised doesn't come up more often. Also added a test to illustrate the problem.