### PR TITLE
Ignore versions if .ignore file exists

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -432,6 +432,7 @@ class FileSystemPackageRepository(PackageRepository):
                    "package_filenames": [basestring]}
 
     building_prefix = ".building"
+    ignore_prefix = ".ignore"
 
     @classmethod
     def name(cls):
@@ -629,7 +630,9 @@ class FileSystemPackageRepository(PackageRepository):
                     continue
 
                 path = os.path.join(root, name)
-                if os.path.isdir(path):
+                # Ignore a version if there is a .ignore<version> file next to it
+                ignore_path = os.path.join(root, self.ignore_prefix + name)
+                if os.path.isdir(path) and not os.path.isfile(ignore_path):
                     if not self._is_valid_package_directory(path):
                         continue
 
@@ -653,7 +656,9 @@ class FileSystemPackageRepository(PackageRepository):
                 building_dirs.add(ver_str)
 
             path = os.path.join(root, name)
-            if os.path.isdir(path):
+            # Ignore a version if there is a .ignore<version> file next to it
+            ignore_path = os.path.join(root, self.ignore_prefix + name)
+            if os.path.isdir(path) and not os.path.isfile(ignore_path):
                 dirs.add(name)
 
         # check 'building' dirs for validity


### PR DESCRIPTION
Checked and couldn't find any tests for the .building file functionality. Not happy that this doesn't have any tests though. Any help on what tests we can add and where we can put them is highly appreciated.

Fix for #445 