### PR TITLE
Add standard_system_paths setting to set default PATH

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -227,6 +227,7 @@ config_schema = Schema({
     "packages_path":                                PathList,
     "plugin_path":                                  PathList,
     "bind_module_path":                             PathList,
+    "standard_system_paths":                        PathList,
     "package_definition_build_python_paths":        PathList,
     "implicit_packages":                            StrList,
     "platform_map":                                 OptionalDict,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -362,6 +362,16 @@ rez_tools_visibility = "append"
 # scripts (such as .bashrc). If False, package commands are sourced after.
 package_commands_sourced_first = True
 
+# Defines the basic system paths to use for the $PATH env variable. If the
+# empty list is provided (default) the existing environment setup is inspected.
+# On POSIX shells that involves inspecting __PATHS_, on Windows it involves a
+# more complicated scan of the Windows Registry. If a non-empty list of path
+# strings is provided these paths will be loaded instead; the primary use of
+# this is in curated shells where some other process or script has already
+# determined some subset or superset of the standard system defaults and wishes
+# to "hand off" those curated values to Rez.
+standard_system_paths = []
+
 # If you define this function, it will be called as the *preprocess function*
 # on every package that does not provide its own, as part of the build process.
 # The given function must be made available by setting the value of

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -61,7 +61,9 @@ class CMD(Shell):
 
     @classmethod
     def get_syspaths(cls):
-        if not cls.syspaths:
+        if cls.syspaths is None and config.standard_system_paths:
+            cls.syspaths = config.standard_system_paths
+        elif cls.syspaths is None:
             paths = []
 
             cmd = ["REG", "QUERY", "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", "/v", "PATH"]

--- a/src/rezplugins/shell/csh.py
+++ b/src/rezplugins/shell/csh.py
@@ -33,7 +33,9 @@ class CSH(UnixShell):
 
     @classmethod
     def get_syspaths(cls):
-        if not cls.syspaths:
+        if cls.syspaths is None and config.standard_system_paths:
+            cls.syspaths = config.standard_system_paths
+        elif cls.syspaths is None:
             cmd = "cmd=`which %s`; unset PATH; $cmd %s 'echo __PATHS_ $PATH'" \
                   % (cls.name(), cls.command_arg)
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE,

--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -33,7 +33,9 @@ class SH(UnixShell):
 
     @classmethod
     def get_syspaths(cls):
-        if not cls.syspaths:
+        if cls.syspaths is None and config.standard_system_paths:
+            cls.syspaths = config.standard_system_paths
+        elif cls.syspaths is None:
             cmd = "cmd=`which %s`; unset PATH; $cmd %s %s 'echo __PATHS_ $PATH'" \
                   % (cls.name(), cls.norc_arg, cls.command_arg)
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE,


### PR DESCRIPTION
It can be very helpful to configure the paths that should be part of your default PATH when rez runs. Especially under Windows where it will fall back to the registry which is horribly slow.

Hope someone else finds this useful. Let me know if there is anything we should improve before you deem it ready.