### PR TITLE
Implementing tag_exists for hg.

### DIFF
--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -152,6 +152,10 @@ class HgReleaseVCS(ReleaseVCS):
             tags[tag_name] = {'rev': rev, 'shortnode': shortnode}
         return tags
 
+    def tag_exists(self, tag_name):
+        tags = self.get_tags()
+        return (tag_name in tags.keys())
+
     def is_ancestor(self, commit1, commit2, patch=False):
         """Returns True if commit1 is a direct ancestor of commit2, or False
         otherwise.


### PR DESCRIPTION
This allows `check_tag` to work with hg.
https://github.com/nerdvegas/rez/blob/master/src/rez/rezconfig.py#L780

Originally proposed at https://groups.google.com/forum/#!topic/rez-config/Uh6HZEnN_p0
