### PR TITLE
Updated cmd.py subprocess.Popen calls to use "null" handler for stdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 *.pyc
 .project
 .pydevproject

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.14.1"
+_rez_version = "2.14.1.1"
 
 try:
     from rez.vendor.version.version import Version

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -67,9 +67,13 @@ class CMD(Shell):
             cmd = ["REG", "QUERY", "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", "/v", "PATH"]
             expected = "\r\nHKEY_LOCAL_MACHINE\\\\SYSTEM\\\\CurrentControlSet\\\\Control\\\\Session Manager\\\\Environment\r\n    PATH    REG_(EXPAND_)?SZ    (.*)\r\n\r\n"
 
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE, shell=True)
-            out_, _ = p.communicate()
+            # pass null handle to stdin in order to fix Maya handle error on windows
+            with open(os.devnull, 'w') as stdin_handle:
+                p = subprocess.Popen(cmd,
+                                     stdin=stdin_handle,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE, shell=True)
+                out_, _ = p.communicate()
 
             if p.returncode == 0:
                 match = re.match(expected, out_)
@@ -78,9 +82,12 @@ class CMD(Shell):
 
             cmd = ["REG", "QUERY", "HKCU\\Environment", "/v", "PATH"]
             expected = "\r\nHKEY_CURRENT_USER\\\\Environment\r\n    PATH    REG_(EXPAND_)?SZ    (.*)\r\n\r\n"
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE, shell=True)
-            out_, _ = p.communicate()
+            with open(os.devnull, 'w') as stdin_handle:
+                p = subprocess.Popen(cmd,
+                                     stdin=stdin_handle,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE, shell=True)
+                out_, _ = p.communicate()
 
             if p.returncode == 0:
                 match = re.match(expected, out_)


### PR DESCRIPTION
There's an issue where subprocess raises "The handle is invalid" if any of the stdio handles are not real io handles (see https://bugs.python.org/issue3905). This becomes an issue for Maya on windows if Maya is launched via cmd because of how Maya attempts to redirect stdio. Making this change allows the Rez python API to be used in Maya launched via cmd.