### PR TITLE
rez pip errors on pre-satisfied requirements

### DIFF
--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -59,7 +59,6 @@ def _get_dependencies(requirement, distributions):
             try:
                 name, version = parse_name_and_version(package)
                 version = version.replace("==", "")
-                name = get_distrubution_name(name)
             except DistlibException:
                 n, vs = package.split(' (')
                 vs = vs[:-1]
@@ -72,6 +71,12 @@ def _get_dependencies(requirement, distributions):
                 version = "".join(versions)
 
             name = get_distrubution_name(name)
+            if name is None:
+                # Occurs when pip skips installing the requirement
+                print_warning("Skipping installation: 
+                              "Requirement wasn't installed: %s" % package)
+                continue
+
             result.append("-".join([name, version]))
         else:
             name = get_distrubution_name(package)


### PR DESCRIPTION
When doing `rez-bind python`, it includes in the resulting python package any packages that were already installed via pip.

Later, when using `rez-pip`, if you install a package that has a requirement that is already included in your python package, the rez-pip command will error as it tries to pair that requirement with a distributions.

Example:
```
>> pip install six
>> rez-bind python
searching /home/tmosley/dev-local/rez/install/lib/python2.7/site-packages/rez-2.14.1-py2.7.egg/rez/bind...
creating package 'python' in /home/tmosley/packages...
...

>> rez pip -i pkg-requires-six
13:10:32 INFO     Using pip-9.0.1 (/home/tmosley/packages/pip/9.0.1/package.py[0])
...

Requirement already satisfied: six>=1.9.0 in ./packages/python/2.7.5/platform-linux/arch-x86_64/os-CentOS-7.4.1708/python/extra (from pkg-requires-six)
...

Traceback (most recent call last):
  File "/home/tmosley/dev-local/rez/install/bin/rez/rez", line 4, in <module>
    run()
  File "/home/tmosley/dev-local/rez/install/lib/python2.7/site-packages/rez-2.14.1-py2.7.egg/rez/cli/_main.py", line 118, in run
    returncode = run_cmd()
  File "/home/tmosley/dev-local/rez/install/lib/python2.7/site-packages/rez-2.14.1-py2.7.egg/rez/cli/_main.py", line 110, in run_cmd
    return opts.func(opts, opts.parser, arg_groups[1:])
  File "/home/tmosley/dev-local/rez/install/lib/python2.7/site-packages/rez-2.14.1-py2.7.egg/rez/cli/pip.py", line 46, in command
    release=opts.release)
  File "/home/tmosley/dev-local/rez/install/lib/python2.7/site-packages/rez-2.14.1-py2.7.egg/rez/pip.py", line 264, in pip_install_package
    requirements.extend(_get_dependencies(requirement, distributions))
  File "/home/tmosley/dev-local/rez/install/lib/python2.7/site-packages/rez-2.14.1-py2.7.egg/rez/pip.py", line 76, in _get_dependencies
    name = get_distrubution_name(name)
  File "/home/tmosley/dev-local/rez/install/lib/python2.7/site-packages/rez-2.14.1-py2.7.egg/rez/pip.py", line 47, in get_distrubution_name
    pip_to_rez_name = pip_name.lower().replace("-", "_")
AttributeError: 'NoneType' object has no attribute 'lower'
```

This happens because when pip skips installing something it doesn't get added to `distributions`. When that occurs, `get_distrubution_name` return `None`. I believe it's also a bug that `get_distrubtion_name` is called twice when `parse_name_and_version` successfully returns a package name.

This fixes both of those issues.