### PR TITLE
Fix for the undefined var method parent_variables

### DIFF
--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -254,7 +254,8 @@ class ActionManager(object):
     def undefined(self, key):
         _, expanded_key = self._key(key)
         return (expanded_key not in self.environ
-                and expanded_key not in self.parent_environ)
+            and (expanded_key not in self.parent_environ 
+                or expanded_key not in self.parent_variables))
 
     def defined(self, key):
         return not self.undefined(key)


### PR DESCRIPTION
I Propose to check not only if the var is defined within the parent env, but also if the variable will be herited by the new context.