### PR TITLE
rez-build continue on context error

### DIFF
--- a/src/rez/build_process_.py
+++ b/src/rez/build_process_.py
@@ -175,17 +175,21 @@ class BuildProcessHelper(BuildProcess):
         # iterate over variants
         results = []
         num_visited = 0
+        num_error = 0
 
         for variant in self.package.iter_variants():
-            if variants and variant.index not in variants:
-                self._print_header("Skipping %s..." % self._n_of_m(variant))
-                continue
+            try:
+                if variants and variant.index not in variants:
+                    self._print_header("Skipping %s..." % self._n_of_m(variant))
+                    continue
 
-            result = func(variant, **kwargs)
-            results.append(result)
-            num_visited += 1
+                result = func(variant, **kwargs)
+                results.append(result)
+                num_visited += 1
+            except BuildContextResolveError:
+                num_error += 1
 
-        return num_visited, results
+        return num_visited, num_error, results
 
     def get_package_install_path(self, path):
         """Return the installation path for a package (where its payload goes).

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -28,7 +28,7 @@ class LocalBuildProcess(BuildProcessHelper):
         self._print_header("Building %s..." % self.package.qualified_name)
 
         # build variants
-        num_visited, build_env_scripts = self.visit_variants(
+        num_visited, num_error, build_env_scripts = self.visit_variants(
             self._build_variant,
             variants=variants,
             install_path=install_path,
@@ -44,7 +44,7 @@ class LocalBuildProcess(BuildProcessHelper):
             self._print('\n'.join(build_env_scripts))
             self._print('')
         else:
-            self._print("\nAll %d build(s) were successful.\n", num_visited)
+            self._print("\n%d of %d build(s) were successful.\n", num_visited, num_visited + num_error)
         return num_visited
 
     def release(self, release_message=None, variants=None):
@@ -70,7 +70,7 @@ class LocalBuildProcess(BuildProcessHelper):
                        previous_revision=previous_revision)
 
         # release variants
-        num_visited, released_variants = self.visit_variants(
+        num_visited, num_error, released_variants = self.visit_variants(
             self._release_variant,
             variants=variants,
             release_message=release_message)
@@ -92,7 +92,7 @@ class LocalBuildProcess(BuildProcessHelper):
             self.post_release(release_message=release_message)
 
         if self.verbose:
-            msg = "\n%d of %d releases were successful" % (num_released, num_visited)
+            msg = "\n%d of %d releases were successful" % (num_released, num_visited + num_error)
             if num_released < num_visited:
                 Printer()(msg, warning)
             else:


### PR DESCRIPTION
Catching buildContextResolveError from the build_process_.py file.
Adding an num_error variable to print out how many build/release were successful