### PR TITLE
Fix selftest by isolating changes in test environment

### DIFF
--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -1,7 +1,7 @@
 """
 test resolved contexts
 """
-from rez.tests.util import TestBase, TempdirMixin
+from rez.tests.util import os_environ, sys_path, TempdirMixin, TestBase
 from rez.resolved_context import ResolvedContext
 from rez.bind import hello_world
 from rez.utils.platform_ import platform_
@@ -41,9 +41,12 @@ class TestContext(TestBase, TempdirMixin):
 
     def test_apply(self):
         """Test apply() function."""
-        r = ResolvedContext(["hello_world"])
-        r.apply()
-        self.assertEqual(os.environ.get("OH_HAI_WORLD"), "hello")
+        # Isolate our changes to os.environ and sys.path and return to the
+        # original state to not mess with our test environment.
+        with os_environ(), sys_path():
+            r = ResolvedContext(["hello_world"])
+            r.apply()
+            self.assertEqual(os.environ.get("OH_HAI_WORLD"), "hello")
 
     def test_execute_command(self):
         """Test command execution in context."""

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -7,6 +7,8 @@ import shutil
 import os.path
 import os
 import functools
+import sys
+from contextlib import contextmanager
 
 
 class TestBase(unittest.TestCase):
@@ -243,6 +245,59 @@ def get_cli_output(args):
         sys.argv = old_argv
 
     return output, exitcode
+
+
+@contextmanager
+def sys_path():
+    """Encapsulate changes to sys.path and return to the original state.
+
+    This context manager lets you wrap modifications of sys.path and not worry
+    about reverting back to the original.
+
+    Examples:
+        >>> path = '/arbitrary/path'
+        >>> with sys_path():
+        >>>     sys.path.insert(0, '/arbitrary/path')
+        >>>     assert path in sys.path
+        True
+
+        >>> assert path in sys.path
+        False
+
+    Yields:
+        list: The original sys.path.
+
+    """
+    original = sys.path[:]
+    yield sys.path
+    sys.path = original
+
+
+@contextmanager
+def os_environ():
+    """Encapsulate changes to os.environ and return to the original state.
+
+    This context manager lets you wrap modifications of os.environ and not
+    worry about reverting back to the original.
+
+    Examples:
+        >>> key = 'ARBITRARY_KEY'
+        >>> value = 'arbitrary_value'
+        >>> with os_environ():
+        >>>     os.environ[key] = value
+        >>>     assert key in os.environ
+        True
+
+        >>> assert key in os.environ
+        False
+
+    Yields:
+        dict: The original os.environ.
+
+    """
+    original = os.environ.copy()
+    yield os.environ
+    os.environ = original
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
Fixes #480 by using two context managers to isolate the changes to `os.environ` and `sys.path` and not letting `apply()` dirty the test environment.