### PR TITLE
Fix alias command in Windows when PATH is modified

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -273,6 +273,40 @@ class TestShells(TestBase, TempdirMixin):
 
         _execute_code(_rex_appending, expected_output)
 
+    @shell_dependent()
+    def test_rex_code_alias(self):
+        """Ensure PATH changes do not influence the alias command.
+
+        This is important for Windows because the doskey.exe might not be on
+        the PATH anymore at the time it's executed. That's why we use the full
+        path to doskey.exe and figure out the path to it before we modify the
+        PATH.
+
+        """
+        def _execute_code(func):
+            loc = inspect.getsourcelines(func)[0][1:]
+            code = textwrap.dedent('\n'.join(loc))
+            r = self._create_context([])
+            p = r.execute_rex_code(code, stdout=subprocess.PIPE)
+
+            out, _ = p.communicate()
+            self.assertEqual(p.returncode, 0)
+
+        def _alias_after_path_manipulation():
+            # Appending something to the PATH and creating an alias afterwards
+            # did fail before we implemented a doskey specific fix.
+            env.PATH.append("hey")
+            alias('alias_test', '"echo test_echo"')
+
+            # We can not run the command from a batch file because the Windows
+            # doskey doesn't support it. From the docs:
+            # "You cannot run a doskey macro from a batch program."
+            # command('alias_test')
+
+        # We don't expect any output, the shell should just return with exit
+        # code 0.
+        _execute_code(_alias_after_path_manipulation)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -278,9 +278,9 @@ class TestShells(TestBase, TempdirMixin):
         """Ensure PATH changes do not influence the alias command.
 
         This is important for Windows because the doskey.exe might not be on
-        the PATH anymore at the time it's executed. That's why we use the full
-        path to doskey.exe and figure out the path to it before we modify the
-        PATH.
+        the PATH anymore at the time it's executed. That's why we figure out
+        the absolute path to doskey.exe before we modify PATH and continue to
+        use the absolute path after the modifications.
 
         """
         def _execute_code(func):


### PR DESCRIPTION
Fixes #389, fixes #343

Includes an easy test to see if the `alias` command works after modifying the `PATH` on Windows. This is not meant to be a fix for how to deal with `PATH` and modifications to it. It's just about the `alias` command and not getting anymore errors in Windows when using it.