### PR TITLE
Clarify what variant number is currently building

### DIFF
--- a/src/rez/build_process_.py
+++ b/src/rez/build_process_.py
@@ -178,7 +178,9 @@ class BuildProcessHelper(BuildProcess):
 
         for variant in self.package.iter_variants():
             if variants and variant.index not in variants:
-                self._print_header("Skipping %s..." % self._n_of_m(variant))
+                self._print_header(
+                    "Skipping variant %s (%s)..."
+                    % (variant.index, self._n_of_m(variant)))
                 continue
 
             result = func(variant, **kwargs)

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -181,7 +181,9 @@ class LocalBuildProcess(BuildProcessHelper):
     def _build_variant(self, variant, install_path=None, clean=False,
                        install=False, **kwargs):
         if variant.index is not None:
-            self._print_header("Building variant %s..." % self._n_of_m(variant))
+            self._print_header(
+                "Building variant %s (%s)..."
+                % (variant.index, self._n_of_m(variant)))
 
         # build and possibly install variant
         install_path = install_path or self.package.config.local_packages_path


### PR DESCRIPTION
Fixes #466.

Clarify what variant number is currently building or being skipped. I didn't bother writing a test for this addition to two print statements, hope that's ok.