### PR TITLE
Update print statements to be Python 3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Resolved environments can also be created via the API:
     >>> p = r.execute_shell(command='which hescape', stdout=subprocess.PIPE)
     >>> out, err = p.communicate()
     >>>
-    >>> print out
+    >>> print(out)
     '/software/ext/houdini/12.5.562/bin/hescape'
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,7 +90,7 @@ Resolved environments can also be created programmatically:
     >>> p = r.execute_shell(command='which hescape', stdout=subprocess.PIPE)
     >>> stdout,stderr = p.communicate()
     >>>
-    >>> print stdout
+    >>> print(stdout)
     '/software/ext/houdini/12.5.562/bin/hescape'
 
 Features

--- a/example_packages/hello_world/python/hello_world.py
+++ b/example_packages/hello_world/python/hello_world.py
@@ -1,4 +1,4 @@
 
 
 def hello():
-    print "Hello world!"
+    print("Hello world!")

--- a/example_packages/hello_world/rezbuild.py.example
+++ b/example_packages/hello_world/rezbuild.py.example
@@ -36,8 +36,8 @@ def build(source_path, build_path, install_path, targets):
             if os.path.exists(dest):
                 shutil.rmtree(dest)
 
-            print src
-            print dest
+            print(src)
+            print(dest)
             shutil.copytree(src, dest)
 
     _build()

--- a/install.py
+++ b/install.py
@@ -2,6 +2,8 @@
 This script uses an embedded copy of virtualenv to create a standalone,
 production-ready Rez installation in the specified directory.
 """
+from __future__ import print_function
+
 import os
 import sys
 import shutil
@@ -128,7 +130,7 @@ if __name__ == "__main__":
     if not opts.keep_symlinks:
         dest_dir = os.path.realpath(dest_dir)
 
-    print "installing rez to %s..." % dest_dir
+    print("installing rez to %s..." % dest_dir)
 
     # make virtualenv verbose
     log_level = Logger.level_for_integer(2 - opts.verbose)
@@ -144,7 +146,7 @@ if __name__ == "__main__":
                                                                   "")})
     args = [py_executable, "setup.py", "install"]
     if opts.verbose:
-        print "running in %s: %s" % (source_path, " ".join(args))
+        print("running in %s: %s" % (source_path, " ".join(args)))
     p = subprocess.Popen(args, cwd=source_path)
     p.wait()
 
@@ -161,11 +163,11 @@ if __name__ == "__main__":
         f.write(_rez_version)
 
     # done
-    print
-    print "SUCCESS! To activate Rez, add the following path to $PATH:"
-    print dest_bin_dir
+    print()
+    print("SUCCESS! To activate Rez, add the following path to $PATH:")
+    print(dest_bin_dir)
 
     if completion_path:
-        print "You may also want to source the relevant completion script from:"
-        print completion_path
-    print
+        print("You may also want to source the relevant completion script from:")
+        print(completion_path)
+    print()

--- a/repository/hello_world_py/1.0.0/python/hello_world.py
+++ b/repository/hello_world_py/1.0.0/python/hello_world.py
@@ -1,4 +1,5 @@
+from __future__ import print_function
 
 
 def hello():
-    print "Hello world!"
+    print("Hello world!")

--- a/repository/tbb/4.3/install.py
+++ b/repository/tbb/4.3/install.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import shutil
 import os
@@ -6,7 +8,7 @@ from fnmatch import fnmatch
 
 
 def copytree(src, dest):
-    print "copying %s -> %s..." % (src, dest)
+    print("copying %s -> %s..." % (src, dest))
     if os.path.exists(dest):
         shutil.rmtree(dest)
     shutil.copytree(src, dest)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from __future__ import with_statement
+from __future__ import print_function, with_statement
+
 import fnmatch
 import os
 import os.path
@@ -8,12 +9,12 @@ import sys
 try:
     from setuptools import setup, find_packages
 except ImportError:
-    print >> sys.stderr, "install failed - requires setuptools"
+    print("install failed - requires setuptools", file=sys.stderr)
     sys.exit(1)
 
 
 if sys.version_info < (2, 6):
-    print >> sys.stderr, "install failed - requires python v2.6 or greater"
+    print("install failed - requires python v2.6 or greater", file=sys.stderr)
     sys.exit(1)
 
 

--- a/src/build_utils/add_license.py
+++ b/src/build_utils/add_license.py
@@ -2,6 +2,8 @@
 Adds LGPL and Copyright notice to the end of each .py file. You need to run
 this script from the src/ subdirectory of the rez source.
 """
+from __future__ import print_function
+
 import os
 import os.path
 from datetime import datetime
@@ -72,7 +74,7 @@ if __name__ == "__main__":
         for name in names:
             if name.endswith(".py"):
                 filepath = os.path.join(root, name)
-                print "found: %s" % filepath
+                print("found: %s" % filepath)
                 filepaths.append(filepath)
 
         for dirname in skip_dirs:
@@ -110,6 +112,6 @@ if __name__ == "__main__":
 
         new_txt = '\n'.join(lines)
 
-        print "Writing updated %s..." % filepath
+        print("Writing updated %s..." % filepath)
         with open(filepath, 'w') as f:
             f.write(new_txt)

--- a/src/build_utils/distlib/compat.py
+++ b/src/build_utils/distlib/compat.py
@@ -4,7 +4,7 @@
 # Licensed to the Python Software Foundation under a contributor agreement.
 # See LICENSE.txt and CONTRIBUTORS.txt.
 #
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 import re
@@ -1028,7 +1028,7 @@ except ImportError: # pragma: no cover
             else:
                 rest = rest[m.end():]
                 d = self.config[m.groups()[0]]
-                #print d, rest
+                # print(d, rest)
                 while rest:
                     m = self.DOT_PATTERN.match(rest)
                     if m:

--- a/src/build_utils/make_README.py
+++ b/src/build_utils/make_README.py
@@ -3,7 +3,8 @@ Generates the RestructuredText 'README' file from the markdown 'README.md' file.
 Be careful: it isn't foolproof, use of fancier markdown features will probably
 break it. The README file is used by Pypi to create the Rez frontpage.
 """
-from __future__ import with_statement
+from __future__ import print_function, with_statement
+
 import os.path
 
 
@@ -82,4 +83,4 @@ if __name__ == "__main__":
     with open(readme, 'w') as f:
         f.write('\n'.join(dest))
 
-    print "README was written"
+    print("README was written")

--- a/src/rez/__init__.py
+++ b/src/rez/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.utils._version import _rez_version
 import logging.config
 import atexit
@@ -26,8 +28,8 @@ if action:
     if action == "print_stack":
         def callback(sig, frame):
             txt = ''.join(traceback.format_stack(frame))
-            print
-            print txt
+            print()
+            print(txt)
     else:
         callback = None
 

--- a/src/rez/bind/PyQt.py
+++ b/src/rez/bind/PyQt.py
@@ -14,7 +14,7 @@ def bind(path, version_range=None, opts=None, parser=None):
     version = get_version_in_python(
         name,
         ["from PyQt4 import QtCore",
-         "print QtCore.PYQT_VERSION_STR"])
+         "print(QtCore.PYQT_VERSION_STR)"])
 
     variants = _pymodule.bind(name,
                               path=path,

--- a/src/rez/bind/_pymodule.py
+++ b/src/rez/bind/_pymodule.py
@@ -5,7 +5,8 @@ Note that we subproc out to python at various points here because we can't use
 the current python interpreter - this is rez's, inside its installation
 virtualenv.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
 from rez.bind._utils import check_version, find_exe, make_dirs, \
     get_version_in_python, run_python_command, log
 from rez.package_maker__ import make_package
@@ -30,7 +31,7 @@ def commands_with_bin():
 def copy_module(name, destpath):
     success, out, err = run_python_command(
         ["import %s" % name,
-         "print %s.__path__[0] if hasattr(%s, '__path__') else ''" % (name, name)])
+         "print(%s.__path__[0] if hasattr(%s, '__path__') else '')" % (name, name)])
 
     if out:
         srcpath = out
@@ -38,7 +39,7 @@ def copy_module(name, destpath):
     else:
         success, out, err = run_python_command(
             ["import %s" % name,
-             "print %s.__file__" % name])
+             "print(%s.__file__)" % name])
         if not success:
             raise RezBindError("Couldn't locate module %s: %s" % (name, err))
 
@@ -63,7 +64,7 @@ def bind(name, path, import_name=None, version_range=None, version=None,
         version = get_version_in_python(
             name,
             ["import %s" % import_name,
-             "print %s.__version__" % import_name])
+             "print(%s.__version__)" % import_name])
 
     check_version(version, version_range)
 

--- a/src/rez/bind/hello_world.py
+++ b/src/rez/bind/hello_world.py
@@ -5,7 +5,8 @@ Note: Even though this is a python-based package, it does not list python as a
 requirement. This is not typical! This package is intended as a very simple test
 case, and for that reason we do not want any dependencies.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
 from rez.package_maker__ import make_package
 from rez.vendor.version.version import Version
 from rez.utils.lint_helper import env
@@ -31,7 +32,7 @@ def hello_world_source():
     opts,args = p.parse_args()
 
     if not opts.quiet:
-        print "Hello Rez World!"
+        print("Hello Rez World!")
     sys.exit(opts.retcode)
 
 

--- a/src/rez/bind/python.py
+++ b/src/rez/bind/python.py
@@ -37,7 +37,7 @@ def post_commands():
 def bind(path, version_range=None, opts=None, parser=None):
     # find executable, determine version
     exepath = find_exe("python", opts.exe)
-    code = "import sys; print '.'.join(str(x) for x in sys.version_info)"
+    code = "import sys; print('.'.join(str(x) for x in sys.version_info))"
     version = extract_version(exepath, ["-c", code])
 
     check_version(version, version_range)
@@ -51,7 +51,7 @@ def bind(path, version_range=None, opts=None, parser=None):
     for dirname, module_name in entries:
         success, out, err = run_python_command([
             "import %s" % module_name,
-            "print %s.__file__" % module_name])
+            "print(%s.__file__)" % module_name])
 
         if success:
             pypath = os.path.dirname(out)

--- a/src/rez/bind/sip.py
+++ b/src/rez/bind/sip.py
@@ -12,7 +12,7 @@ def bind(path, version_range=None, opts=None, parser=None):
     version = get_version_in_python(
         name,
         ["import sip",
-         "print sip.SIP_VERSION_STR"])
+         "print(sip.SIP_VERSION_STR)"])
 
     variants = _pymodule.bind(name,
                               path=path,

--- a/src/rez/build_process_.py
+++ b/src/rez/build_process_.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.packages_ import get_developer_package, iter_packages
 from rez.exceptions import BuildProcessError, BuildContextResolveError, \
     ReleaseHookCancellingError, RezError, ReleaseError, BuildError, \
@@ -383,7 +385,7 @@ class BuildProcessHelper(BuildProcess):
         if self.verbose:
             if nargs:
                 txt = txt % nargs
-            print txt
+            print(txt)
 
     def _print_header(self, txt, n=1):
         self._print('')

--- a/src/rez/cli/_bez.py
+++ b/src/rez/cli/_bez.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 import os.path
@@ -20,7 +22,7 @@ def run():
     # check necessary files, load info about the build
     for file in ("build.rxt", ".bez.yaml"):
         if not os.path.isfile(file):
-            print >> sys.stderr, "no %s file found. Stop." % file
+            print("no %s file found. Stop." % file, file=sys.stderr)
             sys.exit(1)
 
     with open(".bez.yaml") as f:
@@ -29,7 +31,7 @@ def run():
     source_path = doc["source_path"]
     buildfile = os.path.join(source_path, "rezbuild.py")
     if not os.path.isfile(buildfile):
-        print >> sys.stderr, "no rezbuild.py at %s. Stop." % source_path
+        print("no rezbuild.py at %s. Stop." % source_path, file=sys.stderr)
         sys.exit(1)
 
     # run rezbuild.py:build() in python subprocess. Cannot import module here
@@ -43,7 +45,7 @@ def run():
     buildfunc = env.get("build")
     if not buildfunc:
         import sys
-        print >> sys.stderr, "Did not find function 'build' in rezbuild.py"
+        print("Did not find function 'build' in rezbuild.py", file=sys.stderr)
         sys.exit(1)
 
     kwargs = dict(source_path="%(srcpath)s",
@@ -72,7 +74,7 @@ def run():
     with open(bezfile, "w") as fd:
         fd.write(cli_code)
 
-    print "executing rezbuild.py..."
+    print("executing rezbuild.py...")
     cmd = ["python", bezfile]
     p = subprocess.Popen(cmd)
     p.wait()

--- a/src/rez/cli/_bez.py
+++ b/src/rez/cli/_bez.py
@@ -38,6 +38,8 @@ def run():
     # because we're in a python env configured for rez, not the build
     code = \
     """
+    from __future__ import print_function
+
     stream=open("%(buildfile)s")
     env={}
     exec stream in env

--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -1,6 +1,8 @@
 """
 The main command-line entry point.
 """
+from __future__ import print_function
+
 import sys
 from rez.vendor.argparse import _StoreTrueAction, SUPPRESS
 from rez.cli._util import subcommands, LazyArgumentParser, _env_var_true
@@ -28,7 +30,7 @@ class SetupRezSubParser(object):
             error_msg = "command module %s  must provide a setup_parser() " \
                 "function" % self.module_name
         if error_msg:
-            print >> sys.stderr, error_msg
+            print(error_msg, file=sys.stderr)
             return SUPPRESS
 
         mod.setup_parser(parser)
@@ -60,9 +62,9 @@ class InfoAction(_StoreTrueAction):
     def __call__(self, parser, args, values, option_string=None):
         from rez.system import system
         txt = system.get_summary_string()
-        print
-        print txt
-        print
+        print()
+        print(txt)
+        print()
         sys.exit(0)
 
 
@@ -120,7 +122,7 @@ def run(command=None):
             raise
         except exc_type as e:
             print_error("%s: %s" % (e.__class__.__name__, str(e)))
-            #print >> sys.stderr, "rez: %s: %s" % (e.__class__.__name__, str(e))
+            # print("rez: %s: %s" % (e.__class__.__name__, str(e)), file=sys.stderr)
             sys.exit(1)
 
     sys.exit(returncode or 0)

--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 import signal
@@ -125,7 +127,7 @@ def sigint_handler(signum, frame):
     if not _handled_int:
         _handled_int = True
         if not _env_var_true("_REZ_QUIET_ON_SIG"):
-            print >> sys.stderr, "Interrupted by user"
+            print("Interrupted by user", file=sys.stderr)
         sigbase_handler(signum, frame)
 
 
@@ -135,7 +137,7 @@ def sigterm_handler(signum, frame):
     if not _handled_term:
         _handled_term = True
         if not _env_var_true("_REZ_QUIET_ON_SIG"):
-            print >> sys.stderr, "Terminated by user"
+            print("Terminated by user", file=sys.stderr)
         sigbase_handler(signum, frame)
 
 

--- a/src/rez/cli/bind.py
+++ b/src/rez/cli/bind.py
@@ -1,6 +1,8 @@
 '''
 Create a Rez package for existing software.
 '''
+from __future__ import print_function
+
 from rez.vendor import argparse
 
 
@@ -51,7 +53,7 @@ def command(opts, parser, extra_arg_groups=None):
         rows = [["PACKAGE", "BIND MODULE"],
                 ["-------", "-----------"]]
         rows += sorted(d.items())
-        print '\n'.join(columnise(rows))
+        print('\n'.join(columnise(rows)))
         return
 
     if opts.quickstart:
@@ -68,7 +70,7 @@ def command(opts, parser, extra_arg_groups=None):
         variants = []
 
         for name in names:
-            print "Binding %s into %s..." % (name, install_path)
+            print("Binding %s into %s..." % (name, install_path))
             variants_ = bind_package(name,
                                      path=install_path,
                                      no_deps=True,
@@ -76,13 +78,13 @@ def command(opts, parser, extra_arg_groups=None):
             variants.extend(variants_)
 
         if variants:
-            print ("\nSuccessfully converted the following software found on "
-                   "the current system into Rez packages:")
-            print
+            print("\nSuccessfully converted the following software found on "
+                  "the current system into Rez packages:")
+            print()
             _print_package_list(variants)
 
-        print ("\nTo bind other software, see what's available using the "
-               "command 'rez-bind --list', then run 'rez-bind <name>'.\n")
+        print("\nTo bind other software, see what's available using the "
+              "command 'rez-bind --list', then run 'rez-bind <name>'.\n")
 
         return
 

--- a/src/rez/cli/build.py
+++ b/src/rez/cli/build.py
@@ -1,6 +1,8 @@
 '''
 Build a package from source.
 '''
+from __future__ import print_function
+
 import os
 
 
@@ -127,7 +129,7 @@ def command(opts, parser, extra_arg_groups=None):
                       install=opts.install,
                       variants=opts.variants)
     except BuildContextResolveError as e:
-        print >> sys.stderr, str(e)
+        print(str(e), file=sys.stderr)
 
         if opts.fail_graph:
             if e.context.graph:
@@ -135,8 +137,8 @@ def command(opts, parser, extra_arg_groups=None):
                 g = e.context.graph(as_dot=True)
                 view_graph(g)
             else:
-                print >> sys.stderr, \
-                    "the failed resolve context did not generate a graph."
+                print("the failed resolve context did not generate a graph.",
+                      file=sys.stderr)
         sys.exit(1)
 
 

--- a/src/rez/cli/complete.py
+++ b/src/rez/cli/complete.py
@@ -1,6 +1,8 @@
 """
 Prints package completion strings.
 """
+from __future__ import print_function
+
 from rez.vendor import argparse
 
 
@@ -56,7 +58,7 @@ def command(opts, parser, extra_arg_groups=None):
         cmds = set(subcommands) - set(hidden_subcommands)
         if prefix:
             cmds = (x for x in cmds if x.startswith(prefix))
-        print " ".join(cmds)
+        print(" ".join(cmds))
 
     if subcommand not in subcommands:
         return
@@ -93,7 +95,7 @@ def command(opts, parser, extra_arg_groups=None):
                                     comp_line=comp_line,
                                     comp_point=comp_point)
     words = completer.completions
-    print ' '.join(words)
+    print(' '.join(words))
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/cli/config.py
+++ b/src/rez/cli/config.py
@@ -1,6 +1,7 @@
 '''
 Print current rez settings.
 '''
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -25,12 +26,12 @@ def command(opts, parser, extra_arg_groups=None):
 
     if opts.search_list:
         for filepath in config.filepaths:
-            print filepath
+            print(filepath)
         return
 
     if opts.source_list:
         for filepath in config.sourced_filepaths:
-            print filepath
+            print(filepath)
         return
 
     data = config.data
@@ -46,9 +47,9 @@ def command(opts, parser, extra_arg_groups=None):
 
     if isinstance(data, (dict, list)):
         txt = dump_yaml(data).strip()
-        print txt
+        print(txt)
     else:
-        print data
+        print(data)
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/cli/context.py
+++ b/src/rez/cli/context.py
@@ -1,6 +1,8 @@
 '''
 Print information about the current rez context, or a given context file.
 '''
+from __future__ import print_function
+
 import sys
 from rez.rex import OutputStyle
 
@@ -102,7 +104,7 @@ def command(opts, parser, extra_arg_groups=None):
 
     rxt_file = opts.RXT if opts.RXT else status.context_file
     if not rxt_file:
-        print >> sys.stderr, "not in a resolved environment context."
+        print("not in a resolved environment context.", file=sys.stderr)
         sys.exit(1)
 
     if rxt_file == '-':  # read from stdin
@@ -114,16 +116,16 @@ def command(opts, parser, extra_arg_groups=None):
         if rc.has_graph:
             return rc.graph(as_dot=True)
         else:
-            print >> sys.stderr, "The context does not contain a graph."
+            print("The context does not contain a graph.", file=sys.stderr)
             sys.exit(1)
 
     parent_env = {} if opts.no_env else None
 
     if not opts.interpret:
         if opts.print_request:
-            print " ".join(str(x) for x in rc.requested_packages(False))
+            print(" ".join(str(x) for x in rc.requested_packages(False)))
         elif opts.print_resolve:
-            print ' '.join(x.qualified_package_name for x in rc.resolved_packages)
+            print(' '.join(x.qualified_package_name for x in rc.resolved_packages))
         elif opts.tools:
             rc.print_tools()
         elif opts.diff:
@@ -138,12 +140,12 @@ def command(opts, parser, extra_arg_groups=None):
             cmd = opts.which
             path = rc.which(cmd, parent_environ=parent_env)
             if path:
-                print path
+                print(path)
             else:
-                print >> sys.stderr, "'%s' not found in the context" % cmd
+                print("'%s' not found in the context" % cmd, file=sys.stderr)
         elif opts.print_graph:
             gstr = _graph()
-            print gstr
+            print(gstr)
         elif opts.graph or opts.write_graph:
             gstr = _graph()
             if opts.prune_pkg:
@@ -162,16 +164,16 @@ def command(opts, parser, extra_arg_groups=None):
 
         if opts.format == 'table':
             rows = [x for x in sorted(env.iteritems())]
-            print '\n'.join(columnise(rows))
+            print('\n'.join(columnise(rows)))
         elif opts.format == 'dict':
-            print pformat(env)
+            print(pformat(env))
         else:  # json
-            print json.dumps(env, sort_keys=True, indent=4)
+            print(json.dumps(env, sort_keys=True, indent=4))
     else:
         code = rc.get_shell_code(shell=opts.format,
                                  parent_environ=parent_env,
                                  style=OutputStyle[opts.style])
-        print code
+        print(code)
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/cli/depends.py
+++ b/src/rez/cli/depends.py
@@ -1,6 +1,7 @@
 """
 Perform a reverse package dependency lookup.
 """
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -64,7 +65,7 @@ def command(opts, parser, extra_arg_groups=None):
     if opts.graph or opts.print_graph or opts.write_graph:
         gstr = write_dot(g)
         if opts.print_graph:
-            print gstr
+            print(gstr)
         elif opts.write_graph:
             save_graph(gstr, dest_file=opts.write_graph)
         else:
@@ -76,7 +77,7 @@ def command(opts, parser, extra_arg_groups=None):
             toks = pkgs
         else:
             toks = ["#%d:" % i] + pkgs
-        print ' '.join(toks)
+        print(' '.join(toks))
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/cli/env.py
+++ b/src/rez/cli/env.py
@@ -1,6 +1,7 @@
 '''
 Open a rez-configured shell, possibly interactive.
 '''
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -160,7 +161,7 @@ def command(opts, parser, extra_arg_groups=None):
             parser.error("Cannot use --input and provide PKG(s) at the same time")
         context = ResolvedContext.load(opts.input)
         if context.status != ResolverStatus.solved:
-            print >> sys.stderr, "cannot rez-env into a failed context"
+            print("cannot rez-env into a failed context", file=sys.stderr)
             sys.exit(1)
 
     if opts.patch:
@@ -170,7 +171,7 @@ def command(opts, parser, extra_arg_groups=None):
             from rez.status import status
             context = status.context
             if context is None:
-                print >> sys.stderr, "cannot patch: not in a context"
+                print("cannot patch: not in a context", file=sys.stderr)
                 sys.exit(1)
 
         request = context.get_patched_request(request,
@@ -216,8 +217,8 @@ def command(opts, parser, extra_arg_groups=None):
                 g = context.graph(as_dot=True)
                 view_graph(g)
             else:
-                print >> sys.stderr, \
-                    "the failed resolve context did not generate a graph."
+                print("the failed resolve context did not generate a graph.",
+                      file=sys.stderr)
 
     if opts.output:
         if opts.output == '-':  # print to stdout

--- a/src/rez/cli/help.py
+++ b/src/rez/cli/help.py
@@ -1,6 +1,7 @@
 """
 Utility for displaying help for the given package.
 """
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -37,17 +38,17 @@ def command(opts, parser=None, extra_arg_groups=None):
     help_ = PackageHelp(request.name, request.range, verbose=opts.verbose)
     if not help_.success:
         msg = "Could not find a package with help for %r." % request
-        print >> sys.stderr, msg
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
     package = help_.package
-    print "Help found for:"
-    print package.uri
+    print("Help found for:")
+    print(package.uri)
     if package.description:
-        print
-        print "Description:"
-        print package.description.strip()
-        print
+        print()
+        print("Description:")
+        print(package.description.strip())
+        print()
 
     if opts.entries:
         help_.print_info()
@@ -55,7 +56,7 @@ def command(opts, parser=None, extra_arg_groups=None):
         try:
             help_.open(opts.SECTION - 1)
         except IndexError:
-            print >> sys.stderr, "No such help section."
+            print("No such help section.", file=sys.stderr)
             sys.exit(2)
 
 

--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -1,6 +1,7 @@
 '''
 Execute some Rex code and print the interpreted result.
 '''
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -68,11 +69,11 @@ def command(opts, parser, extra_arg_groups=None):
     if isinstance(o, dict):
         if opts.format == "table":
             rows = [x for x in sorted(o.iteritems())]
-            print '\n'.join(columnise(rows))
+            print('\n'.join(columnise(rows)))
         else:
-            print pformat(o)
+            print(pformat(o))
     else:
-        print o
+        print(o)
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/cli/memcache.py
+++ b/src/rez/cli/memcache.py
@@ -1,6 +1,7 @@
 """
 Manage and query memcache server(s).
 """
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -26,8 +27,8 @@ def poll(client, interval):
     import time
 
     prev_entry = None
-    print "%-64s %-16s %-16s %-16s %-16s %-16s" \
-        % ("SERVER", "CONNS", "GET/s", "SET/s", "TEST_GET", "TEST_SET")
+    print("%-64s %-16s %-16s %-16s %-16s %-16s"
+          % ("SERVER", "CONNS", "GET/s", "SET/s", "TEST_GET", "TEST_SET"))
 
     while True:
         stats = dict(client.get_stats())
@@ -59,9 +60,9 @@ def poll(client, interval):
 
                     nconns = int(payload["curr_connections"])
 
-                    print "%-64s %-16d %-16g %-16g %-16g %-16g" \
-                        % (instance, nconns, gets_per_sec, sets_per_sec,
-                           test_get, test_set)
+                    print("%-64s %-16d %-16g %-16g %-16g %-16g"
+                          % (instance, nconns, gets_per_sec, sets_per_sec,
+                             test_get, test_set))
 
         prev_entry = entry
         time.sleep(interval)
@@ -79,7 +80,7 @@ def command(opts, parser, extra_arg_groups=None):
                              debug=config.debug_memcache)
 
     if not memcache_client:
-        print >> sys.stderr, "memcaching is not enabled."
+        print("memcaching is not enabled.", file=sys.stderr)
         sys.exit(1)
 
     if opts.poll:
@@ -88,23 +89,23 @@ def command(opts, parser, extra_arg_groups=None):
 
     if opts.flush:
         memcache_client.flush(hard=True)
-        print "memcached servers are flushed."
+        print("memcached servers are flushed.")
         return
 
     if opts.reset_stats:
         memcache_client.reset_stats()
-        print "memcached servers are stat reset."
+        print("memcached servers are stat reset.")
         return
 
     def _fail():
-        print >> sys.stderr, "memcached servers are not responding."
+        print("memcached servers are not responding.", file=sys.stderr)
         sys.exit(1)
 
     stats = memcache_client.get_stats()
     if opts.stats:
         if stats:
             txt = dump_yaml(stats)
-            print txt
+            print(txt)
         else:
             _fail()
         return
@@ -138,7 +139,7 @@ def command(opts, parser, extra_arg_groups=None):
                "%s (%d%%)" % (readable_memory_size(used), used_percent))
 
         rows.append(row)
-    print '\n'.join(columnise(rows))
+    print('\n'.join(columnise(rows)))
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -1,6 +1,7 @@
 """
 Install a pip-compatible python package, and its dependencies, as rez packages.
 """
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -53,23 +54,23 @@ def command(opts, parser, extra_arg_groups=None):
         txt = "%s: %s" % (pkg.qualified_name, pkg.uri)
         if v.subpath:
             txt += " (%s)" % v.subpath
-        print "  " + txt
+        print("  " + txt)
 
-    print
+    print()
     if installed_variants:
-        print "%d packages were installed:" % len(installed_variants)
+        print("%d packages were installed:" % len(installed_variants))
         for variant in installed_variants:
             print_variant(variant)
     else:
-        print "NO packages were installed."
+        print("NO packages were installed.")
 
     if skipped_variants:
-        print
-        print "%d packages were already installed:" % len(skipped_variants)
+        print()
+        print("%d packages were already installed:" % len(skipped_variants))
         for variant in skipped_variants:
             print_variant(variant)
 
-    print
+    print()
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/cli/plugins.py
+++ b/src/rez/cli/plugins.py
@@ -1,6 +1,7 @@
 """
 Get a list of a package's plugins.
 """
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -33,9 +34,9 @@ def command(opts, parser, extra_arg_groups=None):
 
     pkgs_list = get_plugins(package_name=opts.PKG, paths=pkg_paths)
     if pkgs_list:
-        print '\n'.join(pkgs_list)
+        print('\n'.join(pkgs_list))
     else:
-        print >> sys.stderr, "package '%s' has no plugins." % opts.PKG
+        print("package '%s' has no plugins." % opts.PKG, file=sys.stderr)
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/cli/release.py
+++ b/src/rez/cli/release.py
@@ -1,6 +1,8 @@
 '''
 Build a package from source and deploy it.
 '''
+from __future__ import print_function
+
 import os
 import sys
 from subprocess import call
@@ -104,7 +106,7 @@ def command(opts, parser, extra_arg_groups=None):
                 txt += changelog
 
             with open(filepath, 'w') as f:
-                print >> f, txt
+                print(txt, file=f)
 
         call([config.editor, filepath])
 
@@ -126,11 +128,11 @@ def command(opts, parser, extra_arg_groups=None):
         if not release_msg:
             ch = None
             while ch not in ('A', 'a', 'C', 'c'):
-                print "Empty release message. [A]bort or [C]ontinue release?"
+                print("Empty release message. [A]bort or [C]ontinue release?")
                 ch = raw_input()
 
             if ch in ('A', 'a'):
-                print "Release aborted."
+                print("Release aborted.")
                 sys.exit(1)
 
     # perform the release

--- a/src/rez/cli/search.py
+++ b/src/rez/cli/search.py
@@ -1,6 +1,7 @@
 """
 Search for packages.
 """
+from __future__ import print_function
 
 
 # these are package fields that can be printed using the --format option.
@@ -132,7 +133,7 @@ def command(opts, parser, extra_arg_groups=None):
             if type_ == "auto":
                 type_ = "package" if family.name == name_pattern else "family"
             if type_ == "family":
-                print family.name
+                print(family.name)
                 found = True
 
     def _handle(e):
@@ -158,9 +159,9 @@ def command(opts, parser, extra_arg_groups=None):
                 if opts.no_newlines:
                     line_ = line_.replace('\n', "\\n")
 
-                print line_
+                print(line_)
         else:
-            print r.qualified_name
+            print(r.qualified_name)
 
     # packages/variants
     if type_ in ("package", "variant"):
@@ -204,9 +205,9 @@ def command(opts, parser, extra_arg_groups=None):
 
     if not found:
         if opts.errors:
-            print "no erroneous packages found"
+            print("no erroneous packages found")
         else:
-            print "no matches found"
+            print("no matches found")
             sys.exit(1)
 
 

--- a/src/rez/cli/suite.py
+++ b/src/rez/cli/suite.py
@@ -1,6 +1,7 @@
 '''
 Manage a suite or print information about an existing suite.
 '''
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -95,7 +96,7 @@ def command(opts, parser, extra_arg_groups=None):
 
     def _pr(s):
         if opts.verbose:
-            print s
+            print(s)
 
     def _option(name):
         value = getattr(opts, name)
@@ -108,9 +109,9 @@ def command(opts, parser, extra_arg_groups=None):
         suites = status.suites
         if suites:
             for suite in suites:
-                print suite.load_path
+                print(suite.load_path)
         else:
-            print "No visible suites."
+            print("No visible suites.")
         sys.exit(0)
 
     if not opts.DIR:
@@ -132,14 +133,14 @@ def command(opts, parser, extra_arg_groups=None):
         try:
             suite.validate()
         except SuiteError as e:
-            print >> sys.stderr, "The suite is invalid:\n%s" % str(e)
+            print("The suite is invalid:\n%s" % str(e), file=sys.stderr)
             sys.exit(1)
-        print "The suite is valid."
+        print("The suite is valid.")
     elif _option("find_request") or _option("find_resolve"):
         context_names = suite.find_contexts(in_request=opts.find_request,
                                             in_resolve=opts.find_resolve)
         if context_names:
-            print '\n'.join(context_names)
+            print('\n'.join(context_names))
     elif _option("print_tools"):
         suite.print_tools(verbose=opts.verbose, context_name=opts.context)
     elif _option("add"):
@@ -178,7 +179,7 @@ def command(opts, parser, extra_arg_groups=None):
     elif _option("which"):
         filepath = suite.get_tool_filepath(opts.which)
         if filepath:
-            print filepath
+            print(filepath)
             sys.exit(0)
         else:
             sys.exit(1)

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -1,6 +1,7 @@
 '''
 Run tests listed in a package's definition file.
 '''
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -49,11 +50,11 @@ def command(opts, parser, extra_arg_groups=None):
     test_names = runner.get_test_names()
     if not test_names:
         uri = runner.get_package().uri
-        print >> sys.stderr, "No tests found in %s" % uri
+        print("No tests found in %s" % uri, file=sys.stderr)
         sys.exit(0)
 
     if opts.list:
-        print '\n'.join(test_names)
+        print('\n'.join(test_names))
         sys.exit(0)
 
     if opts.TEST:

--- a/src/rez/cli/view.py
+++ b/src/rez/cli/view.py
@@ -1,6 +1,7 @@
 """
 View the contents of a package.
 """
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -38,12 +39,13 @@ def command(opts, parser, extra_arg_groups=None):
     if opts.current:
         context = status.context
         if context is None:
-            print >> sys.stderr, "not in a resolved environment context."
+            print("not in a resolved environment context.", file=sys.stderr)
             sys.exit(1)
 
         variant = context.get_resolved_package(req.name)
         if variant is None:
-            print >> sys.stderr, "Package %r is not in the current context" % req.name
+            print("Package %r is not in the current context" % req.name,
+                  file=sys.stderr)
             sys.exit(1)
 
         package = variant.parent
@@ -52,17 +54,17 @@ def command(opts, parser, extra_arg_groups=None):
         packages = sorted(it, key=lambda x: x.version)
 
         if not packages:
-            print "no matches found"
+            print("no matches found")
             sys.exit(1)
 
         package = packages[-1]
 
     if not opts.brief:
-        print "URI:"
-        print package.uri
+        print("URI:")
+        print(package.uri)
 
-        print
-        print "CONTENTS:"
+        print()
+        print("CONTENTS:")
 
     if opts.format == "py":
         format_ = FileFormat.py

--- a/src/rez/cli/yaml2py.py
+++ b/src/rez/cli/yaml2py.py
@@ -1,6 +1,7 @@
 """
 Print a package.yaml file in package.py format.
 """
+from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):
@@ -29,7 +30,7 @@ def command(opts, parser, extra_arg_groups=None):
         package = None
 
     if package is None:
-        print >> sys.stderr, "Couldn't load the package at %r" % path
+        print("Couldn't load the package at %r" % path, file=sys.stderr)
         sys.exit(1)
 
     package.print_info(format_=FileFormat.py)

--- a/src/rez/package_bind.py
+++ b/src/rez/package_bind.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.exceptions import RezBindError
 from rez import module_root_path
 from rez.util import get_close_pkgs
@@ -22,7 +24,7 @@ def get_bind_modules(verbose=False):
 
     for path in searchpaths:
         if verbose:
-            print "searching %s..." % path
+            print("searching %s..." % path)
         if not os.path.isdir(path):
             continue
 
@@ -60,10 +62,10 @@ def find_bind_module(name, verbose=False):
 
     if fuzzy_matches:
         rows = [(x[0], bindnames[x[0]]) for x in fuzzy_matches]
-        print "'%s' not found. Close matches:" % name
-        print '\n'.join(columnise(rows))
+        print("'%s' not found. Close matches:" % name)
+        print('\n'.join(columnise(rows)))
     else:
-        print "No matches."
+        print("No matches.")
 
     return None
 
@@ -134,8 +136,8 @@ def bind_package(name, path=None, version_range=None, no_deps=False,
             exc_type = RezBindError
 
     if installed_variants and not quiet:
-        print "The following packages were installed:"
-        print
+        print("The following packages were installed:")
+        print()
         _print_package_list(installed_variants)
 
     return installed_variants
@@ -164,7 +166,7 @@ def _bind_package(name, path=None, version_range=None, bind_args=None,
     install_path = path or config.local_packages_path
 
     if not quiet:
-        print "creating package '%s' in %s..." % (name, install_path)
+        print("creating package '%s' in %s..." % (name, install_path))
 
     bindfunc = namespace.get("bind")
     if not bindfunc:
@@ -185,4 +187,4 @@ def _print_package_list(variants):
     rows = [["PACKAGE", "URI"],
             ["-------", "---"]]
     rows += [(x.name, x.uri) for x in packages]
-    print '\n'.join(columnise(rows))
+    print('\n'.join(columnise(rows)))

--- a/src/rez/package_help.py
+++ b/src/rez/package_help.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.packages_ import iter_packages
 from rez.config import config
 from rez.rex_bindings import VersionBinding
@@ -34,7 +36,7 @@ class PackageHelp(object):
         packages = sorted(it, key=lambda x: x.version, reverse=True)
         for package_ in packages:
             if self._verbose:
-                print "searching for help in %s..." % package_.uri
+                print("searching for help in %s..." % package_.uri)
             if package_.help:
                 package = package_
                 break
@@ -46,7 +48,7 @@ class PackageHelp(object):
             elif isinstance(help_, list):
                 sections = help_
             if self._verbose:
-                print "found %d help entries in %s." % (len(sections), package.uri)
+                print("found %d help entries in %s." % (len(sections), package.uri))
 
             # create string formatter for help entries
             if package.num_variants == 0:
@@ -92,16 +94,16 @@ class PackageHelp(object):
             self._open_url(uri)
         else:
             if self._verbose:
-                print "running command: %s" % uri
+                print("running command: %s" % uri)
             p = popen(uri, shell=True)
             p.wait()
 
     def print_info(self, buf=None):
         """Print help sections."""
         buf = buf or sys.stdout
-        print >> buf, "Sections:"
+        print("Sections:", file=buf)
         for i, section in enumerate(self._sections):
-            print >> buf, "  %s:\t%s (%s)" % (i + 1, section[0], section[1])
+            print("  %s:\t%s (%s)" % (i + 1, section[0], section[1]), file=buf)
 
     @classmethod
     def open_rez_manual(cls):
@@ -113,12 +115,12 @@ class PackageHelp(object):
         if config.browser:
             cmd = [config.browser, url]
             if not config.quiet:
-                print "running command: %s" % " ".join(cmd)
+                print("running command: %s" % " ".join(cmd))
             p = popen(cmd)
             p.communicate()
         else:
             if not config.quiet:
-                print "opening URL in browser: %s" % url
+                print("opening URL in browser: %s" % url)
             webbrowser.open_new(url)
 
 

--- a/src/rez/package_py_utils.py
+++ b/src/rez/package_py_utils.py
@@ -30,11 +30,11 @@ def expand_requirement(request, paths=None):
 
     Examples:
 
-        >>> print expand_requirement('python-2.*')
+        >>> print(expand_requirement('python-2.*'))
         python-2.7
-        >>> print expand_requirement('python==2.**')
+        >>> print(expand_requirement('python==2.**'))
         python==2.7.12
-        >>> print expand_requirement('python<**')
+        >>> print(expand_requirement('python<**'))
         python<3.0.5
 
     Args:
@@ -145,9 +145,9 @@ def expand_requires(*requests):
 
     Example:
 
-        >>> print expand_requires(["boost-1.*.*"])
+        >>> print(expand_requires(["boost-1.*.*"]))
         ["boost-1.55.0"]
-        >>> print expand_requires(["boost-1.*"])
+        >>> print(expand_requires(["boost-1.*"]))
         ["boost-1.55"]
 
     Args:
@@ -230,7 +230,7 @@ def find_site_python(module_name, paths=None):
     import ast
     import os
 
-    py_cmd = 'import {x}; print {x}.__path__'.format(x=module_name)
+    py_cmd = 'import {x}; print({x}.__path__)'.format(x=module_name)
 
     p = popen(["python", "-c", py_cmd], stdout=subprocess.PIPE,
                stderr=subprocess.PIPE)

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.vendor import yaml
 from rez.serialise import FileFormat
 from rez.package_resources_ import help_schema, late_bound
@@ -151,13 +153,13 @@ def _dump_package_data_yaml(items, buf):
 
         d = {key: value}
         txt = dump_yaml(d)
-        print >> buf, txt
+        print(txt, file=buf)
         if i < len(items) - 1:
-            print >> buf, ''
+            print('', file=buf)
 
 
 def _dump_package_data_py(items, buf):
-    print >> buf, "# -*- coding: utf-8 -*-\n"
+    print("# -*- coding: utf-8 -*-\n", file=buf)
 
     for i, (key, value) in enumerate(items):
         if key in ("description", "changelog") and len(value) > 40:
@@ -194,9 +196,9 @@ def _dump_package_data_py(items, buf):
             else:
                 txt = "%s = %s" % (key, value_txt)
 
-        print >> buf, txt
+        print(txt, file=buf)
         if i < len(items) - 1:
-            print >> buf, ''
+            print('', file=buf)
 
 
 dump_functions = {FileFormat.py: _dump_package_data_py,

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.packages_ import get_latest_package
 from rez.vendor.version.version import Version
 from rez.vendor.distlib import DistlibException
@@ -224,7 +226,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
 
     if context and config.debug("package_release"):
         buf = StringIO()
-        print >> buf, "\n\npackage download environment:"
+        print("\n\npackage download environment:", file=buf)
         context.print_info(buf)
         _log(buf.getvalue())
 

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez import __version__, module_root_path
 from rez.package_repository import package_repository_manager
 from rez.solver import SolverCallbackReturn
@@ -852,7 +854,7 @@ class ResolvedContext(object):
             for pkg in sorted(removed_packages, key=lambda x: x.name):
                 rows.append((pkg.qualified_name, "-", ""))
 
-        print '\n'.join(columnise(rows))
+        print('\n'.join(columnise(rows)))
 
     def _on_success(fn):
         @wraps(fn)
@@ -1344,7 +1346,7 @@ class ResolvedContext(object):
             msg.append("was written by a newer version of Rez. The load may "
                        "fail (serialize version %d > %d)"
                        % (_print_version(load_ver), _print_version(curr_ver)))
-            print >> sys.stderr, ' '.join(msg)
+            print(' '.join(msg), file=sys.stderr)
 
         # create and init the context
         r = ResolvedContext.__new__(ResolvedContext)

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import subprocess
 import sys
@@ -601,12 +603,12 @@ class Python(ActionInterpreter):
     def info(self, value):
         if not self.passive:
             value = self.escape_string(value)
-            print value
+            print(value)
 
     def error(self, value):
         if not self.passive:
             value = self.escape_string(value)
-            print >> sys.stderr, value
+            print(value, file=sys.stderr)
 
     def subprocess(self, args, **subproc_kwargs):
         if self.manager:

--- a/src/rez/rex_bindings.py
+++ b/src/rez/rex_bindings.py
@@ -40,7 +40,7 @@ class VersionBinding(Binding):
         (1, 2, '3alpha')
         >>> str(v)
         '1.2.3alpha'
-        >>> print v[5]
+        >>> print(v[5])
         None
         >>> v.as_tuple():
         (1, 2, '3alpha')

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -7,6 +7,8 @@ with a faster resolve.
 
 See SOLVER.md for an in-depth description of how this module works.
 """
+from __future__ import print_function
+
 from rez.config import config
 from rez.packages_ import iter_packages
 from rez.package_repository import package_repo_stats
@@ -110,7 +112,7 @@ class _Printer(object):
         self.pending_br = True
 
     def pr(self, txt='', *args):
-        print >> self.buf, txt % args
+        print(txt % args, file=self.buf)
 
     def __nonzero__(self):
         return self.verbosity
@@ -502,18 +504,18 @@ class _PackageVariantList(_Common):
         return result or None
 
     def dump(self):
-        print self.package_name
+        print(self.package_name)
 
         for package, value in self.entries:
-            print str(package.version)
+            print(str(package.version))
             if value is None:
-                print "    [FILTERED]"
+                print("    [FILTERED]")
             elif isinstance(value, list):
                 variants = value
                 for variant in variants:
-                    print "    %s" % str(variant)
+                    print("    %s" % str(variant))
             else:
-                print "    %s" % str(package)
+                print("    %s" % str(package))
 
     def __str__(self):
         strs = []
@@ -827,8 +829,8 @@ class _PackageVariantSlice(_Common):
             self.pr("sorted: %s packages: version descending", self.package_name)
 
     def dump(self):
-        print self.package_name
-        print '\n'.join(map(str, self.iter_variants()))
+        print(self.package_name)
+        print('\n'.join(map(str, self.iter_variants())))
 
     def _copy(self, new_entries):
         slice_ = _PackageVariantSlice(package_name=self.package_name,
@@ -1971,7 +1973,7 @@ class Solver(_Common):
         elif self.print_stats:
             from pprint import pformat
             data = {"solve_stats": self.solve_stats}
-            print >> (self.buf or sys.stdout), pformat(data)
+            print(pformat(data), file=self.buf or sys.stdout)
 
     @property
     def solve_stats(self):
@@ -2142,19 +2144,19 @@ class Solver(_Common):
         for i, phase in enumerate(self.phase_stack):
             rows.append((self._depth_label(i), phase.status, str(phase)))
 
-        print "status: %s (%s)" % (self.status.name, self.status.description)
-        print "initial request: %s" % str(self.request_list)
-        print
-        print "solve stack:"
-        print '\n'.join(columnise(rows))
+        print("status: %s (%s)" % (self.status.name, self.status.description))
+        print("initial request: %s" % str(self.request_list))
+        print()
+        print("solve stack:")
+        print('\n'.join(columnise(rows)))
 
         if self.failed_phase_list:
             rows = []
             for i, phase in enumerate(self.failed_phase_list):
                 rows.append(("#%d" % i, phase.status, str(phase)))
-            print
-            print "previous failures:"
-            print '\n'.join(columnise(rows))
+            print()
+            print("previous failures:")
+            print('\n'.join(columnise(rows)))
 
     def _init(self):
         self.phase_stack = []

--- a/src/rez/status.py
+++ b/src/rez/status.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import os
 import os.path
@@ -111,10 +113,10 @@ class Status(object):
             b_ = fn(obj, buf, b)
             b |= b_
             if b_:
-                print >> buf, ''
+                print('', file=buf)
 
         if not b:
-            print >> buf, "Rez does not know what '%s' is" % obj
+            print("Rez does not know what '%s' is" % obj, file=buf)
         return b
 
     def print_tools(self, pattern=None, buf=sys.stdout):
@@ -365,7 +367,7 @@ class Status(object):
             lines.append("\nCurrently within context %r in suite at %s"
                          % (context_name, self.parent_suite.load_path))
 
-        print >> buf, "\n".join(lines)
+        print("\n".join(lines), file=buf)
 
 
 # singleton

--- a/src/rez/suite.py
+++ b/src/rez/suite.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.util import create_forwarding_script
 from rez.exceptions import SuiteError, ResolvedContextError
 from rez.resolved_context import ResolvedContext
@@ -424,7 +426,7 @@ class Suite(object):
         if os.path.exists(path):
             if self.load_path and self.load_path == path:
                 if verbose:
-                    print "saving over previous suite..."
+                    print("saving over previous suite...")
                 for context_name in self.context_names:
                     self.context(context_name)  # load before dir deleted
                 shutil.rmtree(path)
@@ -446,14 +448,14 @@ class Suite(object):
             context._set_parent_suite(path, context_name)
             filepath = self._context_path(context_name, path)
             if verbose:
-                print "writing %r..." % filepath
+                print("writing %r..." % filepath)
             context.save(filepath)
 
         # create alias wrappers
         tools_path = os.path.join(path, "bin")
         os.makedirs(tools_path)
         if verbose:
-            print "creating alias wrappers in %r..." % tools_path
+            print("creating alias wrappers in %r..." % tools_path)
 
         tools = self.get_tools()
         for tool_alias, d in tools.iteritems():
@@ -464,8 +466,8 @@ class Suite(object):
             prefix_char = data.get("prefix_char")
 
             if verbose:
-                print ("creating %r -> %r (%s context)..."
-                       % (tool_alias, tool_name, context_name))
+                print("creating %r -> %r (%s context)..."
+                      % (tool_alias, tool_name, context_name))
             filepath = os.path.join(tools_path, tool_alias)
 
             create_forwarding_script(filepath,

--- a/src/rez/tests/data/builds/packages/anti/1.0.0/rezbuild.py
+++ b/src/rez/tests/data/builds/packages/anti/1.0.0/rezbuild.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from build_util import build_directory_recurse, check_visible
 
 def build(source_path, build_path, install_path, targets):
@@ -13,7 +15,7 @@ def build(source_path, build_path, install_path, targets):
         import loco
         raise Exception('loco should not be here')
     except ImportError:
-        print 'Intentionally raising an ImportError since loco should not be available'
+        print('Intentionally raising an ImportError since loco should not be available')
         pass
 
 

--- a/src/rez/tests/data/builds/packages/bah/2.1/rezbuild.py
+++ b/src/rez/tests/data/builds/packages/bah/2.1/rezbuild.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from build_util import check_visible
 
 
@@ -6,13 +8,13 @@ def build(source_path, build_path, install_path, targets):
     # normal requirement 'foo' should be visible
     check_visible("bah", "foo")
     import foo
-    print foo.report()
+    print(foo.report())
 
     # 'floob' should be visible - it is a build requirement of foo, and
     # build requirements are transitive
     check_visible("bah", "floob")
     import floob
-    print floob.hello()
+    print(floob.hello())
 
     # note - this package intentionally doesn't build anything
     pass

--- a/src/rez/tests/data/builds/packages/build_util/1/build_util/__init__.py
+++ b/src/rez/tests/data/builds/packages/build_util/1/build_util/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import shutil
 import os.path
 
@@ -7,7 +9,7 @@ def build_directory_recurse(src_dir, dest_dir, source_path, build_path,
                             install_path=None):
 
     def _copy(src, dest):
-        print "copying %s to %s..." % (src, dest)
+        print("copying %s to %s..." % (src, dest))
         if os.path.exists(dest):
             shutil.rmtree(dest)
         shutil.copytree(src, dest)

--- a/src/rez/tests/data/builds/packages/build_util/1/rezbuild.py
+++ b/src/rez/tests/data/builds/packages/build_util/1/rezbuild.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import shutil
 import os.path
 
@@ -5,7 +7,7 @@ import os.path
 def build(source_path, build_path, install_path, targets):
 
     def _copy(src, dest):
-        print "copying %s to %s..." % (src, dest)
+        print("copying %s to %s..." % (src, dest))
         if os.path.exists(dest):
             shutil.rmtree(dest)
         shutil.copytree(src, dest)

--- a/src/rez/tests/data/builds/packages/foo/1.0.0/rezbuild.py
+++ b/src/rez/tests/data/builds/packages/foo/1.0.0/rezbuild.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from build_util import build_directory_recurse, check_visible
 import os.path
 
@@ -7,7 +9,7 @@ def build(source_path, build_path, install_path, targets):
     # build requirement 'floob' should be visible
     check_visible("foo", "floob")
     import floob
-    print floob.hello()
+    print(floob.hello())
 
     # do the build
     if "install" not in (targets or []):

--- a/src/rez/tests/data/builds/packages/foo/1.1.0/rezbuild.py
+++ b/src/rez/tests/data/builds/packages/foo/1.1.0/rezbuild.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from build_util import build_directory_recurse, check_visible
 import os.path
 
@@ -7,7 +9,7 @@ def build(source_path, build_path, install_path, targets):
     # build requirement 'floob' should be visible
     check_visible("foo", "floob")
     import floob
-    print floob.hello()
+    print(floob.hello())
 
     # do the build
     if "install" not in (targets or []):

--- a/src/rez/tests/data/release/rezbuild.py
+++ b/src/rez/tests/data/release/rezbuild.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import shutil
 import os.path
 
@@ -5,7 +7,7 @@ import os.path
 def build(source_path, build_path, install_path, targets):
 
     def _copy(src, dest):
-        print "copying %s to %s..." % (src, dest)
+        print("copying %s to %s..." % (src, dest))
         if os.path.exists(dest):
             shutil.rmtree(dest)
         shutil.copytree(src, dest)

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -64,8 +64,8 @@ class TestContext(TestBase, TempdirMixin):
         r = ResolvedContext(["hello_world"])
 
         pycode = ("import os; "
-                  "print os.getenv(\"BIGLY\"); "
-                  "print os.getenv(\"OH_HAI_WORLD\")")
+                  "print(os.getenv(\"BIGLY\")); "
+                  "print(os.getenv(\"OH_HAI_WORLD\"))")
 
         args = ["python", "-c", pycode]
 

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -1,6 +1,8 @@
 """
 test shell invocation
 """
+from __future__ import print_function
+
 from rez.system import system
 from rez.shells import create_shell
 from rez.resolved_context import ResolvedContext
@@ -150,7 +152,7 @@ class TestShells(TestBase, TempdirMixin):
         # exactly what we expect.
         echo_cmd = which("echo")
         if not echo_cmd:
-            print "\nskipping test, 'echo' command not found."
+            print("\nskipping test, 'echo' command not found.")
             return
 
         cmd = [os.path.join(system.rez_bin_path, "rez-env"), "--", "echo", "hey"]

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -1,6 +1,8 @@
 """
 test dependency resolving algorithm
 """
+from __future__ import print_function
+
 from rez.vendor.version.requirement import Requirement
 from rez.solver import Solver, Cycle, SolverStatus
 from rez.config import config
@@ -42,7 +44,7 @@ class TestSolver(TestBase):
         return (s1, s2, s_perms)
 
     def _solve(self, packages, expected_resolve):
-        print
+        print()
         reqs = [Requirement(x) for x in packages]
         s1, s2, s_perms = self._create_solvers(reqs)
 
@@ -50,19 +52,19 @@ class TestSolver(TestBase):
         self.assertEqual(s1.status, SolverStatus.solved)
         resolve = [str(x) for x in s1.resolved_packages]
 
-        print
-        print "request: %s" % ' '.join(packages)
-        print "expecting: %s" % ' '.join(expected_resolve)
-        print "result: %s" % ' '.join(str(x) for x in resolve)
+        print()
+        print("request: %s" % ' '.join(packages))
+        print("expecting: %s" % ' '.join(expected_resolve))
+        print("result: %s" % ' '.join(str(x) for x in resolve))
         self.assertEqual(resolve, expected_resolve)
 
-        print "checking that unoptimised solve matches optimised..."
+        print("checking that unoptimised solve matches optimised...")
         s2.solve()
         self.assertEqual(s2.status, SolverStatus.solved)
         resolve2 = [str(x) for x in s2.resolved_packages]
         self.assertEqual(resolve2, resolve)
 
-        print "checking that permutations also succeed..."
+        print("checking that permutations also succeed...")
         for s in s_perms:
             s.solve()
             self.assertEqual(s.status, SolverStatus.solved)
@@ -70,23 +72,23 @@ class TestSolver(TestBase):
         return s1
 
     def _fail(self, *packages):
-        print
+        print()
         reqs = [Requirement(x) for x in packages]
         s1, s2, s_perms = self._create_solvers(reqs)
 
         s1.solve()
-        print
-        print "request: %s" % ' '.join(packages)
-        print "expecting failure"
+        print()
+        print("request: %s" % ' '.join(packages))
+        print("expecting failure")
         self.assertEqual(s1.status, SolverStatus.failed)
-        print "result: %s" % str(s1.failure_reason())
+        print("result: %s" % str(s1.failure_reason()))
 
-        print "checking that unoptimised solve fail matches optimised..."
+        print("checking that unoptimised solve fail matches optimised...")
         s2.solve()
         self.assertEqual(s2.status, SolverStatus.failed)
         self.assertEqual(s1.failure_reason(), s2.failure_reason())
 
-        print "checking that permutations also fail..."
+        print("checking that permutations also fail...")
         for s in s_perms:
             s.solve()
             self.assertEqual(s.status, SolverStatus.failed)

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import rez.vendor.unittest2 as unittest
 from rez.config import config, _create_locked_config
 from rez.shells import get_shell_types
@@ -154,7 +156,7 @@ def shell_dependent(exclude=None):
             for shell in shells:
                 if exclude and shell in exclude:
                     self.skipTest("This test does not run on %s shell." % shell)
-                print "\ntesting in shell: %s..." % shell
+                print("\ntesting in shell: %s..." % shell)
                 config.override("default_shell", shell)
                 func(self, *args, **kwargs)
         return wrapper
@@ -169,8 +171,8 @@ def install_dependent(fn):
         if os.getenv("__REZ_SELFTEST_RUNNING") and system.is_production_rez_install:
             fn(self, *args, **kwargs)
         else:
-            print ("\nskipping test, must be run via 'rez-selftest' tool, from "
-                   "a PRODUCTION rez installation.")
+            print("\nskipping test, must be run via 'rez-selftest' tool, from "
+                  "a PRODUCTION rez installation.")
     return _fn
 
 

--- a/src/rez/utils/colorize.py
+++ b/src/rez/utils/colorize.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import logging
 from rez.vendor import colorama
@@ -297,7 +299,7 @@ class Printer(object):
                         or stream_is_tty(buf)
 
     def __call__(self, msg='', style=None):
-        print >> self.buf, self.get(msg, style)
+        print(self.get(msg, style), file=self.buf)
 
     def get(self, msg, style=None):
         if style and self.colorize:

--- a/src/rez/utils/data_utils.py
+++ b/src/rez/utils/data_utils.py
@@ -129,7 +129,7 @@ class cached_property(object):
         >>> class Foo(object):
         >>>     @cached_property
         >>>     def bah(self):
-        >>>         print 'bah'
+        >>>         print('bah')
         >>>         return 1
         >>>
         >>> f = Foo()
@@ -169,7 +169,7 @@ class cached_class_property(object):
         >>> class Foo(object):
         >>>     @cached_class_property
         >>>     def bah(cls):
-        >>>         print 'bah'
+        >>>         print('bah')
         >>>         return 1
         >>>
         >>> Foo.bah
@@ -404,11 +404,11 @@ class AttributeForwardMeta(type):
         >>>
         >>> x = Foo()
         >>> y = Bah(x)
-        >>> print y.a
+        >>> print(y.a)
         a_from_bah
-        >>> print y.b
+        >>> print(y.b)
         b_from_foo
-        >>> print y.c
+        >>> print(y.c)
         None
     """
     def __new__(cls, name, parents, members):

--- a/src/rez/utils/diff_packages.py
+++ b/src/rez/utils/diff_packages.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.packages_ import iter_packages
 from rez.config import config
 from rez.plugin_managers import plugin_manager
@@ -37,14 +39,14 @@ def diff_packages(pkg1, pkg2=None):
     paths = []
 
     for pkg in (pkg1, pkg2):
-        print "Exporting %s..." % pkg.qualified_name
+        print("Exporting %s..." % pkg.qualified_name)
         path_ = os.path.join(path, pkg.qualified_name)
         vcs_cls_1 = plugin_manager.get_plugin_class("release_vcs", pkg1.vcs)
         vcs_cls_1.export(revision=pkg.revision, path=path_)
         paths.append(path_)
 
     difftool = config.difftool
-    print "Opening diff viewer %s..." % difftool
+    print("Opening diff viewer %s..." % difftool)
     proc = Popen([difftool] + paths)
     proc.wait()
 

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -1,6 +1,8 @@
 """
 Filesystem-related utilities.
 """
+from __future__ import print_function
+
 from threading import Lock
 from tempfile import mkdtemp
 from contextlib import contextmanager
@@ -344,13 +346,13 @@ def decode_filesystem_name(filename):
 
 def test_encode_decode():
     def do_test(orig, expected_encoded):
-        print '=' * 80
-        print orig
+        print('=' * 80)
+        print(orig)
         encoded = encode_filesystem_name(orig)
-        print encoded
+        print(encoded)
         assert encoded == expected_encoded
         decoded = decode_filesystem_name(encoded)
-        print decoded
+        print(decoded)
         assert decoded == orig
 
     do_test("Foo_Bar (fun).txt", '_foo___bar_020_028fun_029.txt')

--- a/src/rez/utils/formatting.py
+++ b/src/rez/utils/formatting.py
@@ -44,7 +44,7 @@ class PackageRequest(Requirement):
     Example:
 
         >>> pr = PackageRequest("foo-1.3+")
-        >>> print pr.name, pr.range
+        >>> print(pr.name, pr.range)
         foo 1.3+
     """
     def __init__(self, s):
@@ -247,7 +247,7 @@ def dict_to_attributes_code(dict_):
 
     Example:
         >>> d = {'foo': 'bah', 'colors': {'red': 1, 'blue': 2}}
-        >>> print dict_to_attributes_code(d)
+        >>> print(dict_to_attributes_code(d))
         foo = 'bah'
         colors.red = 1
         colors.blue = 2

--- a/src/rez/utils/graph_utils.py
+++ b/src/rez/utils/graph_utils.py
@@ -1,6 +1,8 @@
 """
 Functions for manipulating dot-based resolve graphs.
 """
+from __future__ import print_function
+
 import re
 import os.path
 import subprocess
@@ -232,7 +234,7 @@ def view_graph(graph_str, dest_file=None):
     from rez.config import config
 
     if (system.platform == "linux") and (not os.getenv("DISPLAY")):
-        print >> sys.stderr, "Unable to open display."
+        print("Unable to open display.", file=sys.stderr)
         sys.exit(1)
 
     dest_file = _write_graph(graph_str, dest_file=dest_file)
@@ -240,7 +242,7 @@ def view_graph(graph_str, dest_file=None):
     # view graph
     viewed = False
     prog = config.image_viewer or 'browser'
-    print "loading image viewer (%s)..." % prog
+    print("loading image viewer (%s)..." % prog)
 
     if config.image_viewer:
         proc = popen([config.image_viewer, dest_file])
@@ -259,7 +261,7 @@ def _write_graph(graph_str, dest_file=None):
         os.close(tmpf[0])
         dest_file = tmpf[1]
 
-    print "rendering image to " + dest_file + "..."
+    print("rendering image to " + dest_file + "...")
     save_graph(graph_str, dest_file)
     return dest_file
 

--- a/src/rez/utils/memcached.py
+++ b/src/rez/utils/memcached.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.config import config
 from rez.vendor.memcache.memcache import Client as Client_, SERVER_MAX_KEY_LENGTH
 from threading import local
@@ -152,7 +154,7 @@ class Client(object):
         """Disconnect from server(s). Behaviour is undefined after this call."""
         if self.servers and self._client:
             self._client.disconnect_all()
-        #print "Disconnected memcached client %s" % str(self)
+        # print("Disconnected memcached client %s" % str(self))
 
     def _qualified_key(self, key):
         return "%s:%s:%s" % (cache_interface_version, self.current, key)

--- a/src/rez/utils/patching.py
+++ b/src/rez/utils/patching.py
@@ -6,9 +6,9 @@ def get_patched_request(requires, patchlist):
 
     For example, consider:
 
-        >>> print get_patched_request(["foo-5", "bah-8.1"], ["foo-6"])
+        >>> print(get_patched_request(["foo-5", "bah-8.1"], ["foo-6"]))
         ["foo-6", "bah-8.1"]
-        >>> print get_patched_request(["foo-5", "bah-8.1"], ["^bah"])
+        >>> print(get_patched_request(["foo-5", "bah-8.1"], ["^bah"]))
         ["foo-5"]
 
     The following rules apply wrt how normal/conflict/weak patches override

--- a/src/rez/utils/py_dist.py
+++ b/src/rez/utils/py_dist.py
@@ -1,6 +1,8 @@
 """
 Functions for converting python distributions to rez packages.
 """
+from __future__ import print_function
+
 from rez.exceptions import RezSystemError
 import pkg_resources
 import shutil
@@ -73,8 +75,9 @@ def convert_requirement(req):
             r = "!%s-%s" % (pkg_name, ver)
             req_strs.append(r)
         else:
-            print >> sys.stderr, \
-                "Warning: Can't understand op '%s', just depending on unversioned package..." % op
+            print("Warning: Can't understand op '%s', just depending on "
+                  "unversioned package..." % op,
+                  file=sys.stderr)
             req_strs.append(pkg_name)
 
     return req_strs

--- a/src/rez/utils/scope.py
+++ b/src/rez/utils/scope.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.utils.formatting import StringFormatMixin, StringFormatType
 import UserDict
 import sys
@@ -11,16 +13,16 @@ class RecursiveAttribute(UserDict.UserDict, StringFormatMixin):
         >>> a.foo['eek'] = 'hey'
         >>> a.fee = 1
 
-        >>> print a.to_dict()
+        >>> print(a.to_dict())
         {'foo': {'bah': 5, 'eek': 'hey'}, 'fee': 1}
 
     A recursive attribute can also be created from a dict, and made read-only::
 
         >>> d = {'fee': {'fi': {'fo': 'fum'}}, 'ho': 'hum'}
         >>> a = RecursiveAttribute(d, read_only=True)
-        >>> print str(a)
+        >>> print(str(a))
         {'fee': {'fi': {'fo': 'fum'}}, 'ho': 'hum'}
-        >>> print a.ho
+        >>> print(a.ho)
         hum
         >>> a.new = True
         AttributeError: 'RecursiveAttribute' object has no attribute 'new'
@@ -47,7 +49,7 @@ class RecursiveAttribute(UserDict.UserDict, StringFormatMixin):
             _noattrib()
 
         # the new attrib isn't actually added to this instance until it's set
-        # to something. This stops code like "print instance.notexist" from
+        # to something. This stops code like "print(instance.notexist)" from
         # adding empty attributes
         attr_ = self._create_child_attribute(attr)
         assert(isinstance(attr_, RecursiveAttribute))
@@ -182,7 +184,7 @@ class ScopeContext(object):
 
     The dictionaries can then be retrieved::
 
-        >>> print pprint.pformat(scope.to_dict())
+        >>> print(pprint.pformat(scope.to_dict()))
         {'animal': {'count': 3,
                     'cat': {'friendly': False,
                             'num_legs': 4},
@@ -243,7 +245,7 @@ def scoped_format(txt, **objects):
         >>> Class Foo(object):
         >>>     def __init__(self):
         >>>         self.name = "Dave"
-        >>> print scoped_format("hello {foo.name}", foo=Foo())
+        >>> print(scoped_format("hello {foo.name}", foo=Foo()))
         hello Dave
 
     Args:

--- a/src/rez/wrapper.py
+++ b/src/rez/wrapper.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rez.resolved_context import ResolvedContext
 from rez.utils.colorize import heading, local, critical, Printer
 from rez.utils.data_utils import cached_property
@@ -198,12 +200,12 @@ class Wrapper(object):
     def print_about(self):
         """Print an info message about the tool."""
         filepath = os.path.join(self.suite_path, "bin", self.tool_name)
-        print "Tool:     %s" % self.tool_name
-        print "Path:     %s" % filepath
-        print "Suite:    %s" % self.suite_path
+        print("Tool:     %s" % self.tool_name)
+        print("Path:     %s" % filepath)
+        print("Suite:    %s" % self.suite_path)
 
         msg = "%s (%r)" % (self.context.load_path, self.context_name)
-        print "Context:  %s" % msg
+        print("Context:  %s" % msg)
 
         variants = self.context.get_tool_variants(self.tool_name)
         if variants:
@@ -211,7 +213,7 @@ class Wrapper(object):
                 self._print_conflicting(variants)
             else:
                 variant = iter(variants).next()
-                print "Package:  %s" % variant.qualified_package_name
+                print("Package:  %s" % variant.qualified_package_name)
         return 0
 
     def print_package_versions(self):

--- a/src/rezgui/dialogs/ProcessDialog.py
+++ b/src/rezgui/dialogs/ProcessDialog.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rezgui.qt import QtCore, QtGui
 from rezgui.util import create_pane
 from rezgui.mixins.StoreSizeMixin import StoreSizeMixin
@@ -76,7 +78,7 @@ class ProcessDialog(QtGui.QDialog, StoreSizeMixin):
                 self.lock.release()
 
             txt = ''.join(buf)
-            print >> self.edit, txt
+            print(txt, file=self.edit)
 
         if not self.ended and self.proc.poll() is not None:
             self.bar.setMaximum(10)

--- a/src/rezgui/objects/ResolveThread.py
+++ b/src/rezgui/objects/ResolveThread.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rezgui.qt import QtCore
 from rez.exceptions import RezError
 
@@ -47,12 +49,12 @@ class ResolveThread(QtCore.QObject):
 
     def _callback(self, solver_state):
         if self.buf and self.verbosity == 0:
-            print >> self.buf, "solve step %d..." % solver_state.num_solves
+            print("solve step %d..." % solver_state.num_solves, file=self.buf)
         return (not self.stopped), self.abort_reason
 
     def _package_load_callback(self, package):
         if self.buf:
-            print >> self.buf, "loading %s..." % str(package)
+            print("loading %s..." % str(package), file=self.buf)
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -1,6 +1,8 @@
 """
 CMake-based build system
 """
+from __future__ import print_function
+
 from rez.build_system import BuildSystem
 from rez.build_process_ import BuildType
 from rez.resolved_context import ResolvedContext
@@ -100,7 +102,7 @@ class CMakeBuildSystem(BuildSystem):
               build_type=BuildType.local):
         def _pr(s):
             if self.verbose:
-                print s
+                print(s)
 
         # find cmake binary
         if self.settings.cmake_binary:

--- a/src/rezplugins/release_hook/amqp.py
+++ b/src/rezplugins/release_hook/amqp.py
@@ -1,6 +1,8 @@
 """
 Publishes a message to the broker.
 """
+from __future__ import print_function
+
 from rez.release_hook import ReleaseHook
 from rez.utils.logging_ import print_error, print_debug
 from rez.vendor.amqp import Connection, basic_message
@@ -115,7 +117,7 @@ class AmqpReleaseHook(ReleaseHook):
             content_encoding="utf-8")
 
         routing_key = self.settings.exchange_routing_key
-        print "Publishing AMQP message on %s..." % routing_key
+        print("Publishing AMQP message on %s..." % routing_key)
 
         # publish the message
         try:

--- a/src/rezplugins/release_hook/command.py
+++ b/src/rezplugins/release_hook/command.py
@@ -1,6 +1,7 @@
 """
 Executes pre- and post-release shell commands
 """
+from __future__ import print_function
 
 import getpass
 import sys
@@ -50,7 +51,7 @@ class CommandReleaseHook(ReleaseHook):
         def _err(msg):
             errors.append(msg)
             if self.settings.print_error:
-                print >> sys.stderr, msg
+                print(msg, file=sys.stderr)
 
         kwargs = {}
         if env:
@@ -65,7 +66,7 @@ class CommandReleaseHook(ReleaseHook):
                 _err(msg)
                 return False
             if self.settings.print_output:
-                print stdout.strip()
+                print(stdout.strip())
             return True
 
         if not os.path.isfile(cmd_name):
@@ -181,7 +182,7 @@ class CommandReleaseHook(ReleaseHook):
                         msgs.append("    with: %s=%s" % (key, value))
 
                 if self.settings.print_commands:
-                    print '\n'.join(msgs)
+                    print('\n'.join(msgs))
                 else:
                     for msg in msgs:
                         print_debug(msg)

--- a/src/rezplugins/release_hook/emailer.py
+++ b/src/rezplugins/release_hook/emailer.py
@@ -1,6 +1,8 @@
 """
 Sends a post-release email
 """
+from __future__ import print_function
+
 from rez.release_hook import ReleaseHook
 from rez.system import system
 from email.mime.text import MIMEText
@@ -71,8 +73,8 @@ class EmailReleaseHook(ReleaseHook):
         if not recipients:
             return
 
-        print "Sending release email to:"
-        print '\n'.join("- %s" % x for x in recipients)
+        print("Sending release email to:")
+        print('\n'.join("- %s" % x for x in recipients))
 
         msg = MIMEText(body)
         msg["Subject"] = subject
@@ -84,7 +86,7 @@ class EmailReleaseHook(ReleaseHook):
             s.sendmail(from_addr=self.settings.sender,
                        to_addrs=recipients,
                        msg=msg.as_string())
-            print 'Email(s) sent.'
+            print('Email(s) sent.')
         except Exception, e:
             print_error("release email delivery failed: %s" % str(e))
 

--- a/src/rezplugins/release_vcs/git.py
+++ b/src/rezplugins/release_vcs/git.py
@@ -1,6 +1,8 @@
 """
 Git version control
 """
+from __future__ import print_function
+
 from rez.release_vcs import ReleaseVCS
 from rez.utils.logging_ import print_error, print_warning, print_debug
 from rez.exceptions import ReleaseVCSError
@@ -203,7 +205,7 @@ class GitReleaseVCS(ReleaseVCS):
             return
 
         # create tag
-        print "Creating tag '%s'..." % tag_name
+        print("Creating tag '%s'..." % tag_name)
         args = ["tag", "-a", tag_name]
         args += ["-m", message or '']
         self.git(*args)
@@ -214,7 +216,7 @@ class GitReleaseVCS(ReleaseVCS):
             return
 
         remote_uri = '/'.join((remote, remote_branch))
-        print "Pushing tag '%s' to %s..." % (tag_name, remote_uri)
+        print("Pushing tag '%s' to %s..." % (tag_name, remote_uri))
         self.git("push", remote, tag_name)
 
     @classmethod

--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -1,6 +1,8 @@
 """
 Mercurial version control
 """
+from __future__ import print_function
+
 from rez.release_vcs import ReleaseVCS
 from rez.exceptions import ReleaseVCSError
 from rez.utils.logging_ import print_debug, print_error
@@ -252,7 +254,7 @@ class HgReleaseVCS(ReleaseVCS):
         # commit that created the 2nd tag.
 
         # create tag
-        print "Creating tag '%s'..." % tag_name
+        print("Creating tag '%s'..." % tag_name)
         created_tags = self._create_tag_highlevel(tag_name, message=message)
 
         # push tags / bookmarks

--- a/src/rezplugins/release_vcs/stub.py
+++ b/src/rezplugins/release_vcs/stub.py
@@ -1,6 +1,8 @@
 """
 Stub version control system, for testing purposes
 """
+from __future__ import print_function
+
 from rez.release_vcs import ReleaseVCS
 from rez.utils.logging_ import print_warning
 from rez.utils.yaml import dump_yaml
@@ -59,7 +61,7 @@ class StubReleaseVCS(ReleaseVCS):
             print_warning("Skipped tag creation, tag '%s' already exists" % tag_name)
             return
 
-        print "Creating tag '%s'..." % tag_name
+        print("Creating tag '%s'..." % tag_name)
         data["tags"][tag_name] = message
         self._write_stub(data)
 

--- a/src/rezplugins/release_vcs/svn.py
+++ b/src/rezplugins/release_vcs/svn.py
@@ -1,6 +1,8 @@
 """
 Svn version control
 """
+from __future__ import print_function
+
 from rez.release_vcs import ReleaseVCS
 from rez.exceptions import ReleaseVCSError
 import os.path
@@ -45,7 +47,7 @@ def get_svn_login(realm, username, may_save):
     """
     import getpass
 
-    print "svn requires a password for the user %s:" % username
+    print("svn requires a password for the user %s:" % username)
     pwd = ''
     while not pwd.strip():
         pwd = getpass.getpass("--> ")
@@ -91,7 +93,7 @@ class SvnReleaseVCS(ReleaseVCS):
 
     def _create_tag_impl(self, tag_name, message=None):
         tag_url = self.get_tag_url(tag_name)
-        print "rez-release: creating project tag in: %s..." % tag_url
+        print("rez-release: creating project tag in: %s..." % tag_url)
         self.svnc.callback_get_log_message = lambda x: (True, x)
         self.svnc.copy2([(self.this_url,)], tag_url, make_parents=True)
 

--- a/src/support/shotgun_toolkit/rez_app_launch.py
+++ b/src/support/shotgun_toolkit/rez_app_launch.py
@@ -22,6 +22,7 @@ Please note that this requires Rez to be installed as a package,
 which exposes the Rez Python API. With a proper Rez installation, you can do this
 by running "rez-bind rez".
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -142,14 +143,15 @@ class AppLaunch(tank.Hook):
                 raise ImportError("Failed to find Rez as a package in the current "
                                   "environment! Try 'rez-bind rez'!")
             else:
-                print >> sys.stderr, ("WARNING: Failed to find a Rez package in the current "
-                                      "environment. Unable to request Rez packages.")
+                print("WARNING: Failed to find a Rez package in the current "
+                      "environment. Unable to request Rez packages.",
+                      file=sys.stderr)
 
             rez_path = ""
         else:
             rez_path = rez_path.strip()
-            print "Found Rez:", rez_path
-            print "Adding Rez to system path..."
+            print("Found Rez:", rez_path)
+            print("Adding Rez to system path...")
             sys.path.append(rez_path)
 
         return rez_path

--- a/wiki/pages/Package-Definition-Guide.md
+++ b/wiki/pages/Package-Definition-Guide.md
@@ -406,12 +406,12 @@ installation instead, and binds that into a rez package.
     def _bin_path():
         return this._exec_python(
             "_bin_path",
-            "import sys, os.path; print os.path.dirname(sys.executable)")
+            "import sys, os.path; print(os.path.dirname(sys.executable))")
 
     def _version():
         return _exec_python(
             "version",
-            "import sys; print sys.version.split()[0]")
+            "import sys; print(sys.version.split()[0])")
 
     __version = _version()
 
@@ -617,7 +617,7 @@ You should set the uuid on a new package once, and not change it from then on. T
 string doesn't actually matter, but you'd typically use a true UUID, and you can generate one
 like so:
 
-    ]$ python -c 'import uuid; print uuid.uuid4().hex'
+    ]$ python -c 'import uuid; print(uuid.uuid4().hex)'
 
 ### variants
 *List of list of string*


### PR DESCRIPTION
I updated all print statements in the entire code base to use the Python 3 syntax `print(value)` instead of the deprecated `print value`. It's a first step towards being Python 3 compatible.

Please take a look and let me know if you see any issues with merging these changes.