### PR TITLE
Add all shells to Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,15 @@ matrix:
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
+    - language: generic
+      os: osx
+      env: _REZ_SHELL=tcsh
+      before_install:
+        - brew update
+        - brew install tcsh
+        - brew install python2
+        - virtualenv env -p python2
+        - source env/bin/activate
 
 install:
   - 'python ./install.py ../rez_install'

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,14 @@ matrix:
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
+    - language: generic
+      os: osx
+      env: _REZ_SHELL=csh
+      before_install:
+        - brew update
+        - brew install python2
+        - virtualenv env -p python2
+        - source env/bin/activate
 
 install:
   - 'python ./install.py ../rez_install'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,16 @@ matrix:
       before_install:
         - brew update
         - brew install tcsh
-        - brew install python2
+        # The Python version might already be installed and has some symlinks
+        # lying around. We remove the symlinks only when the version is not yet
+        # installed of course.
+        - if ! [ brew list python@2 ] && [ -L /usr/local/bin/python2 ]; then
+          brew unlink python;
+          fi
+        # brew install errors out if the formulae is already installed, lets
+        # check and make sure we actually need to install Python.
+        - if ! [ brew list python@2 ]; then brew install python@2; fi
+        - export PATH="/usr/local/opt/python@2/libexec/bin:$PATH"
         - virtualenv env -p python2
         - source env/bin/activate
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,59 +4,22 @@ matrix:
   include:
     - python: 2.7
       os: linux
-      env: _REZ_SHELL=bash
-    - python: 2.7
-      os: linux
-      env: _REZ_SHELL=sh
-    - python: 2.7
-      os: linux
-      env: _REZ_SHELL=tcsh
       before_install:
         - sudo apt-get install tcsh -y
-    - python: 2.7
-      os: linux
-      env: _REZ_SHELL=csh
-      before_install:
         - sudo apt-get install csh -y
     # Travis CI does not support Python on Mac OS out of the box, this is a
     # simple workaround until they can. More info:
     # https://github.com/travis-ci/travis-ci/issues/2312
     - language: generic
       os: osx
-      env: _REZ_SHELL=bash
-      before_install:
-        - brew update
-        - brew install python2
-        - virtualenv env -p python2
-        - source env/bin/activate
-    - language: generic
-      os: osx
-      env: _REZ_SHELL=sh
-      before_install:
-        - brew update
-        - brew install python2
-        - virtualenv env -p python2
-        - source env/bin/activate
-    - language: generic
-      os: osx
-      env: _REZ_SHELL=tcsh
       before_install:
         - brew update
         - brew install tcsh
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
-    - language: generic
-      os: osx
-      env: _REZ_SHELL=csh
-      before_install:
-        - brew update
-        - brew install python2
-        - virtualenv env -p python2
-        - source env/bin/activate
-
 install:
   - 'python ./install.py ../rez_install'
 
 script:
-  - '/bin/$_REZ_SHELL -c "../rez_install/bin/rez/rez-selftest -s $_REZ_SHELL"'
+  - '"../rez_install/bin/rez/rez-selftest"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,24 +21,21 @@ matrix:
     # Travis CI does not support Python on Mac OS out of the box, this is a
     # simple workaround until they can. More info:
     # https://github.com/travis-ci/travis-ci/issues/2312
-    - language: generic
-      os: osx
+    - os: osx
       env: _REZ_SHELL=bash
       before_install:
         - brew update
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
-    - language: generic
-      os: osx
+    - os: osx
       env: _REZ_SHELL=sh
       before_install:
         - brew update
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
-    - language: generic
-      os: osx
+    - os: osx
       env: _REZ_SHELL=tcsh
       before_install:
         - brew update
@@ -46,8 +43,7 @@ matrix:
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
-    - language: generic
-      os: osx
+    - os: osx
       env: _REZ_SHELL=csh
       before_install:
         - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ install:
   - 'python ./install.py ../rez_install'
 
 script:
-  - '../rez_install/bin/rez/rez-selftest -s $_REZ_SHELL'
+  - '/bin/$_REZ_SHELL ../rez_install/bin/rez/rez-selftest -s $_REZ_SHELL'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ matrix:
       env: _REZ_SHELL=tcsh
       before_install:
         - sudo apt-get install tcsh -y
+    - python: 2.7
+      os: linux
+      env: _REZ_SHELL=csh
+      before_install:
+        - sudo apt-get install csh -y
     # Travis CI does not support Python on Mac OS out of the box, this is a
     # simple workaround until they can. More info:
     # https://github.com/travis-ci/travis-ci/issues/2312

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ install:
   - 'python ./install.py ../rez_install'
 
 script:
-  - '/bin/$_REZ_SHELL ../rez_install/bin/rez/rez-selftest -s $_REZ_SHELL'
+  - '/bin/$_REZ_SHELL -c "../rez_install/bin/rez/rez-selftest -s $_REZ_SHELL"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,19 @@ matrix:
     - python: 2.7
       os: linux
       env: _REZ_SHELL=bash
+    # Travis CI does not support Python on Mac OS out of the box, this is a
+    # simple workaround until they can. More info:
+    # https://github.com/travis-ci/travis-ci/issues/2312
+    - language: generic
+      os: osx
+      env: _REZ_SHELL=bash
+      before_install:
+        - brew update
+        - brew install python2
+        - virtualenv env -p python2
+        - source env/bin/activate
 
 install:
-  - 'if [ "$_REZ_SHELL" == "tcsh" ]; then sudo apt-get install tcsh; fi'
   - 'python ./install.py ../rez_install'
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ matrix:
     - python: 2.7
       os: linux
       env: _REZ_SHELL=sh
+    - python: 2.7
+      os: linux
+      env: _REZ_SHELL=tcsh
+      before_install:
+        - sudo apt-get install tcsh -y
     # Travis CI does not support Python on Mac OS out of the box, this is a
     # simple workaround until they can. More info:
     # https://github.com/travis-ci/travis-ci/issues/2312

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,21 +21,24 @@ matrix:
     # Travis CI does not support Python on Mac OS out of the box, this is a
     # simple workaround until they can. More info:
     # https://github.com/travis-ci/travis-ci/issues/2312
-    - os: osx
+    - language: generic
+      os: osx
       env: _REZ_SHELL=bash
       before_install:
         - brew update
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
-    - os: osx
+    - language: generic
+      os: osx
       env: _REZ_SHELL=sh
       before_install:
         - brew update
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
-    - os: osx
+    - language: generic
+      os: osx
       env: _REZ_SHELL=tcsh
       before_install:
         - brew update
@@ -43,7 +46,8 @@ matrix:
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
-    - os: osx
+    - language: generic
+      os: osx
       env: _REZ_SHELL=csh
       before_install:
         - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ matrix:
         - brew install python2
         - virtualenv env -p python2
         - source env/bin/activate
+    - language: generic
+      os: osx
+      env: _REZ_SHELL=sh
+      before_install:
+        - brew update
+        - brew install python2
+        - virtualenv env -p python2
+        - source env/bin/activate
 
 install:
   - 'python ./install.py ../rez_install'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ matrix:
     - python: 2.7
       os: linux
       env: _REZ_SHELL=bash
+    - python: 2.7
+      os: linux
+      env: _REZ_SHELL=sh
     # Travis CI does not support Python on Mac OS out of the box, this is a
     # simple workaround until they can. More info:
     # https://github.com/travis-ci/travis-ci/issues/2312


### PR DESCRIPTION
This adds all shells in Mac OS and Linux to the Travis CI configuration. Running `selftest` in every shell will increase our confidence in merging new code changes.

While setting up the configuration I noticed tests are breaking for `sh` on Linux and `tcsh` on Mac OS. I will try to take a look at why they are failing so we don't end up with a "build:error" badge right after the merge.

@nerdvegas I know you haven't been a big fan of Travis CI so far but I am sure we can figure out why the badge hasn't been all green all the time.

Let me know what you think of this PR.