### PR TITLE
Fix escaping backslashes in tcsh on Mac OS

### DIFF
--- a/src/rezplugins/shell/tcsh.py
+++ b/src/rezplugins/shell/tcsh.py
@@ -34,7 +34,6 @@ class TCSH(CSH):
                 if not txt.startswith("'"):
                     txt = "'%s'" % txt
             else:
-                txt = txt.replace('\\', '\\\\')
                 txt = txt.replace('"', '"\\""')
                 txt = txt.replace('!', '\\!')
                 txt = '"%s"' % txt


### PR DESCRIPTION
Fix a problem with escaping backslashes in tcsh under Mac OS which failed `selftest` on Mac OS. `tcsh` under Linux did not fail before and does still run after.

You can see the successful result via the Travis CI jobs:
This branch doesn't include the fix: https://travis-ci.org/Pixomondo/rez/builds/348841077
This branch does: https://travis-ci.org/Pixomondo/rez/builds/348840338

This fixes the tcsh issues which kept the tcsh tests on Mac OS from succeeding in #496 