### PR TITLE
Fix whitespace issue in PS1

### DIFF
--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -92,7 +92,7 @@ class SH(UnixShell):
 
     def _bind_interactive_rez(self):
         if config.set_prompt and self.settings.prompt:
-            self._addline('if [ -z "$REZ_STORED_PROMPT" ]; then export REZ_STORED_PROMPT=$PS1; fi')
+            self._addline('if [ -z "$REZ_STORED_PROMPT" ]; then export REZ_STORED_PROMPT="$PS1"; fi')
             if config.prefix_prompt:
                 cmd = 'export PS1="%s $REZ_STORED_PROMPT"'
             else:


### PR DESCRIPTION
Fixes the Travis CI issue when testing the sh shell. There was some whitespace in $PS1 which wasn't understood properly when exporting it.

Another step towards testing all shells, all the time in #496.