### PR TITLE
added support for different behavior of cli arg parsing, per subcommand

### DIFF
--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -1,6 +1,4 @@
-"""
-The main command-line entry point.
-"""
+"""The main command-line entry point."""
 import sys
 from rez.vendor.argparse import _StoreTrueAction, SUPPRESS
 from rez.cli._util import subcommands, LazyArgumentParser, _env_var_true
@@ -10,7 +8,8 @@ from rez import __version__
 
 
 class SetupRezSubParser(object):
-    """Callback class for lazily setting up rez sub-parsers."""
+    """Callback class for lazily setting up rez sub-parsers.
+    """
     def __init__(self, module_name):
         self.module_name = module_name
 
@@ -86,20 +85,47 @@ def run(command=None):
     subparser = parser.add_subparsers(dest='cmd', metavar='COMMAND')
     for subcommand in subcommands:
         module_name = "rez.cli.%s" % subcommand
+
         subparser.add_parser(
             subcommand,
             help='',  # required so that it can be setup later
             setup_subparser=SetupRezSubParser(module_name))
 
-    # parse args, but split extras into groups separated by "--"
-    all_args = ([command] + sys.argv[1:]) if command else sys.argv[1:]
-    arg_groups = [[]]
-    for arg in all_args:
-        if arg == '--':
-            arg_groups.append([])
-            continue
-        arg_groups[-1].append(arg)
-    opts = parser.parse_args(arg_groups[0])
+    # construct args list. Note that commands like 'rez-env foo' and
+    # 'rez env foo' are equivalent
+    if command:
+        args = [command] + sys.argv[1:]
+    elif len(sys.argv) > 1 and sys.argv[1] in subcommands:
+        command = sys.argv[1]
+        args = sys.argv[1:]
+    else:
+        args = sys.argv[1:]
+
+    # parse args depending on subcommand behaviour
+    if command:
+        arg_mode = subcommands[command].get("arg_mode")
+    else:
+        arg_mode = None
+
+    if arg_mode == "grouped":
+        # args split into groups by '--'
+        arg_groups = [[]]
+        for arg in args:
+            if arg == '--':
+                arg_groups.append([])
+                continue
+            arg_groups[-1].append(arg)
+
+        opts = parser.parse_args(arg_groups[0])
+        extra_arg_groups = arg_groups[1:]
+    elif arg_mode == "passthrough":
+        # unknown args passed in first extra_arg_group
+        opts, extra_args = parser.parse_known_args(args)
+        extra_arg_groups = [extra_args]
+    else:
+        # native arg parsing
+        opts = parser.parse_args(args)
+        extra_arg_groups = []
 
     if opts.debug or _env_var_true("REZ_DEBUG"):
         exc_type = None
@@ -107,7 +133,7 @@ def run(command=None):
         exc_type = RezError
 
     def run_cmd():
-        return opts.func(opts, opts.parser, arg_groups[1:])
+        return opts.func(opts, opts.parser, extra_arg_groups)
 
     if opts.profile:
         import cProfile
@@ -120,7 +146,6 @@ def run(command=None):
             raise
         except exc_type as e:
             print_error("%s: %s" % (e.__class__.__name__, str(e)))
-            #print >> sys.stderr, "rez: %s: %s" % (e.__class__.__name__, str(e))
             sys.exit(1)
 
     sys.exit(returncode or 0)

--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -5,36 +5,54 @@ from rez.vendor.argparse import _SubParsersAction, ArgumentParser, SUPPRESS, \
     ArgumentError
 
 
-subcommands = [
-    "bind",
-    "build",
-    "config",
-    "context",
-    "complete",
-    "depends",
-    "env",
-    "forward",
-    "help",
-    "interpret",
-    "python",
-    "plugins",
-    "pip",
-    "release",
-    "search",
-    "test",
-    "view",
-    "status",
-    "suite",
-    "memcache",
-    "selftest",
-    "yaml2py",
-    "diff",
-    "gui"]
-
-
-hidden_subcommands = [
-    "complete",
-    "forward"]
+# Subcommands and their behaviors.
+#
+# 'arg_mode' determines how cli args are parsed. Values are:
+# * 'grouped': Args can be separated by '--'. This causes args to be grouped into
+#   lists which are then passed as 'extra_arg_groups' to each command.
+# * 'passthrough': Unknown args are passed as first list in 'extra_arg_groups'.
+#   The '--' arg is not treated as a special case.
+# * missing: Native python argparse behavior.
+#
+subcommands = {
+    "bind": {},
+    "build": {
+        "arg_mode": "grouped"
+    },
+    "config": {},
+    "context": {},
+    "complete": {
+        "hidden": True
+    },
+    "depends": {},
+    "diff": {},
+    "env": {
+        "arg_mode": "grouped"
+    },
+    "forward": {
+        "hidden": True,
+        "arg_mode": "passthrough"
+    },
+    "gui": {},
+    "help": {},
+    "interpret": {},
+    "memcache": {},
+    "pip": {},
+    "plugins": {},
+    "python": {
+        "arg_mode": "passthrough"
+    },
+    "release": {
+        "arg_mode": "grouped"
+    },
+    "search": {},
+    "selftest": {},
+    "status": {},
+    "suite": {},
+    "test": {},
+    "view": {},
+    "yaml2py": {},
+}
 
 
 class LazySubParsersAction(_SubParsersAction):

--- a/src/rez/cli/complete.py
+++ b/src/rez/cli/complete.py
@@ -12,7 +12,7 @@ def setup_parser(parser, completions=False):
 
 
 def command(opts, parser, extra_arg_groups=None):
-    from rez.cli._util import subcommands, hidden_subcommands
+    from rez.cli._util import subcommands
     import os
     import re
 
@@ -53,7 +53,8 @@ def command(opts, parser, extra_arg_groups=None):
         subcommand = cmd.split("-", 1)[-1]
 
     if subcommand is None:
-        cmds = set(subcommands) - set(hidden_subcommands)
+        cmds = [k for k, v in subcommands.iteritems() if not v.get("hidden")]
+
         if prefix:
             cmds = (x for x in cmds if x.startswith(prefix))
         print " ".join(cmds)

--- a/src/rez/cli/python.py
+++ b/src/rez/cli/python.py
@@ -1,23 +1,18 @@
 """
 Start a python interpreter or execute a python script within Rez's own execution context.
+
+Unrecognised args are passed directly to the underlying python interpreter.
 """
 
 
 def setup_parser(parser, completions=False):
-    parser.add_argument(
-        "-i", "--interactive", action="store_true",
-        help="inspect interactively after FILE has run")
-    FILE_action = parser.add_argument(
+    file_action = parser.add_argument(
         "FILE", type=str, nargs='?',
         help='python script to execute')
-    parser.add_argument(
-        "ARG", type=str, nargs='*',
-        help='arguments to python script')
-    parser.add_argument('-c', help="python code to execute", dest='command')
 
     if completions:
         from rez.cli._complete_util import FilesCompleter
-        FILE_action.completer = FilesCompleter(dirs=False,
+        file_action.completer = FilesCompleter(dirs=False,
                                                file_patterns=["*.py"])
 
 
@@ -27,15 +22,11 @@ def command(opts, parser, extra_arg_groups=None):
 
     cmd = [sys.executable, "-E"]
 
-    if opts.interactive:
-        cmd.append("-i")
-
-    if opts.command:
-        cmd.extend(['-c', opts.command])
+    for arg_group in (extra_arg_groups or []):
+        cmd.extend(arg_group)
 
     if opts.FILE:
         cmd.append(opts.FILE)
-        cmd.extend(opts.ARG or [])
 
     p = subprocess.Popen(cmd)
     sys.exit(p.wait())

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.19.1"
+_rez_version = "2.20.0"
 
 try:
     from rez.vendor.version.version import Version


### PR DESCRIPTION
-rez-python now passes args directly to python subproc
-addresses https://github.com/nerdvegas/rez/issues/492
-deprecates https://github.com/nerdvegas/rez/pull/494
