### PR TITLE
Add a developer mode to rez-view

### DIFF
--- a/src/rez/cli/build.py
+++ b/src/rez/cli/build.py
@@ -61,9 +61,6 @@ def setup_parser(parser, completions=False):
         help="create build scripts rather than performing the full build. "
         "Running these scripts will place you into a build environment, where "
         "you can invoke the build system directly.")
-    parser.add_argument(
-        "--view-pre", action="store_true",
-        help="just view the preprocessed package definition, and exit.")
     setup_parser_common(parser)
 
 
@@ -90,16 +87,11 @@ def command(opts, parser, extra_arg_groups=None):
     from rez.packages_ import get_developer_package
     from rez.build_process_ import create_build_process
     from rez.build_system import create_build_system
-    from rez.serialise import FileFormat
     import sys
 
     # load package
     working_dir = os.getcwd()
     package = get_developer_package(working_dir)
-
-    if opts.view_pre:
-        package.print_info(format_=FileFormat.py, skip_attributes=["preprocess"])
-        sys.exit(0)
 
     # create build system
     build_args, child_build_args = get_build_args(opts, parser, extra_arg_groups)

--- a/src/rez/cli/view.py
+++ b/src/rez/cli/view.py
@@ -14,12 +14,28 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "-b", "--brief", action="store_true",
         help="do not print extraneous info, such as package uri")
-    parser.add_argument(
+
+    mutual_group = parser.add_mutually_exclusive_group()
+    mutual_group.add_argument(
+        "-d", "--developer", action="store_true",
+        help="all to give a path as package name to view the package.py in this path")
+    mutual_group.add_argument(
         "-c", "--current", action="store_true",
         help="show the package in the current context, if any")
+
+    parser.add_argument(
+        "-p", "--pretty", dest="pretty", action="store_true",
+        help="Prints the fields in a pretty manner, by default they are printed in raw format")
+    parser.add_argument(
+        "-s", "--separator", type=str,
+        help="Separator to be used when printing lists. defaults to empty space ")
+    parser.add_argument(
+        "--fields", nargs="*",
+        help="only show the given fields")
+
     PKG_action = parser.add_argument(
         "PKG", type=str,
-        help="the package to view")
+        help="the package to view (can be a path if -d/--developer is given)")
 
     if completions:
         from rez.cli._complete_util import PackageCompleter
@@ -29,11 +45,15 @@ def setup_parser(parser, completions=False):
 def command(opts, parser, extra_arg_groups=None):
     from rez.utils.formatting import PackageRequest
     from rez.serialise import FileFormat
-    from rez.packages_ import iter_packages
+    from rez.packages_ import iter_packages, get_developer_package
     from rez.status import status
+    from rez.exceptions import PackageMetadataError
+    import os
     import sys
 
-    req = PackageRequest(opts.PKG)
+    req = None
+    if not opts.developer:
+        req = PackageRequest(opts.PKG)
 
     if opts.current:
         context = status.context
@@ -47,7 +67,7 @@ def command(opts, parser, extra_arg_groups=None):
             sys.exit(1)
 
         package = variant.parent
-    else:
+    elif req:
         it = iter_packages(req.name, req.range)
         packages = sorted(it, key=lambda x: x.version)
 
@@ -56,6 +76,18 @@ def command(opts, parser, extra_arg_groups=None):
             sys.exit(1)
 
         package = packages[-1]
+    else:
+        path = os.path.abspath(opts.PKG)
+        if not os.path.exists(path):
+            print "The path %r does not exist" % path
+            sys.exit(-1)
+
+        try:
+            package = get_developer_package(path)
+        except PackageMetadataError:
+            print "There is no rez package at %s " % path
+            print "Please provide a valid path to a directory containing a package.py file."
+            sys.exit(-1)
 
     if not opts.brief:
         print "URI:"
@@ -64,11 +96,22 @@ def command(opts, parser, extra_arg_groups=None):
         print
         print "CONTENTS:"
 
-    if opts.format == "py":
+    format_fields = ["fields", "pretty", "separator"]
+    # If any of the --fields, --pretty and --separator argument are used, we want to use the
+    # txt format.
+    custom_format = any(getattr(opts, arg) != parser.get_default(arg) for arg in format_fields)
+    if custom_format:
+        format_ = FileFormat.txt
+    elif opts.format == "py":
         format_ = FileFormat.py
     else:
         format_ = FileFormat.yaml
-    package.print_info(format_=format_, include_release=opts.all)
+    package.print_info(format_=format_,
+                       include_release=opts.all,
+                       include_attributes=opts.fields,
+                       skip_attributes=["preprocess"],
+                       separator=opts.separator,
+                       pretty=opts.pretty)
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -97,15 +97,19 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
         return (self.resource._repository.uid == local_repo.uid)
 
     def print_info(self, buf=None, format_=FileFormat.yaml,
-                   skip_attributes=None, include_release=False):
+                   include_attributes=None, skip_attributes=None,
+                   include_release=False, separator=None, pretty=False):
         """Print the contents of the package.
 
         Args:
             buf (file-like object): Stream to write to.
             format_ (`FileFormat`): Format to write in.
+            include_attributes (list of str): List of attributes to print.
             skip_attributes (list of str): List of attributes to not print.
             include_release (bool): If True, include release-related attributes,
                 such as 'timestamp' and 'changelog'
+            separator (str): Separator to use to prin the fields (used only with pretty).
+            pretty (bool): Show every field in a pretty manner (no yaml/py).
         """
         data = self.validated_data().copy()
 
@@ -126,7 +130,8 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
 
         buf = buf or sys.stdout
         dump_package_data(data, buf=buf, format_=format_,
-                          skip_attributes=skip_attributes)
+                          include_attributes=include_attributes, skip_attributes=skip_attributes,
+                          separator=separator, pretty=pretty)
 
     def _wrap_forwarded(self, key, value):
         if isinstance(value, SourceCode) and value.late_binding:

--- a/src/rez/tests/data/package_serialise/py/package.py
+++ b/src/rez/tests/data/package_serialise/py/package.py
@@ -1,0 +1,21 @@
+name = 'usdBase'
+version = '0.8.al3.1.0'
+description = 'universal scene description'
+private_build_requires = ['cmake-2.8',
+                        'gcc-4.8',
+                        'gdb',
+                        ]
+requires = ['stdlib-4.8',
+            'tbb-4.4',
+            'ilmbase-2.2',
+            ]
+
+variants = [[ 'AL_boost-1.55.0', 'AL_boost_python-1.55'],
+['boost-1.55.0', 'boost_python-1.55']]
+
+use_chroot = True
+
+def commands():
+    prependenv('PATH', '{root}/bin')
+    prependenv('PYTHONPATH', '{root}/lib/python')
+    prependenv('LD_LIBRARY_PATH', '{root}/lib')

--- a/src/rez/tests/data/package_serialise/yaml/package.yaml
+++ b/src/rez/tests/data/package_serialise/yaml/package.yaml
@@ -1,0 +1,29 @@
+config_version : 0
+
+uuid: 97937642-3646-4966-ab9c-8f337bbbce6a
+
+name: rez
+
+version: 2.8.0.11
+
+authors: [ rez ]
+
+description: Rez is a suite of tools for resolving a list of packages
+
+help:
+- [ "Reference Guide", "$BROWSER http://nerdvegas.github.io/rez/" ]
+
+private_build_requires:
+- cmake-2.8
+
+requires:
+- setuptools
+- python
+
+variants:
+- [ CentOS-6.2+<7, python-2.6 ]
+- [ CentOS-6.2+<7, python-2.7 ]
+
+commands: |
+  prependenv('PATH', '{root}/bin/rez/')
+  setenv('REZ_PATH', '{root}')

--- a/src/rez/tests/test_package_serialise.py
+++ b/src/rez/tests/test_package_serialise.py
@@ -1,0 +1,418 @@
+"""
+test package serialisation
+"""
+import os
+import StringIO
+import rez.vendor.unittest2 as unittest
+
+from rez.serialise import FileFormat
+from rez.packages_ import get_developer_package
+from rez.package_serialise import dump_package_data
+
+
+class TestDumpYaml(unittest.TestCase):
+    """Test yaml serialisation"""
+
+    def setUp(self):
+        """Setup run at each test"""
+        super(TestDumpYaml, self).setUp()
+
+        self.buf = StringIO.StringIO()
+
+        path = os.path.realpath(os.path.dirname(__file__))
+        self.packages_base_path = os.path.join(path, "data", "package_serialise")
+
+    def test_simple(self):
+        """Without include or exclude"""
+        path = os.path.join(self.packages_base_path, "yaml")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.yaml
+        )
+        self.assertEqual(
+            "name: rez\n\n"
+            "version: 2.8.0.11\n\n"
+            "description: Rez is a suite of tools for resolving a list of packages\n\n"
+            "authors:\n"
+            "- rez\n\n"
+            "requires:\n"
+            "- setuptools\n"
+            "- python\n\n"
+            "private_build_requires:\n"
+            "- cmake-2.8\n\n"
+            "variants:\n"
+            "- - CentOS-6.2+<7\n"
+            "  - python-2.6\n"
+            "- - CentOS-6.2+<7\n"
+            "  - python-2.7\n\n"
+            "commands: |-\n"
+            "  prependenv('PATH', '{root}/bin/rez/')\n"
+            "  setenv('REZ_PATH', '{root}')\n\n"
+            "help:\n"
+            "- - Reference Guide\n"
+            "  - $BROWSER http://nerdvegas.github.io/rez/\n\n"
+            "uuid: 97937642-3646-4966-ab9c-8f337bbbce6a\n\n"
+            "config_version: 0\n",
+            self.buf.getvalue()
+        )
+
+    def test_include(self):
+        """With include only"""
+        path = os.path.join(self.packages_base_path, "yaml")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.yaml,
+            include_attributes=["name", "variants", "commands"]
+        )
+        self.assertEqual(
+            "name: rez\n\n"
+            "variants:\n"
+            "- - CentOS-6.2+<7\n"
+            "  - python-2.6\n"
+            "- - CentOS-6.2+<7\n"
+            "  - python-2.7\n\n"
+            "commands: |-\n"
+            "  prependenv('PATH', '{root}/bin/rez/')\n"
+            "  setenv('REZ_PATH', '{root}')\n",
+            self.buf.getvalue()
+        )
+
+    def test_exclude(self):
+        """With exclude only"""
+        path = os.path.join(self.packages_base_path, "yaml")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.yaml,
+            skip_attributes=["name", "variants", "commands"]
+        )
+        self.assertEqual(
+            "version: 2.8.0.11\n\n"
+            "description: Rez is a suite of tools for resolving a list of packages\n\n"
+            "authors:\n"
+            "- rez\n\n"
+            "requires:\n"
+            "- setuptools\n"
+            "- python\n\n"
+            "private_build_requires:\n"
+            "- cmake-2.8\n\n"
+            "help:\n"
+            "- - Reference Guide\n"
+            "  - $BROWSER http://nerdvegas.github.io/rez/\n\n"
+            "uuid: 97937642-3646-4966-ab9c-8f337bbbce6a\n\n"
+            "config_version: 0\n",
+            self.buf.getvalue()
+        )
+
+    def test_include_exclude(self):
+        """With exclude and exclude. Include wins over exclude"""
+        path = os.path.join(self.packages_base_path, "yaml")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.yaml,
+            include_attributes=["requires", "help", "variants"],
+            skip_attributes=["name", "variants", "commands"]
+        )
+        self.assertEqual(
+            "requires:\n"
+            "- setuptools\n"
+            "- python\n\n"
+            "variants:\n"
+            "- - CentOS-6.2+<7\n"
+            "  - python-2.6\n"
+            "- - CentOS-6.2+<7\n"
+            "  - python-2.7\n\n"
+            "help:\n"
+            "- - Reference Guide\n"
+            "  - $BROWSER http://nerdvegas.github.io/rez/\n",
+            self.buf.getvalue()
+        )
+
+
+class TestDumpPy(unittest.TestCase):
+    """Test Python serialisation"""
+
+    def setUp(self):
+        """Setup run at each test"""
+        super(TestDumpPy, self).setUp()
+
+        self.buf = StringIO.StringIO()
+
+        path = os.path.realpath(os.path.dirname(__file__))
+        self.packages_base_path = os.path.join(path, "data", "package_serialise")
+
+    def test_simple(self):
+        """Without include or exclude"""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.py
+        )
+        self.assertEqual(
+            "# -*- coding: utf-8 -*-\n\n"
+            "name = 'usdBase'\n\n"
+            "version = '0.8.al3.1.0'\n\n"
+            "description = 'universal scene description'\n\n"
+            "requires = [\n"
+            "    'stdlib-4.8',\n"
+            "    'tbb-4.4',\n"
+            "    'ilmbase-2.2'\n"
+            "]\n\n"
+            "private_build_requires = [\n"
+            "    'cmake-2.8',\n"
+            "    'gcc-4.8',\n"
+            "    'gdb'\n"
+            "]\n\n"
+            "variants = [\n"
+            "    ['AL_boost-1.55.0', 'AL_boost_python-1.55'],\n"
+            "    ['boost-1.55.0', 'boost_python-1.55']\n"
+            "]\n\n"
+            "def commands():\n"
+            "    prependenv('PATH', '{root}/bin')\n"
+            "    prependenv('PYTHONPATH', '{root}/lib/python')\n"
+            "    prependenv('LD_LIBRARY_PATH', '{root}/lib')\n\n"
+            "use_chroot = True\n",
+            self.buf.getvalue()
+        )
+
+    def test_include(self):
+        """With include only"""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.py,
+            include_attributes=["name", "variants", "commands"]
+        )
+        self.assertEqual(
+            "# -*- coding: utf-8 -*-\n\n"
+            "name = 'usdBase'\n\n"
+            "variants = [\n"
+            "    ['AL_boost-1.55.0', 'AL_boost_python-1.55'],\n"
+            "    ['boost-1.55.0', 'boost_python-1.55']\n"
+            "]\n\n"
+            "def commands():\n"
+            "    prependenv('PATH', '{root}/bin')\n"
+            "    prependenv('PYTHONPATH', '{root}/lib/python')\n"
+            "    prependenv('LD_LIBRARY_PATH', '{root}/lib')\n",
+            self.buf.getvalue()
+        )
+
+    def test_exclude(self):
+        """With exclude only"""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.py,
+            skip_attributes=["name", "variants", "commands"]
+        )
+        self.assertEqual(
+            "# -*- coding: utf-8 -*-\n\n"
+            "version = '0.8.al3.1.0'\n\n"
+            "description = 'universal scene description'\n\n"
+            "requires = [\n"
+            "    'stdlib-4.8',\n"
+            "    'tbb-4.4',\n"
+            "    'ilmbase-2.2'\n"
+            "]\n\n"
+            "private_build_requires = [\n"
+            "    'cmake-2.8',\n"
+            "    'gcc-4.8',\n"
+            "    'gdb'\n"
+            "]\n\n"
+            "use_chroot = True\n",
+            self.buf.getvalue()
+        )
+
+    def test_include_exclude(self):
+        """With exclude and exclude. Include wins over exclude"""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.py,
+            include_attributes=["requires", "help", "variants"],
+            skip_attributes=["name", "variants", "commands"]
+        )
+        self.assertEqual(
+            "# -*- coding: utf-8 -*-\n\n"
+            "requires = [\n"
+            "    'stdlib-4.8',\n"
+            "    'tbb-4.4',\n"
+            "    'ilmbase-2.2'\n"
+            "]\n\n"
+            "variants = [\n"
+            "    ['AL_boost-1.55.0', 'AL_boost_python-1.55'],\n"
+            "    ['boost-1.55.0', 'boost_python-1.55']\n"
+            "]\n",
+            self.buf.getvalue()
+        )
+
+
+class TestDumpTxt(unittest.TestCase):
+    """Test text serialisation"""
+
+    def setUp(self):
+        """Setup run at each test"""
+        super(TestDumpTxt, self).setUp()
+
+        self.buf = StringIO.StringIO()
+
+        path = os.path.realpath(os.path.dirname(__file__))
+        self.packages_base_path = os.path.join(path, "data", "package_serialise")
+
+    def test_simple(self):
+        """Without include or exclude. Separator: '' and pretty = False"""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.txt
+        )
+        self.assertEqual(
+            "usdBase\n"
+            "0.8.al3.1.0\n"
+            "universal scene description\n"
+            "['stdlib-4.8', 'tbb-4.4', 'ilmbase-2.2']\n"
+            "['cmake-2.8', 'gcc-4.8', 'gdb']\n"
+            "[['AL_boost-1.55.0', 'AL_boost_python-1.55'], ['boost-1.55.0', 'boost_python-1.55']]\n"
+            "prependenv('PATH', '{root}/bin')\n"
+            "prependenv('PYTHONPATH', '{root}/lib/python')\n"
+            "prependenv('LD_LIBRARY_PATH', '{root}/lib')\n"
+            "True\n",
+            self.buf.getvalue()
+        )
+
+    def test_include(self):
+        """With include only"""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.txt,
+            include_attributes=["name", "variants", "commands"]
+        )
+        self.assertEqual(
+            "usdBase\n"
+            "[['AL_boost-1.55.0', 'AL_boost_python-1.55'], ['boost-1.55.0', 'boost_python-1.55']]\n"
+            "prependenv('PATH', '{root}/bin')\n"
+            "prependenv('PYTHONPATH', '{root}/lib/python')\n"
+            "prependenv('LD_LIBRARY_PATH', '{root}/lib')\n",
+            self.buf.getvalue()
+        )
+
+    def test_exclude(self):
+        """With exclude only"""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.txt,
+            skip_attributes=["name", "variants", "commands"]
+        )
+        self.assertEqual(
+            "0.8.al3.1.0\n"
+            "universal scene description\n"
+            "['stdlib-4.8', 'tbb-4.4', 'ilmbase-2.2']\n"
+            "['cmake-2.8', 'gcc-4.8', 'gdb']\n"
+            "True\n",
+            self.buf.getvalue()
+        )
+
+    def test_include_exclude(self):
+        """With exclude and exclude. Include wins over exclude"""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.txt,
+            include_attributes=["requires", "help", "variants"],
+            skip_attributes=["name", "variants", "commands"],
+        )
+        self.assertEqual(
+            "['stdlib-4.8', 'tbb-4.4', 'ilmbase-2.2']\n"
+            "[['AL_boost-1.55.0', 'AL_boost_python-1.55'], ['boost-1.55.0', 'boost_python-1.55']]\n",
+            self.buf.getvalue()
+        )
+
+    def test_coma_separator_raw(self):
+        """Test with a coma as a separator in raw mode. It won't have an effect."""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.txt,
+            separator=" , ",
+            include_attributes=["requires"]
+        )
+
+        self.assertEqual("['stdlib-4.8', 'tbb-4.4', 'ilmbase-2.2']\n", self.buf.getvalue())
+
+    def test_coma_without_separator_pretty(self):
+        """Test without a separator in pretty mode."""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.txt,
+            include_attributes=["variants"],
+            pretty=True
+        )
+        self.assertEqual(
+            "AL_boost-1.55.0 AL_boost_python-1.55\n"
+            "boost-1.55.0 boost_python-1.55\n",
+            self.buf.getvalue()
+        )
+
+    def test_coma_separator_pretty(self):
+        """Test with a coma as a separator in pretty mode."""
+        path = os.path.join(self.packages_base_path, "py")
+        package = get_developer_package(path)
+
+        dump_package_data(
+            package.validated_data().copy(),
+            self.buf,
+            format_=FileFormat.txt,
+            separator=" , ",
+            include_attributes=["variants"],
+            pretty=True
+        )
+
+        self.assertEqual(
+            "AL_boost-1.55.0 , AL_boost_python-1.55\n"
+            "boost-1.55.0 , boost_python-1.55\n",
+            self.buf.getvalue()
+        )


### PR DESCRIPTION
`--developer` is used to query a package in a given path. It's useful to get the package information from a CI infra (Jenkins, Travis, etc)

This PR is a retake from https://github.com/nerdvegas/rez/pull/467. It does exactly the same thing, but with all the goods of `rez-view`. It also unifies the viewing functionalities (see discussions in the linked PR).

`rez-view . --developer` will give us the package in the current directory in YAML format.
`rez-view /path/to/package/dir --developer` does the same thing that `rez-view . --developer`

New arguments added to `rez-view` (except --developer):
* `--fields`: Allows to only print the given fields
* `--separator`: If used, separator to be used when printing lists. defaults to empty space.
* `--pretty`: Prints the fields in a pretty manner, by default they are printed in raw format.

For examples, please see the tests included in this PR.
