### PR TITLE
Call the flush method every time a Printer instance is called

### DIFF
--- a/src/rez/utils/colorize.py
+++ b/src/rez/utils/colorize.py
@@ -298,6 +298,7 @@ class Printer(object):
 
     def __call__(self, msg='', style=None):
         print >> self.buf, self.get(msg, style)
+        self.buf.flush()
 
     def get(self, msg, style=None):
         if style and self.colorize:


### PR DESCRIPTION
This is a really really simple PR.

Logs printed with `rez.utils.colorize.Printer` are being buffered for too long and it's causing the logs to be unordered in multiple cases (simply with `rez-env -- some commands  1> /tmp/file` or under Jenkins).

So I'm just flushing the buffer given to Printer every time it prints.