### PR TITLE
Issue 549

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
 
+## 2.26.0 [[#???](https://github.com/nerdvegas/rez/pull/???)] Build System Detection Fixes
+
+#### Addressed Issues
+
+* [#549](https://github.com/nerdvegas/rez/issues/549) '--build-system' rez-build option not always
+  available
+
+#### Notes
+
+To fix this issue:
+* The '--build-system' rez-build option is now always present.
+* To provide further control over the build system type, the package itself can not specify its build
+  system - see https://github.com/nerdvegas/rez/wiki/Package-Definition-Guide#build_system
+
+#### COMPATIBILITY ISSUE!
+
+Unfortunately, the 'cmake' build system had its own '--build-system' commandline option also. This
+was possible because previous rez versions suppressed the standard '--build-system' option if only
+one valid build system was present for a given package working directory. **This option has been
+changed to --cmake-build-system**.
+
 
 ## 2.25.0 [[#548](https://github.com/nerdvegas/rez/pull/548)] Various Build-related issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 To fix this issue:
 * The '--build-system' rez-build option is now always present.
-* To provide further control over the build system type, the package itself can not specify its build
+* To provide further control over the build system type, the package itself can now specify its build
   system - see https://github.com/nerdvegas/rez/wiki/Package-Definition-Guide#build_system
 
 #### COMPATIBILITY ISSUE!
@@ -18,7 +18,7 @@ To fix this issue:
 Unfortunately, the 'cmake' build system had its own '--build-system' commandline option also. This
 was possible because previous rez versions suppressed the standard '--build-system' option if only
 one valid build system was present for a given package working directory. **This option has been
-changed to --cmake-build-system**.
+changed to '--cmake-build-system'**.
 
 
 ## 2.25.0 [[#548](https://github.com/nerdvegas/rez/pull/548)] Various Build-related issues

--- a/src/rez/cli/build.py
+++ b/src/rez/cli/build.py
@@ -4,6 +4,24 @@ Build a package from source.
 import os
 
 
+# Cache the developer package loaded from cwd. This is so the package is only
+# loaded once, even though it's required once at arg parsing time (to determine
+# valid build system types), and once at command run time.
+#
+_package = None
+
+
+def get_current_developer_package():
+    from rez.packages_ import get_developer_package
+
+    global _package
+
+    if _package is None:
+        _package = get_developer_package(os.getcwd())
+
+    return _package
+
+
 def setup_parser_common(parser):
     """Parser setup common to both rez-build and rez-release."""
     from rez.build_process_ import get_build_process_types
@@ -14,29 +32,36 @@ def setup_parser_common(parser):
         "--process", type=str, choices=process_types, default="local",
         help="the build process to use (default: %(default)s).")
 
-    # add build system option only if one build system is associated with cwd
-    clss = get_valid_build_systems(os.getcwd())
+    # add build system choices valid for this package
+    package = get_current_developer_package()
+    clss = get_valid_build_systems(os.getcwd(), package=package)
 
     if clss:
         if len(clss) == 1:
-            cls = clss[0]
-            cls.bind_cli(parser)
-        else:
-            types = [x.name() for x in clss]
-            parser.add_argument(
-                "-b", "--build-system", dest="buildsys", type=str, choices=types,
-                help="the build system to use.")
+            cls_ = clss[0]
+            title = "%s build system arguments" % cls_.name()
+            group = parser.add_argument_group(title)
+            cls_.bind_cli(group)
+
+        types = [x.name() for x in clss]
+    else:
+        types = None
+
+    parser.add_argument(
+        "-b", "--build-system", dest="buildsys", choices=types,
+        help="the build system to use. If not specified, it is detected. Set "
+        "'build_system' or 'build_command' to specify the build system in the "
+        "package itself.")
 
     parser.add_argument(
         "--variants", nargs='+', type=int, metavar="INDEX",
         help="select variants to build (zero-indexed).")
     parser.add_argument(
-        "--ba", "--build-args", dest="build_args", type=str, metavar="ARGS",
+        "--ba", "--build-args", dest="build_args", metavar="ARGS",
         help="arguments to pass to the build system. Alternatively, list these "
-        "after a '--'")
+        "after a '--'.")
     parser.add_argument(
-        "--cba", "--child-build-args", dest="child_build_args", type=str,
-        metavar="ARGS",
+        "--cba", "--child-build-args", dest="child_build_args", metavar="ARGS",
         help="arguments to pass to the child build system, if any. "
         "Alternatively, list these after a second '--'.")
 
@@ -51,7 +76,7 @@ def setup_parser(parser, completions=False):
         "choose a custom install path.")
     parser.add_argument(
         "-p", "--prefix", type=str, metavar='PATH',
-        help="install to a custom path.")
+        help="install to a custom package repository path.")
     parser.add_argument(
         "--fail-graph", action="store_true",
         help="if the build environment fails to resolve due to a conflict, "
@@ -87,7 +112,6 @@ def get_build_args(opts, parser, extra_arg_groups):
 
 def command(opts, parser, extra_arg_groups=None):
     from rez.exceptions import BuildContextResolveError
-    from rez.packages_ import get_developer_package
     from rez.build_process_ import create_build_process
     from rez.build_system import create_build_system
     from rez.serialise import FileFormat
@@ -95,7 +119,7 @@ def command(opts, parser, extra_arg_groups=None):
 
     # load package
     working_dir = os.getcwd()
-    package = get_developer_package(working_dir)
+    package = get_current_developer_package()
 
     if opts.view_pre:
         package.print_info(format_=FileFormat.py, skip_attributes=["preprocess"])
@@ -103,11 +127,10 @@ def command(opts, parser, extra_arg_groups=None):
 
     # create build system
     build_args, child_build_args = get_build_args(opts, parser, extra_arg_groups)
-    buildsys_type = opts.buildsys if ("buildsys" in opts) else None
 
     buildsys = create_build_system(working_dir,
                                    package=package,
-                                   buildsys_type=buildsys_type,
+                                   buildsys_type=opts.buildsys,
                                    opts=opts,
                                    write_build_scripts=opts.scripts,
                                    verbose=True,

--- a/src/rez/cli/release.py
+++ b/src/rez/cli/release.py
@@ -9,6 +9,7 @@ from subprocess import call
 def setup_parser(parser, completions=False):
     from rez.cli.build import setup_parser_common
     from rez.release_vcs import get_release_vcs_types
+
     vcs_types = get_release_vcs_types()
     parser.add_argument(
         "-m", "--message", type=str,
@@ -36,16 +37,15 @@ def setup_parser(parser, completions=False):
 
 
 def command(opts, parser, extra_arg_groups=None):
-    from rez.packages_ import get_developer_package
     from rez.build_process_ import create_build_process
     from rez.build_system import create_build_system
     from rez.release_vcs import create_release_vcs
-    from rez.cli.build import get_build_args
+    from rez.cli.build import get_build_args, get_current_developer_package
     from rez.config import config
 
     # load package
     working_dir = os.getcwd()
-    package = get_developer_package(working_dir)
+    package = get_current_developer_package()
 
     # create vcs
     vcs = create_release_vcs(working_dir, opts.vcs)

--- a/src/rez/package_maker__.py
+++ b/src/rez/package_maker__.py
@@ -62,6 +62,7 @@ package_schema = Schema({
     Optional('post_commands'):          _commands_schema,
 
     # attributes specific to pre-built packages
+    Optional("build_system"):           basestring,
     Optional("build_command"):          Or([basestring], basestring, False),
     Optional("preprocess"):             _function_schema,
 

--- a/src/rez/package_resources_.py
+++ b/src/rez/package_resources_.py
@@ -26,6 +26,7 @@ package_release_keys = (
 # package attributes that we don't install
 package_build_only_keys = (
     "requires_rez_version",
+    "build_system",
     "build_command",
     "preprocess",
 )

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.25.0"
+_rez_version = "2.26.0"
 
 try:
     from rez.vendor.version.version import Version

--- a/src/rezplugins/build_system/bez.py
+++ b/src/rezplugins/build_system/bez.py
@@ -31,7 +31,7 @@ class BezBuildSystem(BuildSystem):
         return "bez"
 
     @classmethod
-    def is_valid_root(cls, path):
+    def is_valid_root(cls, path, package=None):
         return os.path.isfile(os.path.join(path, "rezbuild.py"))
 
     def __init__(self, working_dir, opts=None, package=None, write_build_scripts=False,

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -38,22 +38,22 @@ class CMakeBuildSystem(BuildSystem):
     """
 
     build_systems = {
-        'eclipse':     "Eclipse CDT4 - Unix Makefiles",
-        'codeblocks':  "CodeBlocks - Unix Makefiles",
-        'make':        "Unix Makefiles",
-        'nmake':       "NMake Makefiles",
-        'mingw':       "MinGW Makefiles",
-        'xcode':       "Xcode"
+        'eclipse': "Eclipse CDT4 - Unix Makefiles",
+        'codeblocks': "CodeBlocks - Unix Makefiles",
+        'make': "Unix Makefiles",
+        'nmake': "NMake Makefiles",
+        'mingw': "MinGW Makefiles",
+        'xcode': "Xcode"
     }
 
     build_targets = ["Debug", "Release", "RelWithDebInfo"]
 
     schema_dict = {
-        "build_target":     Or(*build_targets),
-        "build_system":     Or(*build_systems.keys()),
-        "cmake_args":       [basestring],
-        "cmake_binary":     Or(None, basestring),
-        "make_binary":     Or(None, basestring)
+        "build_target": Or(*build_targets),
+        "build_system": Or(*build_systems.keys()),
+        "cmake_args": [basestring],
+        "cmake_binary": Or(None, basestring),
+        "make_binary": Or(None, basestring)
     }
 
     @classmethod
@@ -65,7 +65,7 @@ class CMakeBuildSystem(BuildSystem):
         return "make"
 
     @classmethod
-    def is_valid_root(cls, path):
+    def is_valid_root(cls, path, package=None):
         return os.path.isfile(os.path.join(path, "CMakeLists.txt"))
 
     @classmethod
@@ -75,8 +75,8 @@ class CMakeBuildSystem(BuildSystem):
                             type=str, choices=cls.build_targets,
                             default=settings.build_target,
                             help="set the build target (default: %(default)s).")
-        parser.add_argument("--bs", "--build-system", dest="build_system",
-                            type=str, choices=cls.build_systems.keys(),
+        parser.add_argument("--bs", "--cmake-build-system",
+                            choices=cls.build_systems.keys(),
                             default=settings.build_system,
                             help="set the cmake build system (default: %(default)s).")
 
@@ -92,8 +92,9 @@ class CMakeBuildSystem(BuildSystem):
             child_build_args=child_build_args)
 
         self.settings = self.package.config.plugins.build_system.cmake
-        self.build_target = (opts and opts.build_target) or self.settings.build_target
-        self.cmake_build_system = (opts and opts.build_system) or self.settings.build_system
+        self.build_target = getattr(opts, "build_target", self.settings.build_target)
+        self.cmake_build_system = getattr(opts, "cmake_build_system", self.settings.build_system)
+
         if self.cmake_build_system == 'xcode' and platform_.name != 'osx':
             raise RezCMakeError("Generation of Xcode project only available "
                                 "on the OSX platform")

--- a/src/rezplugins/build_system/custom.py
+++ b/src/rezplugins/build_system/custom.py
@@ -22,23 +22,29 @@ class CustomBuildSystem(BuildSystem):
 
     For example, consider the package.py snippet:
 
-        build_commands = "bash {root}/build.sh"
+        build_commands = "bash {root}/build.sh {install}"
 
     This will run the given bash command in the build path - this is typically
     located somewhere under the 'build' dir under the root dir containing the
-    package.py. The '{root}' string will expand to the source directory (the
-    one containing the package.py).
+    package.py.
+
+    The '{root}' string will expand to the source directory (the one containing
+    the package.py).
+
+    The '{install}' string will expand to 'install' if an install is occuring,
+    and the empty string ('') otherwise.
     """
     @classmethod
     def name(cls):
         return "custom"
 
     @classmethod
-    def is_valid_root(cls, path):
-        try:
-            package = get_developer_package(path)
-        except PackageMetadataError:
-            return False
+    def is_valid_root(cls, path, package=None):
+        if package is None:
+            try:
+                package = get_developer_package(path)
+            except PackageMetadataError:
+                return False
 
         return (getattr(package, "build_command", None) is not None)
 

--- a/src/rezplugins/build_system/make.py
+++ b/src/rezplugins/build_system/make.py
@@ -11,7 +11,7 @@ class MakeBuildSystem(BuildSystem):
         return "make"
 
     @classmethod
-    def is_valid_root(cls, path):
+    def is_valid_root(cls, path, package=None):
         return os.path.isfile(os.path.join(path, "Makefile"))
 
     def __init__(self, working_dir, opts=None, package=None, write_build_scripts=False,

--- a/wiki/pages/Package-Definition-Guide.md
+++ b/wiki/pages/Package-Definition-Guide.md
@@ -744,6 +744,14 @@ otherwise. This is useful for passing the install target directly to the command
 using *make*) rather than relying on a build script checking the *REZ_BUILD_INSTALL* environment
 variable.
 
+### build_system
+*String*
+
+    build_system = "cmake"
+
+Specify the build system used to build this package. If not set, it is detected automatically when
+a build occurs (or the user specifies it using the `--build-system` option).
+
 ### preprocess
 *Function*
 


### PR DESCRIPTION
## 2.26.0 Build System Detection Fixes

#### Addressed Issues

* [#549](https://github.com/nerdvegas/rez/issues/549) '--build-system' rez-build option not always
  available

#### Notes

To fix this issue:
* The '--build-system' rez-build option is now always present.
* To provide further control over the build system type, the package itself can now specify its build
  system - see https://github.com/nerdvegas/rez/wiki/Package-Definition-Guide#build_system

#### COMPATIBILITY ISSUE!

Unfortunately, the 'cmake' build system had its own '--build-system' commandline option also. This
was possible because previous rez versions suppressed the standard '--build-system' option if only
one valid build system was present for a given package working directory. **This option has been
changed to '--cmake-build-system'**.
