### PR TITLE
Issue 551

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+## 2.26.1 [[#552](https://github.com/nerdvegas/rez/pull/552)] Bugfix in Package Copy
+
+#### Addressed Issues
+
+* [#551](https://github.com/nerdvegas/rez/issues/551) package copy fails if symlinks in root dir
+
+#### Notes
+
+This was failing when symlinks were present within a non-varianted package being copied. Now, these
+symlinks are retained in the target package, unless `--follow-symlinks` is specified.
+
 ## 2.26.0 [[#550](https://github.com/nerdvegas/rez/pull/550)] Build System Detection Fixes
 
 #### Addressed Issues

--- a/src/rez/package_copy.py
+++ b/src/rez/package_copy.py
@@ -242,15 +242,13 @@ def _copy_variant_payload(src_variant, dest_pkg_repo, shallow=False,
                                                 src_variant.subpath)
 
         # perform the copy/symlinking
+        copy_func = partial(replacing_copy,
+                            follow_symlinks=follow_symlinks)
+
         if shallow:
             maybe_symlink = replacing_symlink
         else:
-            maybe_symlink = partial(
-                replacing_copy,
-                copytree_kwargs={
-                    "symlinks": (not follow_symlinks)
-                }
-            )
+            maybe_symlink = copy_func
 
         if src_variant.subpath:
             # symlink/copy the last install dir to the variant root
@@ -259,7 +257,7 @@ def _copy_variant_payload(src_variant, dest_pkg_repo, shallow=False,
         else:
             safe_makedirs(variant_install_path)
 
-            # copy all files, and symlink/copy all dirs within the variant
+            # copy all files, and symlink/copy all dirs within the null variant
             for name in os.listdir(variant_root):
                 src_path = os.path.join(variant_root, name)
                 dest_path = os.path.join(variant_install_path, name)
@@ -267,7 +265,7 @@ def _copy_variant_payload(src_variant, dest_pkg_repo, shallow=False,
                 if os.path.isdir(src_path) and not os.path.islink(src_path):
                     maybe_symlink(src_path, dest_path)
                 else:
-                    replacing_copy(src_path, dest_path)
+                    copy_func(src_path, dest_path)
 
 
 def _copy_package_include_modules(src_package, dest_pkg_repo, overrides=None):

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.26.0"
+_rez_version = "2.26.1"
 
 try:
     from rez.vendor.version.version import Version


### PR DESCRIPTION
## 2.26.1

#### Addressed Issues

* [#551](https://github.com/nerdvegas/rez/issues/551) package copy fails if symlinks in root dir

#### Notes

This was failing when symlinks were present within a non-varianted package being copied. Now, these
symlinks are retained in the target package, unless `--follow-symlinks` is specified.