### PR TITLE
2.26.2 Package Copy Fixes For Non-Varianted Packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 
+## 2.26.2 [[#XXX](https://github.com/nerdvegas/rez/pull/XXX)] Package Copy Fixes For Non-Varianted Packages
+
+#### Addressed Issues
+
+* [#556](https://github.com/nerdvegas/rez/issues/556) rez-cp briefly copies original package definition in non-varianted packages
+* [#555](https://github.com/nerdvegas/rez/issues/555) rez-cp inconsistent symlinking when --shallow=true
+* [#554](https://github.com/nerdvegas/rez/issues/554) rez-cp doesn't keep file metadata in some cases
+
+#### Notes
+
+There were various minor issues related to copying non-varianted packages.
+
 ## 2.26.1 [[#552](https://github.com/nerdvegas/rez/pull/552)] Bugfix in Package Copy
 
 #### Addressed Issues

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,48 @@
+# Releasing New Rez Versions
+
+If you are a collaborator and have push access to master, these are the steps to
+follow to release a new version:
+
+1. Make sure that the version in `utils/_version.py` is updated appropriately.
+   Rez uses [semantic versioning](https://semver.org/).
+1. Before pushing your branch, update `CHANGELOG.md` to describe the changes. Follow
+   the existing structure. The PR for the merge appears in square brackets in the
+   title (eg `[#552]`); since this PR doesn't exist yet, just leave `[#XXX]` as a
+   placeholder.
+2. Push your changes, and create a PR to master. In that PR's description, copy
+   the markdown you added to the changelog for this release. Change only the title
+   - just put the version number there.
+3. Once approved, merge to master.
+4. In master, go back to `CHANGELOG.md` and update the PR number appropriately.
+5. Run tag.sh. This tags the git repo with the version in `utils/_version.py`.
+6. Do a `git push` to push changelog update, and a `git push --tags` to push the
+   new tag.
+7. Goto [https://github.com/nerdvegas/rez/releases] and create a new release. Use
+   the changelog markdown as the starting point, and format appropriately (look
+   at existing release notes to see what to do).
+
+## Example Changelog Entry
+
+```
+## 1.2.3 [[#000](https://github.com/nerdvegas/rez/pull/456)] Release Title Here
+
+#### Addressed Issues
+
+* [#000](https://github.com/nerdvegas/rez/issues/000) some thing is broken
+* [#001](https://github.com/nerdvegas/rez/issues/001) some other thing is broken
+
+#### Merged PRs
+
+* [#002](https://github.com/nerdvegas/rez/pull/002) fixed the floober
+* [#003](https://github.com/nerdvegas/rez/pull/003) added missing flaaber
+
+#### Notes
+
+Notes about the new release go here. These should add any info that isn't
+necessarily obvious from the linked issues.
+
+#### COMPATIBILITY ISSUE!
+
+Put any notes here in the unfortunate case where some form of backwards
+incompatibility is unavoidable. This is rare.
+```

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.26.1"
+_rez_version = "2.26.2"
 
 try:
     from rez.vendor.version.version import Version

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -144,7 +144,7 @@ def replacing_copy(src, dest, follow_symlinks=False):
             shutil.copytree(src, tmp_dest, symlinks=(not follow_symlinks))
         else:
             # copy a file
-            shutil.copy(src, tmp_dest)
+            shutil.copy2(src, tmp_dest)
 
         replace_file_or_dir(dest, tmp_dest)
 
@@ -177,7 +177,7 @@ def replace_file_or_dir(dest, source):
 
 
 def additive_copytree(src, dst, symlinks=False, ignore=None):
-    """Version of `copytree` that can overwrite an existing directory.
+    """Version of `copytree` that merges into an existing directory.
     """
     if not os.path.exists(dst):
         os.makedirs(dst)


### PR DESCRIPTION
#### Addressed Issues

* [#556](https://github.com/nerdvegas/rez/issues/556) rez-cp briefly copies original package definition in non-varianted packages
* [#555](https://github.com/nerdvegas/rez/issues/555) rez-cp inconsistent symlinking when --shallow=true
* [#554](https://github.com/nerdvegas/rez/issues/554) rez-cp doesn't keep file metadata in some cases

#### Notes

There were various minor issues related to copying non-varianted packages.