### PR TITLE
2.26.3 package.py permissions issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.26.3 [[#XXX](https://github.com/nerdvegas/rez/pull/XXX)] Package Copy Fixes For Non-Varianted Packages
+
+#### Addressed Issues
+
+* [#559](https://github.com/nerdvegas/rez/issues/559) package.py permissions issue
+
+#### Notes
+
+Fixes issue where installed `package.py` can be set to r/w for only the current user.
 
 ## 2.26.2 [[#557](https://github.com/nerdvegas/rez/pull/557)] Package Copy Fixes For Non-Varianted Packages
 

--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -40,12 +40,19 @@ class FileFormat(Enum):
 
 
 @contextmanager
-def open_file_for_write(filepath):
+def open_file_for_write(filepath, mode=None):
     """Writes both to given filepath, and tmpdir location.
 
     This is to get around the problem with some NFS's where immediately reading
     a file that has just been written is problematic. Instead, any files that we
     write, we also write to /tmp, and reads of these files are redirected there.
+
+    Args:
+        filepath (str): File to write.
+        mode (int): Same mode arg as you would pass to `os.chmod`.
+
+    Yields:
+        File-like object.
     """
     stream = StringIO()
     yield stream
@@ -59,6 +66,9 @@ def open_file_for_write(filepath):
 
     with atomic_write(filepath, overwrite=True) as f:
         f.write(content)
+
+    if mode is not None:
+        os.chmod(filepath, mode)
 
     with open(cache_filepath, 'w') as f:
         f.write(content)

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.26.2"
+_rez_version = "2.26.3"
 
 try:
     from rez.vendor.version.version import Version

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -4,6 +4,7 @@ Filesystem-based package repository
 from contextlib import contextmanager
 import os.path
 import os
+import stat
 import time
 
 from rez.package_repository import PackageRepository
@@ -438,6 +439,7 @@ class FileSystemPackageRepository(PackageRepository):
                    "package_filenames": [basestring]}
 
     building_prefix = ".building"
+    package_file_mode = (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
     @classmethod
     def name(cls):
@@ -1034,7 +1036,7 @@ class FileSystemPackageRepository(PackageRepository):
         package_file = ".".join([package_filename, package_extension])
         filepath = os.path.join(pkg_base_path, package_file)
 
-        with open_file_for_write(filepath) as f:
+        with open_file_for_write(filepath, mode=self.package_file_mode) as f:
             dump_package_data(package_data, buf=f, format_=package_format)
 
         # delete the tmp 'building' file.


### PR DESCRIPTION
#### Addressed Issues

* [#559](https://github.com/nerdvegas/rez/issues/559) package.py permissions issue

#### Notes

Fixes issue where installed `package.py` can be set to r/w for only the current user.
