### PR TITLE
Fixed Regression in 2.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.26.4 [[#562](https://github.com/nerdvegas/rez/pull/562)] Fixed Regression in 2.24.0
+
+#### Addressed Issues
+
+* [#561](https://github.com/nerdvegas/rez/issues/561) timestamp not written to installed package
+
 ## 2.26.3 [[#560](https://github.com/nerdvegas/rez/pull/560)] Package.py permissions issue
 
 #### Addressed Issues

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.26.3"
+_rez_version = "2.26.4"
 
 try:
     from rez.vendor.version.version import Version

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1026,7 +1026,7 @@ class FileSystemPackageRepository(PackageRepository):
                     package_data[key] = value
 
         # timestamp defaults to now if not specified
-        if "timestamp" not in package_data:
+        if not package_data.get("timestamp"):
             package_data["timestamp"] = int(time.time())
 
         # format version is always set


### PR DESCRIPTION
#### Addressed Issues

* [#561](https://github.com/nerdvegas/rez/issues/561) timestamp not written to installed package
