### PR TITLE
package_test.py: fix rez-test header command with %

### DIFF
--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -203,7 +203,7 @@ class PackageTestRunner(object):
                 else:
                     cmd_str = ' '.join(map(quote, command))
 
-                print_header("\nRunning test command: %s\n" % cmd_str)
+                print_header("\nRunning test command: %s\n", cmd_str)
 
             retcode, _, _ = context.execute_shell(
                 command=command,


### PR DESCRIPTION
We had a test with a command that contains a % that was raising because of a bad use of print_header in package_test.py.

```
print_header("Running test commange: my command 3%")
FAIL

print_header("Running test commange",  "my command 3%")
OK
```