### PR TITLE
[Feature] Install as package

### DIFF
--- a/.github/workflows/install-as-package-test.yml
+++ b/.github/workflows/install-as-package-test.yml
@@ -1,0 +1,62 @@
+# JUST AN EXPERIMENT - delete/replace as necessary before merge
+name: Experimenting with actions - PR 579
+on: [push]
+
+jobs:
+  linux:
+    name: Ubuntu - install prod. venv
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.7']
+        package-name: ['rez', 'foo']
+        rez-shell: ['bash', 'tcsh']
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+
+    - name: Check install.py help
+      run: |
+        python install.py --help
+
+    - name: Install as rez package into HOME/packages
+      run: |
+        INSTALL_LOG=$(mktemp)
+        if [ "${{ matrix.package-name }}" == "rez" ]
+        then
+          INSTALL_FLAGS="-p"
+        else
+          INSTALL_FLAGS="-P ${{ matrix.package-name }}"
+        fi
+        python install.py ${INSTALL_FLAGS} ${HOME}/packages |& tee ${INSTALL_LOG}
+        # Setup rez activation scripts
+        echo "export PATH=${PATH}:$(sed -n '/to .PATH:/ {n;p;q}' ${INSTALL_LOG})" > setup-rez.sh
+
+    - name: View rez rez package
+      run: |
+        source setup-rez.sh
+        find ${HOME}/packages -maxdepth 5
+        rez view ${{ matrix.package-name }}
+
+    - name: Bind Python and check rez env
+      run: |
+        source setup-rez.sh
+        rez bind python
+        rez env ${{ matrix.package-name }} -- rez context
+
+    - name: rez-selftest
+      env:
+        _REZ_SHELL: ${{ matrix.rez-shell }}
+      run: |
+        source setup-rez.sh
+        if [ "$_REZ_SHELL" == "tcsh" ]; then sudo apt-get install tcsh; fi
+        $(rez env ${{ matrix.package-name }} -- which rez-selftest) -s ${_REZ_SHELL}
+
+    # - name: Install in Python Docker Image


### PR DESCRIPTION
Added `-p` and `-P` options during install to install `rez` as a package under the given install directory (typically a packages)

> :robot: [See our `Experimenting with actions - PR 579` GitHub actions workflow](https://github.com/wwfxuk/rez/actions?workflow=Experimenting%20with%20actions%20-%20PR%20579) for some experimental CI and tests! :robot: 

For now, this PR will only focus on `install.py` to perform a production friendly install just requiring `python`. The rez package will be setup up with the variants: 
- `platform-`system platform name (e.g. `linux`), and
- `python-MAJOR.MINOR` for the Python version used to run `python install.py`

So far, it is not intended to replace `rez bind rez`, but maybe at some point (see below).
It does install the rez package in a similar structure and performs package commands to setup the following:

- Add `{root}/bin/rez` into `PATH`
- Copy `{root}/lib/python*//rez*` into `{root}/python` (for clean Python imports of `rez*` modules)
- Add `{root}/python` into `PYTHONPATH`

e.g. for [commit d987f7d](https://github.com/wwfxuk/rez/runs/228702023)

<details>
 <summary>python install.py --help</summary>

```
usage: Rez installer [-h] [-v] [-s] [-p | -P PACKAGE] [DIR]

Install rez in a production ready, standalone Python virtual environment.

positional arguments:
  DIR                   Destination directory. If '{version}' is present, it
                        will be expanded to the rez version. Default: /opt/rez

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Increase verbosity.
  -s, --keep-symlinks   Don't run realpath on the passed DIR to resolve
                        symlinks; ie, the baked script locations may still
                        contain symlinks
  -p, --as-rez-package  Install using rez package structure as 'rez'. (DIR
                        should be a rez packages directory)
  -P PACKAGE, --as-package PACKAGE
                        Given a package name, install using rez package
                        structure. (DIR should be a rez packages directory)
```
</details>


<details>
<summary>python install.py -p ~/packages will install as:</summary>

```
~/packages
~/packages/rez
~/packages/rez/2.47.2
~/packages/rez/2.47.2/package.py
~/packages/rez/2.47.2/platform-linux
~/packages/rez/2.47.2/platform-linux/python-2.7
~/packages/rez/2.47.2/platform-linux/python-2.7/python
~/packages/rez/2.47.2/platform-linux/python-2.7/bin
~/packages/rez/2.47.2/platform-linux/python-2.7/lib
~/packages/rez/2.47.2/platform-linux/python-2.7/include
~/packages/rez/2.47.2/platform-linux/python-2.7/completion
```
</details>

<details>
<summary>rez view rez</summary>

```
URI:
/home/runner/packages/rez/2.47.2/package.py

CONTENTS:
name: rez

version: 2.47.2

description: Standalone, production-ready Rez installation

variants:
- - platform-linux
  - python-2.7

commands: "\"\"\"Setup PYTHONPATH (inspired by src/rez/bind/rez.py).\"\"\"\nimport\
  \ os\nenv.PATH.append(os.path.join('{root}', 'bin', 'rez'))\nenv.PYTHONPATH.append(os.path.join('{root}',\
  \ 'python'))\n\nif defined('SHELL'):\n    is_csh = \"csh\" in str(env.SHELL)\n \
  \   ext = \"csh\" if is_csh else \"sh\"  # Basic selection logic\n    source(os.path.join('{root}',\
  \ 'completion', 'complete.' + ext))"

base: /home/runner/packages/rez/2.47.2
```
</details>

This feature was originally suggest for v2.27 but has been rebase'd and adapted to the latest rez versions since. Needless to say, the various evolution and improvements to rez has put this feature in an interesting spot. 

# Highlights from discussions below

## pip install compatible

`rez` now uses `pip install` internally in `install.py`! Therefore after downloading/`git clone` this repository, one can install rez via several methods (assuming you're running from same folder as rez's `install.py`/`setup.py`):

```bash
# 1. The OG method into a Python venv (production safe), then install rez using venv's pip install
python install.py DEST_DIR   

# 2. pip install using current folder as pip package
pip install --target DEST_DIR . 

# 3. if you have rez already installed, install rez as pip Python package into local package path
# See https://github.com/nerdvegas/rez/wiki/Configuring-Rez#local_packages_path
rez-pip --install .   
```
In the current state of this PR/feature, it more closely follows `1`. It's able to install `rez` even if rez is not currently installed.

Since pip based `2` and `3` installs do not install rez into a venv, more work will need to be done to this PR to get it to be `pip` friendly. See https://github.com/nerdvegas/rez/pull/579#issuecomment-504947600, https://github.com/nerdvegas/rez/pull/579#issuecomment-526801383, https://github.com/nerdvegas/rez/pull/579#issuecomment-528693763

## Deprecate rez bind rez

Since this PR installs into a similar structure/package declaration as the rez package produced by `rez bind rez`, given some extra work, maybe even this PR can deprecate the rez `rez bind`.

`rez bind rez` currently sets up only the rez Python modules into a `rez` package. This is similar to the `pip` style installs (`2` and `3`), but just without the `bin` folder/tools.

See https://github.com/nerdvegas/rez/pull/579#issuecomment-526801383, https://github.com/nerdvegas/rez/pull/579#issuecomment-526872658