### PR TITLE
Fix path list with whitespace

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -126,6 +126,10 @@ class OptionalStrList(StrList):
 class PathList(StrList):
     sep = os.pathsep
 
+    def _parse_env_var(self, value):
+        value = value.split(self.sep)
+        return [x for x in value if x]
+
 
 class Int(Setting):
     schema = Schema(int)

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -234,6 +234,9 @@ class TestConfig(TestBase):
         packages_path = [
             "c:/foo bar/baz",
             "c:/foo 2 bar/baz",
+            r"c:\foo bar\baz",
+            "/home/foo bar/baz",
+            r"/home/foo\ bar/baz"
         ]
         os.environ["REZ_PACKAGES_PATH"] = os.pathsep.join(packages_path)
 

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -226,6 +226,19 @@ class TestConfig(TestBase):
         finally:
             os.environ = old_environ
 
+    def test_7(self):
+        """Test path list environment variable with whitespace."""
+        c = Config([self.root_config_file], locked=False)
+
+        # test basic env-var override
+        packages_path = [
+            "c:/foo bar/baz",
+            "c:/foo 2 bar/baz",
+        ]
+        os.environ["REZ_PACKAGES_PATH"] = os.pathsep.join(packages_path)
+
+        self.assertEqual(c.packages_path, packages_path)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The packages path is split badly if a path contains whitespace.
If I set `REZ_PACKAGES_PATH `to `c:/foo bar/baz`, rez will interpret it as `["c:/foo", "bar/baz"]`.

This PR fixes this issue. I also made a test to prove this.