### PR TITLE
Python3 compatibility proposal

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-midnight

--- a/example_packages/hello_world/package.py
+++ b/example_packages/hello_world/package.py
@@ -15,10 +15,12 @@ tools = [
     "hello"
 ]
 
-requires = [
-    "python"
+build_requires = [
+    "python3",
 ]
-
+variants = [
+    ['python3-3'],
+]
 uuid = "examples.hello_world_py"
 
 def commands():

--- a/example_packages/hello_world/python/hello_world.py
+++ b/example_packages/hello_world/python/hello_world.py
@@ -1,4 +1,4 @@
 
 
 def hello():
-    print "Hello world!"
+    print("Hello world!")

--- a/src/rez/bind/python3.py
+++ b/src/rez/bind/python3.py
@@ -1,0 +1,67 @@
+"""
+Binds a python executable as a rez package.
+"""
+from __future__ import absolute_import
+from rez.bind._utils import check_version, find_exe, extract_version, \
+    make_dirs, log, run_python_command
+from rez.package_maker__ import make_package
+from rez.system import system
+from rez.utils.lint_helper import env
+from rez.utils.platform_ import platform_
+from rez.vendor.version.version import Version
+import shutil
+import os.path
+
+
+def setup_parser(parser):
+    parser.add_argument("--exe", type=str, metavar="PATH",
+                        help="bind an interpreter other than the current "
+                        "python interpreter")
+
+
+def commands():
+    env.PATH.append('{this.root}/bin')
+
+
+def bind(path, version_range=None, opts=None, parser=None):
+    # find executable, determine version
+    exepath = find_exe("python3", opts.exe)
+    code = "import sys; print('.'.join(str(x) for x in sys.version_info))"
+    version = extract_version(exepath, ["-c", code])
+
+    check_version(version, version_range)
+    log("binding python: %s" % exepath)
+
+
+    # make the package
+    #
+
+    def make_root(variant, root):
+        binpath = make_dirs(root, "bin")
+        link = os.path.join(binpath, "python3")
+        platform_.symlink(exepath, link)
+
+
+    with make_package("python3", path, make_root=make_root) as pkg:
+        pkg.version = version
+        pkg.tools = ["python3"]
+        pkg.commands = commands
+        pkg.variants = [system.variant]
+
+    return pkg.installed_variants
+
+
+# Copyright 2013-2016 Allan Johns.
+#
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.

--- a/src/rezplugins/build_system/cmake_files/RezInstallPython.cmake
+++ b/src/rezplugins/build_system/cmake_files/RezInstallPython.cmake
@@ -31,10 +31,14 @@ macro (rez_install_python)
 	#
 
 	list_contains(pyfound python ${REZ_BUILD_ALL_PKGS})
-	if(NOT pyfound)
+	list_contains(py3found python3 ${REZ_BUILD_ALL_PKGS})
+	if (py3found)
+		install_python(${ARGV} BIN python3)
+	elseif (pyfound)
+		install_python(${ARGV} BIN python)
+	else()
 		message(FATAL_ERROR "a version of python must be listed as a requirement when using the 'rez_install_python' macro. Packages for this build are: ${REZ_BUILD_ALL_PKGS}")
-	endif(NOT pyfound)
+	endif()
 
-	install_python(${ARGV} BIN python)
 
 endmacro (rez_install_python)


### PR DESCRIPTION
- I have a simple python3 compatible implementation of rez. 
- I added a rez python3 setup file so you can bind python3 in your current environment into a rez package. 
- The hello_world has been updated to use build_requires instead of requires. It is possible to deploy a python2 and python3 variant of the same version of hello_world. If we do not specify the requires python, the version pulled in will be determined by which python3 package you specify at resolve time.

The resolves seem to work as expected. Thoughts?