### PR TITLE
WIP Add --prefix to `rez-pip install`

### DIFF
--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -23,6 +23,9 @@ def setup_parser(parser, completions=False):
         help="install as released package; if not set, package is installed "
         "locally only")
     parser.add_argument(
+        "-p", "--prefix", type=str, metavar='PATH',
+        help="install to a custom package repository path.")
+    parser.add_argument(
         "PACKAGE",
         help="package to install or archive/url to install from")
 
@@ -43,7 +46,8 @@ def command(opts, parser, extra_arg_groups=None):
         opts.PACKAGE,
         pip_version=opts.pip_ver,
         python_version=opts.py_ver,
-        release=opts.release)
+        release=opts.release,
+        prefix=opts.prefix)
 
     # print summary
     #

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -183,7 +183,8 @@ def create_context(pip_version=None, python_version=None):
 
 
 def pip_install_package(source_name, pip_version=None, python_version=None,
-                        mode=InstallMode.min_deps, release=False):
+                        mode=InstallMode.min_deps, release=False,
+                        prefix=None):
     """Install a pip-compatible python package as a rez package.
     Args:
         source_name (str): Name of package or archive/url containing the pip
@@ -197,6 +198,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
             managed.
         release (bool): If True, install as a released package; otherwise, it
             will be installed as a local package.
+        prefix (str, optional): Override release path with this absolute path
 
     Returns:
         2-tuple:
@@ -208,7 +210,11 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
 
     pip_exe, context = find_pip(pip_version, python_version)
 
-    # TODO: should check if packages_path is writable before continuing with pip
+    if prefix is not None:
+        config.release_packages_path = prefix
+
+    # TODO: should check if packages_path is writable
+    # before continuing with pip
     #
     packages_path = (config.release_packages_path if release
                      else config.local_packages_path)


### PR DESCRIPTION
Hi all,

This PR adds support for `--prefix` to `rez-pip install`, for use with releasing a package.

```bash
$ rez pip install some-package --release --prefix c:\some\custom\dir
```

I tried staying as close as possible to `rez-build --prefix`, however:

1. Not sure overwriting `config.release_packages_path` is OK
2. Should `--prefix` affect the final path, even without `--release`?