### PR TITLE
Implement preprocess support for rezconfig.py

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -109,6 +109,10 @@ class OptionalStr(Str):
     schema = Or(None, basestring)
 
 
+class OptionalObject(Str):
+    schema = Or(None, object)
+
+
 class StrList(Setting):
     schema = Schema([basestring])
     sep = ','
@@ -312,7 +316,7 @@ config_schema = Schema({
     "implicit_back":                                OptionalStr,
     "alias_fore":                                   OptionalStr,
     "alias_back":                                   OptionalStr,
-    "package_preprocess_function":                  OptionalStr,
+    "package_preprocess_function":                  OptionalObject,
     "context_tracking_host":                        OptionalStr,
     "variant_shortlinks_dirname":                   OptionalStr,
     "build_thread_count":                           BuildThreadCount_,

--- a/src/rez/developer_package.py
+++ b/src/rez/developer_package.py
@@ -175,6 +175,7 @@ class DeveloperPackage(Package):
             else:
                 # load globally configured preprocess function
                 dotted = self.config.package_preprocess_function
+                funcname = dotted
 
                 if not dotted:
                     return None


### PR DESCRIPTION
Here's a feature proposal, to help simplify life for beginners, without breaking advanced use.

**rezconfig.py**

```python
# Option 1, original
package_preprocess_function = "my_module.function"

# Option 2, this proposal
def package_preprocess_function(this, data):
    # do fancy things
```

I found the original a little heavy on the up-front investment to give the feature a try. Needing to:

1. Write and maintain a separate module
2. Add and maintain another environment variable, i.e. `PYTHONPATH`, outside of the otherwise excellent Rez environment management.

But I can see how the feature circumvents some of the conceptual benefits of the original; e.g. if you've already got an established PYTHONPATH of global e.g. `rezutils.py`, then the overhead isn't as noticeable. However I can see this help beginners getting into Rez, and does not exclude the original use.

### Usecase

My usecase was to prefix packages with a "category".

**package.py**

```python
name = "core_pipeline"
category = "int"
```

**rezconfig.py**

```python
packages_path = [
    "~/packages/int",
    "~/packages/ext",
    "~/.rez/packages/int",
    "~/.rez/packages/ext"
]

def package_preprocess_function(this, data):
    if not data.get("category"):
        return

    try:
        data["config"]["local_packages_path"]
        data["config"]["release_packages_path"]

    except KeyError:
        pass

    else:
        # Already explicitly specified by package
        return

    category = data["category"]
    config = data.get("config", {})

    config["release_packages_path"] = os.path.join(_release_path, category)
    config["local_packages_path"] = os.path.join(_local_path, category)

    data["config"] = config
```