### PR TITLE
WIP Fix file permissions of package.py on Windows

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -442,7 +442,13 @@ class FileSystemPackageRepository(PackageRepository):
     building_prefix = ".building"
     ignore_prefix = ".ignore"
 
-    package_file_mode = (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    package_file_mode = (
+        None if os.name == "nt" else
+
+        # These aren't supported on Windows
+        # https://docs.python.org/2/library/os.html#os.chmod
+        (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    )
 
     @classmethod
     def name(cls):

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -442,13 +442,7 @@ class FileSystemPackageRepository(PackageRepository):
     building_prefix = ".building"
     ignore_prefix = ".ignore"
 
-    package_file_mode = (
-        None if os.name == "nt" else
-
-        # These aren't supported on Windows
-        # https://docs.python.org/2/library/os.html#os.chmod
-        (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-    )
+    package_file_mode = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
 
     @classmethod
     def name(cls):

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -442,7 +442,13 @@ class FileSystemPackageRepository(PackageRepository):
     building_prefix = ".building"
     ignore_prefix = ".ignore"
 
-    package_file_mode = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+    package_file_mode = (
+        None if os.name == "nt" else
+
+        # These aren't supported on Windows
+        # https://docs.python.org/2/library/os.html#os.chmod
+        (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    )
 
     @classmethod
     def name(cls):


### PR DESCRIPTION
This hasn't been confirmed yet; on some machines, this hasn't been an issue, but on mine (Windows 10, non-privileged user, local disk) it was a showstopper.

The permission bits here [aren't supported](https://docs.python.org/2/library/os.html#os.chmod) on Windows which shouldn't be a problem, as they should fall back to the only two bits that are, `IWRITE` and `IREAD`. Here however, they result in read-only file permissions that cannot be overwritten and breaks building of variants amongst others

```bash
$ rez build --install
== Anima Rez Config ==
16:50:44 INFO     Applying preprocess function package_preprocess_function
16:50:44 INFO     Package attributes were changed in preprocessing:
Added attributes: ['config']
16:50:44 INFO     Applying preprocess function package_preprocess_function
16:50:44 INFO     Package attributes were changed in preprocessing:
Added attributes: ['config']

--------------------------------------------------------------------------------
Building ATC-0.3.15...
--------------------------------------------------------------------------------

--------------------------------------------------------------------------------
Building variant 0 (1/2)...
--------------------------------------------------------------------------------
16:50:44 INFO     Applying preprocess function package_preprocess_function
16:50:44 INFO     Package attributes were changed in preprocessing:
Added attributes: ['config']
Resolving build environment: globals-0.0.5+ core_pipeline-1.2+ maya-2018
resolved by manima@toy.fritz.box, on Thu Apr 18 16:50:44 2019, using Rez v2.29.0

requested packages:
globals-0.0.5+
core_pipeline-1.2+
maya-2018
~platform==windows       (implicit)
~arch==AMD64             (implicit)
~os==windows-10.0.17134  (implicit)

resolved packages:
Qt.py-1.1.0            C:\Users\manima\Dropbox\dev\anima\.cache\packages\ext\Qt.py\1.1.0\platform-windows\arch-AMD64\os-windows-10.0.17134\python-2.7
arch-AMD64             C:\Users\manima\packages\arch\AMD64                                                                                             (local)
core_pipeline-1.2.0    C:\Users\manima\Dropbox\dev\anima\.cache\packages\int\core_pipeline\1.2.0
globals-0.0.6          C:\Users\manima\packages\int\globals\0.0.6
maya-2018.0.0          C:\Users\manima\packages\ext\maya\2018.0.0
maya_base-1.0.7        C:\Users\manima\packages\ext\maya_base\1.0.7
os-windows-10.0.17134  C:\Users\manima\packages\os\windows-10.0.17134                                                                                  (local)
platform-windows       C:\Users\manima\packages\platform\windows                                                                                       (local)
python-2.7.14          C:\Users\manima\packages\python\2.7.14\platform-windows\arch-AMD64\os-windows-10.0.17134                                        (local)
six-1.12.0             C:\Users\manima\Dropbox\dev\anima\.cache\packages\ext\six\1.12.0\platform-windows\arch-AMD64\os-windows-10.0.17134\python-2.7

Invoking custom build system...

--------------------------------------------------------------------------------
Building variant 1 (2/2)...
--------------------------------------------------------------------------------
16:50:44 INFO     Applying preprocess function package_preprocess_function
16:50:44 INFO     Package attributes were changed in preprocessing:
Added attributes: ['config']
Resolving build environment: globals-0.0.5+ core_pipeline-1.2+ nuke-11
resolved by manima@toy.fritz.box, on Thu Apr 18 16:50:44 2019, using Rez v2.29.0

requested packages:
globals-0.0.5+
core_pipeline-1.2+
nuke-11
~platform==windows       (implicit)
~arch==AMD64             (implicit)
~os==windows-10.0.17134  (implicit)

resolved packages:
Qt.py-1.1.0            C:\Users\manima\Dropbox\dev\anima\.cache\packages\ext\Qt.py\1.1.0\platform-windows\arch-AMD64\os-windows-10.0.17134\python-2.7
arch-AMD64             C:\Users\manima\packages\arch\AMD64                                                                                             (local)
core_pipeline-1.2.0    C:\Users\manima\Dropbox\dev\anima\.cache\packages\int\core_pipeline\1.2.0
globals-0.0.6          C:\Users\manima\packages\int\globals\0.0.6
nuke-11.3.2            C:\Users\manima\packages\ext\nuke\11.3.2
os-windows-10.0.17134  C:\Users\manima\packages\os\windows-10.0.17134                                                                                  (local)
platform-windows       C:\Users\manima\packages\platform\windows                                                                                       (local)
python-2.7.14          C:\Users\manima\packages\python\2.7.14\platform-windows\arch-AMD64\os-windows-10.0.17134                                        (local)
six-1.12.0             C:\Users\manima\Dropbox\dev\anima\.cache\packages\ext\six\1.12.0\platform-windows\arch-AMD64\os-windows-10.0.17134\python-2.7

Invoking custom build system...
Traceback (most recent call last):
  File "c:\Python27\Lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "c:\Python27\Lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "C:\Users\manima\Dropbox\dev\anima\rez2\Scripts\rez\rez.exe\__main__.py", line 2, in <module>
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\cli\_main.py", line 144, in run
    returncode = run_cmd()
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\cli\_main.py", line 136, in run_cmd
    return opts.func(opts, opts.parser, extra_arg_groups)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\cli\build.py", line 155, in command
    variants=opts.variants)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rezplugins\build_process\local.py", line 41, in build
    install=install)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\build_process_.py", line 197, in visit_variants
    result = func(variant, **kwargs)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rezplugins\build_process\local.py", line 280, in _build_variant
    variant.install(install_path)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\packages_.py", line 401, in install
    overrides=overrides)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rezplugins\package_repository\filesystem.py", line 608, in install_variant
    variant = _create_variant()
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rezplugins\package_repository\filesystem.py", line 601, in _create_variant
    overrides=overrides
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rezplugins\package_repository\filesystem.py", line 1056, in _create_variant
    dump_package_data(package_data, buf=f, format_=package_format)
  File "c:\Python27\Lib\contextlib.py", line 24, in __exit__
    self.gen.next()
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\serialise.py", line 68, in open_file_for_write
    f.write(content)
  File "c:\Python27\Lib\contextlib.py", line 24, in __exit__
    self.gen.next()
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\vendor\atomicwrites\__init__.py", line 154, in _open
    self.commit(f)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\vendor\atomicwrites\__init__.py", line 185, in commit
    replace_atomic(f.name, self._path)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\vendor\atomicwrites\__init__.py", line 92, in replace_atomic
    return _replace_atomic(src, dst)
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\vendor\atomicwrites\__init__.py", line 75, in _replace_atomic
    _windows_default_flags | _MOVEFILE_REPLACE_EXISTING
  File "c:\users\manima\dropbox\dev\anima\rez2\lib\site-packages\rez-2.29.0-py2.7.egg\rez\vendor\atomicwrites\__init__.py", line 70, in _handle_errors
    raise WinError()
WindowsError: [Error 5] Access is denied.
```

Confirmed with this minimal reproducible.

```bash
$ rez python
Python 2.7.14 (v2.7.14:84471935ed, Sep 16 2017, 20:25:58) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> import stat
>>> package_file_mode = (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
>>> with open("test.txt", "w") as f:
...   f.write("Test")
...
>>> os.chmod("test.txt", package_file_mode)
>>> with open("test.txt", "w") as f:
...   pass
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IOError: [Errno 13] Permission denied: 'test.txt'
```