### PR TITLE
Bugfix/custom build arguments

### DIFF
--- a/src/rez/cli/build.py
+++ b/src/rez/cli/build.py
@@ -46,7 +46,7 @@ def setup_parser_common(parser):
             cls_ = clss[0]
             title = "%s build system arguments" % cls_.name()
             group = parser.add_argument_group(title)
-            cls_.bind_cli(group)
+            cls_.bind_cli(parser, group)
 
         types = [x.name() for x in clss]
     else:

--- a/src/rezplugins/build_system/custom.py
+++ b/src/rezplugins/build_system/custom.py
@@ -60,7 +60,7 @@ class CustomBuildSystem(BuildSystem):
             child_build_args=child_build_args)
 
     @classmethod
-    def bind_cli(cls, parser):
+    def bind_cli(cls, parser, group):
         """
         Uses a 'parse_build_args.py' file to add options, if found.
         """
@@ -74,7 +74,7 @@ class CustomBuildSystem(BuildSystem):
         before_args = set(x.dest for x in parser._actions)
 
         try:
-            exec source in {"parser": parser}
+            exec source in {"parser": group}
         except Exception as e:
             print_warning("Error in ./parse_build_args.py: %s" % str(e))
 


### PR DESCRIPTION
# Description

Prior to rez version 2.26, the function call to `bind_cli` within `src/rez/build.py` was passing the parser object as an argument which was then used to store the extra args via `setattr` defined within `parse_build_args.py` onto so that we can get to it in self.build.  

From version 2.26 onwards the passed arguments changed from `ArgumentParser` to an **argument group object** in order to display the extra arguments in a separate group for help messages. 

The above change created a regression because although the custom build arguments (defined in parse_build_args.py) are visible when calling rez-build --help as an additional group the corresponding environment variables are not created in the build environment because the `setattr` function is using the wrong object.

This pull request fixes the problem by passing both the group and parser objects to correctly generate the help menu but also ensure the environment variables are set.

Fixes # (issue)
#590, #587  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please see #587

# How Has This Been Tested?

I have manually tested the changes myself multiple times with various arguments by proving
a series of `parse_build_args.py` files. Furthermore other members of the community have
tried my changes are have reported them to be working.

> I made a custom build with two cherry-picked commits from @lambdaclan and it fixed the issue for me.
> 
> Would be fantastic to have a PR for that so that we don't have to deploy a custom version, nothing really bad about it but it is extra maintenance steps.
> 
> Cheers,
> 
> Thomas

## Todos
- [ ] Tests
- [ ] Documentation

@nerdvegas Please advice :pray: 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works