### PR TITLE
[WIP] Feature/pip install modern

### DIFF
--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -231,10 +231,8 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
 
     # Build pip commandline
     cmd = [pip_exe, "install",
-           "--install-option=--install-lib=%s" % destpath,
-           "--install-option=--install-scripts=%s" % binpath,
-           "--install-option=--install-headers=%s" % incpath,
-           "--install-option=--install-data=%s" % datapath]
+           "--use-pep517",
+           "--target=%s" % destpath]
 
     if mode == InstallMode.no_deps:
         cmd.append("--no-deps")

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -303,13 +303,12 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
 
         variant_reqs.append("python-%s" % py_ver)
 
-        name, _ = parse_name_and_version(distribution.name_and_version)
-        name = distribution.name[0:len(name)].replace("-", "_")
+    name = metadata.name
 
         with make_package(name, packages_path, make_root=make_root) as pkg:
-            pkg.version = distribution.version
-            if distribution.metadata.summary:
-                pkg.description = distribution.metadata.summary
+        pkg.version = metadata.version
+        if metadata.summary:
+            pkg.description = metadata.summary
 
             pkg.variants = [variant_reqs]
             if requirements:

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -255,8 +255,9 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     distribution_path = DistributionPath([destpath])
     distributions = [d for d in distribution_path.get_distributions()]
 
-    folders = [folder for folder in os.listdir(destpath) if os.path.isdir(os.path.join(destpath, folder))]
-    if "bin" in folders:
+    # moving bin folder to expected relative location as per wheel RECORD files
+    staged_binpath = os.path.join(destpath, "bin")
+    if os.path.isdir(staged_binpath):
         shutil.move(os.path.join(destpath, "bin"), binpath)
 
     for distribution in distribution_path.get_distributions():

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -284,10 +284,13 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
             # when in fact ../bin seems to be the resulting path after the
             # installation as such we need to point the bin files to the
             # expected location to match wheel RECORD files
-            if installed_file[0].startswith("."):
-                installed = destpath + installed_file[0]
+            installed_filepath = installed_file[0]
+            bin_prefix = os.path.join('..', '..', 'bin') + os.sep
+            if installed_filepath.startswith(bin_prefix):
+                # account for extra parentdir as explained above
+                installed = os.path.join(destpath, '_', installed_filepath)
             else:
-                installed = os.path.join(destpath, installed_file[0])
+                installed = os.path.join(destpath, installed_filepath)
 
             source_file = os.path.normpath(installed)
 

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -295,7 +295,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
             source_file = os.path.normpath(installed)
 
             if os.path.exists(source_file):
-                destination_file = source_file.split(stagingsep)[1]
+                destination_file = os.path.relpath(source_file, stagingdir)
                 exe = False
 
                 if is_exe(source_file):

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -25,6 +25,41 @@ import sys
 import os
 import re
 
+VERSION_PATTERN = r"""
+    v?
+    (?:
+        (?:(?P<epoch>[0-9]+)!)?                           # epoch
+        (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
+        (?P<pre>                                          # pre-release
+            [-_\.]?
+            (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
+            [-_\.]?
+            (?P<pre_n>[0-9]+)?
+        )?
+        (?P<post>                                         # post release
+            (?:-(?P<post_n1>[0-9]+))
+            |
+            (?:
+                [-_\.]?
+                (?P<post_l>post|rev|r)
+                [-_\.]?
+                (?P<post_n2>[0-9]+)?
+            )
+        )?
+        (?P<dev>                                          # dev release
+            [-_\.]?
+            (?P<dev_l>dev)
+            [-_\.]?
+            (?P<dev_n>[0-9]+)?
+        )?
+    )
+    (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
+"""
+
+CANONICAL_VERSION_RE = re.compile(
+    r"^\s*" + VERSION_PATTERN + r"\s*$",
+    re.VERBOSE | re.IGNORECASE,
+)
 
 class InstallMode(Enum):
     # don't install dependencies. Build may fail, for example the package may
@@ -88,6 +123,56 @@ def is_exe(fpath):
         return os.path.exists(fpath) and os.access(fpath, os.X_OK)
 
 
+def pip_to_rez_version(dist_version):
+    """Convert a distribution version to a rez compatible version.
+
+    The python version schema specification isn't 100% compatible with rez.
+
+    1: version epochs (they make no sense to rez, so they'd just get stripped
+       of the leading N!;
+    2: python versions are case insensitive, so they should probably be
+       lowercased when converted to a rez version.
+    3: local versions are also not compatible with rez
+
+    The canonical public version identifiers MUST comply with the following scheme:
+    [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
+
+    Epoch segment: N! - skip
+    Release segment: N(.N)* 0 as is
+    Pre-release segment: {a|b|rc}N - always lowercase
+    Post-release segment: .postN - always lowercase
+    Development release segment: .devN - always lowercase
+
+    Local version identifiers MUST comply with the following scheme:
+    <public version identifier>[+<local version label>] - use - instead of + convert . to _
+
+    Arguments:
+        dist_version (str): The distribution version to be converted.
+    """
+    version_match = CANONICAL_VERSION_RE.match(dist_version)
+    version_segments = version_match.groupdict()
+
+    available_segments = dict((k, v) for k, v in version_segments.iteritems() if v)
+    version = ""
+    if "release" in available_segments:
+        release = available_segments["release"]
+        version += release
+        if "pre" in available_segments:
+            pre = available_segments["pre"].lower()
+            version += pre
+        if "post" in available_segments:
+            post = available_segments["post"].lower()
+            version += post
+        if "dev" in available_segments:
+            dev = available_segments["dev"].lower()
+            version += dev
+        if "local" in available_segments:
+            local = available_segments["local"].replace("-", "_")
+            version += "-" + local
+
+    return version
+
+
 def pip_to_rez_package_name(distribution):
     """Convert a distribution name to a rez compatible name.
 
@@ -98,7 +183,7 @@ def pip_to_rez_package_name(distribution):
     Example: my-pkg-1.2 is 'my', version 'pkg-1.2'.
 
     Arguments:
-        distribution [Distribution] -- The distribution whose name to convert.
+        distribution (Distribution): The distribution whose name to convert.
     """
     name, _ = parse_name_and_version(distribution.name_and_version)
     name = distribution.name[0:len(name)].replace("-", "_")
@@ -360,7 +445,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
         name = pip_to_rez_package_name(distribution)
 
         with make_package(name, packages_path, make_root=make_root) as pkg:
-            pkg.version = distribution.metadata.version
+            pkg.version = pip_to_rez_version(distribution.version)
             if distribution.metadata.summary:
                 pkg.description = distribution.metadata.summary
 

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -280,16 +280,10 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
         src_dst_lut = {}
 
         for installed_file in distribution.list_installed_files():
-            # a relative directory that needs to be appended without the
-            # os.sep (via os.path.join) in order for normpath to return the
-            # correct path, this is in order to match the wheel RECORD file
-
-            # Example
-
-            # destpath = /tmp/pip-HBkRGa-rez/re]z_staging/python
-            # installed_file[0] = ../../bin/pydocstyle
-            # normpath of /tmp/pip-HBkRGa-rez/rez_staging/python../../bin/pydocstyle =  /tmp/pip-HBkRGa-rez/rez_staging/bin/pydocstyle OK
-            # normapth of /tmp/pip-HBkRGa-rez/rez_staging/python/../../bin/pydocstyle = /tmp/pip-HBkRGa-rez/bin/pydocstyle WRONG
+            # distlib expects the script files to be located in ../../bin/
+            # when in fact ../bin seems to be the resulting path after the
+            # installation as such we need to point the bin files to the
+            # expected location to match wheel RECORD files
             if installed_file[0].startswith("."):
                 installed = destpath + installed_file[0]
             else:

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -244,22 +244,11 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     # Collect resulting python packages using distlib
     distribution_path = DistributionPath([destpath])
     distributions = [d for d in distribution_path.get_distributions()]
+    metadata = next(iter([dist.metadata for dist in distributions if dist.key == source_name]), None)
 
-    for distribution in distribution_path.get_distributions():
-        requirements = []
-        if distribution.metadata.run_requires:
-            # Handle requirements. Currently handles conditional environment based
-            # requirements and normal requirements
-            # TODO: Handle optional requirements?
-            for requirement in distribution.metadata.run_requires:
-                if "environment" in requirement:
-                    if interpret(requirement["environment"]):
-                        requirements.extend(_get_dependencies(requirement, distributions))
-                elif "extra" in requirement:
-                    # Currently ignoring optional requirements
-                    pass
-                else:
-                    requirements.extend(_get_dependencies(requirement, distributions))
+    # TODO deal with the scenario when a wheel fails to build, ie no metadata
+    if not metadata:
+        raise ValueError('Wheel metadata for {} was not found.'.format(source_name))
 
         tools = []
         src_dst_lut = {}

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -242,7 +242,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     _system = System()
 
     # Collect resulting python packages using distlib
-    distribution_path = DistributionPath([destpath], include_egg=True)
+    distribution_path = DistributionPath([destpath])
     distributions = [d for d in distribution_path.get_distributions()]
 
     for distribution in distribution_path.get_distributions():

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -220,9 +220,8 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     stagingsep = "".join([os.path.sep, "rez_staging", os.path.sep])
 
     destpath = os.path.join(stagingdir, "python")
+    # TODO use binpath once https://github.com/pypa/pip/pull/5983 is approved
     binpath = os.path.join(stagingdir, "bin")
-    incpath = os.path.join(stagingdir, "include")
-    datapath = stagingdir
 
     if context and config.debug("package_release"):
         buf = StringIO()

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -250,81 +250,85 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     if not metadata:
         raise ValueError('Wheel metadata for {} was not found.'.format(source_name))
 
-        tools = []
-        src_dst_lut = {}
+    tools = []
+    src_dst_lut = {}
 
-        for installed_file in distribution.list_installed_files(allow_fail=True):
-            source_file = os.path.normpath(os.path.join(destpath, installed_file[0]))
+    for distribution in distributions:
+        for installed_file in distribution.list_installed_files():
+            if 'bin' in installed_file[0]:
+                installed = os.path.relpath(installed_file[0], os.path.join('..','..'))
+            else:
+                installed = installed_file[0]
 
+            source_file = os.path.normpath(os.path.join(destpath, installed))
             if os.path.exists(source_file):
-                destination_file = installed_file[0].split(stagingsep)[1]
+                destination_file = source_file.split(stagingsep)[1]
                 exe = False
 
-                if is_exe(source_file) and \
-                        destination_file.startswith("%s%s" % ("bin", os.path.sep)):
-                    _, _file = os.path.split(destination_file)
-                    tools.append(_file)
-                    exe = True
+                if is_exe(source_file):
+                    if destination_file.startswith("%s%s" % (os.path.join("python", "bin"), os.path.sep)):
+                        destination_file = os.path.join("bin", os.path.basename(source_file))
+                        _, _file = os.path.split(destination_file)
+                        tools.append(_file)
+                        exe = True
 
                 data = [destination_file, exe]
                 src_dst_lut[source_file] = data
             else:
                 _log("Source file does not exist: " + source_file + "!")
 
-        def make_root(variant, path):
-            """Using distlib to iterate over all installed files of the current
-            distribution to copy files to the target directory of the rez package
-            variant
-            """
-            for source_file, data in src_dst_lut.items():
-                destination_file, exe = data
-                destination_file = os.path.normpath(os.path.join(path, destination_file))
+    def make_root(variant, path):
+        """Using distlib to iterate over all installed files of the current
+        distribution to copy files to the target directory of the rez package
+        variant
+        """
+        for source_file, data in src_dst_lut.items():
+            destination_file, exe = data
+            destination_file = os.path.normpath(os.path.join(path, destination_file))
 
-                if not os.path.exists(os.path.dirname(destination_file)):
-                    os.makedirs(os.path.dirname(destination_file))
+            if not os.path.exists(os.path.dirname(destination_file)):
+                os.makedirs(os.path.dirname(destination_file))
 
-                shutil.copyfile(source_file, destination_file)
-                if exe:
-                    shutil.copystat(source_file, destination_file)
+            shutil.copyfile(source_file, destination_file)
+            if exe:
+                shutil.copystat(source_file, destination_file)
 
-        # determine variant requirements
-        # TODO detect if platform/arch/os necessary, no if pure python
-        variant_reqs = []
-        variant_reqs.append("platform-%s" % _system.platform)
-        variant_reqs.append("arch-%s" % _system.arch)
-        variant_reqs.append("os-%s" % _system.os)
+    # determine variant requirements
+    # TODO detect if platform/arch/os necessary, no if pure python
+    variant_reqs = []
+    variant_reqs.append("platform-%s" % _system.platform)
+    variant_reqs.append("arch-%s" % _system.arch)
+    variant_reqs.append("os-%s" % _system.os)
 
-        if context is None:
-            # since we had to use system pip, we have to assume system python version
-            py_ver = '.'.join(map(str, sys.version_info[:2]))
-        else:
-            python_variant = context.get_resolved_package("python")
-            py_ver = python_variant.version.trim(2)
+    if context is None:
+        # since we had to use system pip, we have to assume system python version
+        py_ver = '.'.join(map(str, sys.version_info[:2]))
+    else:
+        python_variant = context.get_resolved_package("python")
+        py_ver = python_variant.version.trim(2)
 
-        variant_reqs.append("python-%s" % py_ver)
+    variant_reqs.append("python-%s" % py_ver)
 
     name = metadata.name
 
-        with make_package(name, packages_path, make_root=make_root) as pkg:
+    with make_package(name, packages_path, make_root=make_root) as pkg:
         pkg.version = metadata.version
         if metadata.summary:
             pkg.description = metadata.summary
 
-            pkg.variants = [variant_reqs]
-            if requirements:
-                pkg.requires = requirements
+        pkg.variants = [variant_reqs]
 
-            commands = []
-            commands.append("env.PYTHONPATH.append('{root}/python')")
+        commands = []
+        commands.append("env.PYTHONPATH.append('{root}/python')")
 
-            if tools:
-                pkg.tools = tools
-                commands.append("env.PATH.append('{root}/bin')")
+        if tools:
+            pkg.tools = tools
+            commands.append("env.PATH.append('{root}/bin')")
 
-            pkg.commands = '\n'.join(commands)
+        pkg.commands = '\n'.join(commands)
 
-        installed_variants.extend(pkg.installed_variants or [])
-        skipped_variants.extend(pkg.skipped_variants or [])
+    installed_variants.extend(pkg.installed_variants or [])
+    skipped_variants.extend(pkg.skipped_variants or [])
 
     # cleanup
     shutil.rmtree(tmpdir)

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -88,6 +88,23 @@ def is_exe(fpath):
         return os.path.exists(fpath) and os.access(fpath, os.X_OK)
 
 
+def pip_to_rez_package_name(distribution):
+    """Convert a distribution name to a rez compatible name.
+
+    The rez package name can't be simply set to the dist name, because some
+    pip packages have hyphen in the name. In rez this is not a valid package
+    name (it would be interpreted as the start of the version).
+
+    Example: my-pkg-1.2 is 'my', version 'pkg-1.2'.
+
+    Arguments:
+        distribution [Distribution] -- The distribution whose name to convert.
+    """
+    name, _ = parse_name_and_version(distribution.name_and_version)
+    name = distribution.name[0:len(name)].replace("-", "_")
+    return name
+
+
 def run_pip_command(command_args, pip_version=None, python_version=None):
     """Run a pip command.
 
@@ -340,7 +357,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
 
         variant_reqs.append("python-%s" % py_ver)
 
-        name = distribution.metadata.name
+        name = pip_to_rez_package_name(distribution)
 
         with make_package(name, packages_path, make_root=make_root) as pkg:
             pkg.version = distribution.metadata.version

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 from rez.packages_ import get_latest_package
-from rez.vendor.version.version import Version
+from rez.vendor.version.version import Version, VersionError
 from rez.vendor.distlib import DistlibException
 from rez.vendor.distlib.database import DistributionPath
 from rez.vendor.distlib.markers import interpret
@@ -23,6 +23,7 @@ import os.path
 import shutil
 import sys
 import os
+import re
 
 
 class InstallMode(Enum):
@@ -131,6 +132,15 @@ def find_pip(pip_version=None, python_version=None):
             context = None
         else:
             raise e
+    finally:
+        pattern = r"pip\s(?P<ver>\d+\.*\d*\.*\d*)"
+        ver_str = subprocess.check_output([pip_exe, '-V'])
+        match = re.search(pattern, ver_str)
+        ver = match.group('ver')
+        pip_major = ver.split('.')[0]
+
+        if int(pip_major) < 19:
+            raise VersionError("pip >= 19 is required! Please update your pip.")
 
     return pip_exe, context
 


### PR DESCRIPTION
# Description

[In collaboration with #599]

The Python community is steadily moving away from eggs and transitioning into wheels. 

As per the Python [wheels website](https://pythonwheels.com/)
> Wheels offer faster installation for pure Python and native C extension packages, avoid arbitrary code execution for installation. (avoids setup.py) and **offer more consistent installs across platforms and machines**.

One of the most important differences is the cross platform compatibility. Furthermore the current
implementation of the pip install command is using install options to split and point the installation to a custom directory (libs, scripts, includes etc) is enforcing the use of source packages and disables the
modern pip default of using a wheel if available. This means that everything that is not a pure python package needs a proper, working and matching compiler setup making it a real pain for Windows users whom may need multiple visual studios versions etc...

The difference with #599 is that it enforces the use of wheels via [PEP 517](https://www.python.org/dev/peps/pep-0517/#source-distributions) which seems to be the way forward. If a package does not have a wheel then one is being built prior to installation ensuring
consistency.

There is still ongoing discussion [here](https://discuss.python.org/t/pep-517-and-projects-that-cant-install-via-wheels/791/3) from the pip maintainers but a few things that got my attention are the following statements:

>we intend (at some point) to remove the legacy "install via setup.py" code path from pip.

> We have that legacy mode at the moment - setup.py installs are (at least in my mind) legacy since PEP 517 support was released. The problem is that we can’t support that (or any other) legacy mode indefinitely, so the question is when (and how) we remove it.

Another interesting discussion to follow is the one [here](https://github.com/pypa/pip/issues/2677) about handling install options with wheel packages.


Relates # (issue)
rez #475, #503 maybe more...

pip https://github.com/pypa/pip/issues/4611 https://github.com/pypa/pip/issues/4501


## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Remarks

* Requires pip >=19.0
* Requires  distlib >= 0.28


# How Has This Been Tested?

I have installed a plethora of packages from known to obscure with good success rate.
Some issues still occur (unable to build a wheel - very rare) depending on the platform but the same problems would also occur with the current implementation.

I have also successfully installed the majority of the packages listed on the Python [wheels website](https://pythonwheels.com/) which do not yet provide a wheel without issues.

**Test Configuration**:
* Python version: 2.7.15
* OS: Linux, Windows 10
* Toolchain: pip 19.0.3, distlib 0.2.8

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Further investigation about dependency gathering (run-time and optional)
- [ ] Metadata and distlib API research notably [DependencyFinder](https://distlib.readthedocs.io/en/latest/reference.html#distlib.locators.DependencyFinder) and [Metadata 2.1](https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use) along with [PEP 508](https://www.python.org/dev/peps/pep-0508/)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works