### PR TITLE
Bugfix for alias() on Windows

### DIFF
--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -284,7 +284,7 @@ class CMD(Shell):
             except:
                 self._doskey = "doskey"
 
-        self._addline("%s %s=%s" % (self._doskey, key, value))
+        self._addline("%s %s=%s $*" % (self._doskey, key, value))
 
     def comment(self, value):
         for line in value.split('\n'):


### PR DESCRIPTION
Here's a bugfix.

### Problem

`alias()` under Windows doesn't let you pass additional arguments to an "alias" - a.k.a. "doskey" under Windows.

```python
def commands():
  alias("python", "c:\python36\python.exe")
```

```bash
$ python -c "print('hello world')"
Python 3.6.4 (v3.6.4:d48eceb, Dec 19 2017, 06:54:40) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>>
```

### Solution

Append `$*` to the `doskey` command.

```bash
$ python -c "print('hello world')"
hello world
```