### PR TITLE
Support iterating over `request` in package.py

### DIFF
--- a/src/rez/rex_bindings.py
+++ b/src/rez/rex_bindings.py
@@ -140,6 +140,11 @@ class VariantsBinding(Binding):
     def __contains__(self, name):
         return (name in self.__variants)
 
+    def __iter__(self):
+        """Support for `for res in resolve`"""
+        for req in self.__variants:
+            yield req
+
 
 class RequirementsBinding(Binding):
     """Binds a list of version.Requirement objects."""

--- a/src/rez/rex_bindings.py
+++ b/src/rez/rex_bindings.py
@@ -162,7 +162,13 @@ class RequirementsBinding(Binding):
             self._attr_error(name)
 
     def __contains__(self, name):
+        """Support for `if req in request`"""
         return (name in self.__requirements)
+
+    def __iter__(self):
+        """Support for `for req in request`"""
+        for req in self.__requirements:
+            yield req
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
This enables the `request` variable of `package.py` to be iterated over.

```python
def commands():
  for req in request:
    print("%s was requested!" % req)
```

### Problem

With support for `if "maya" in request`, I expected the object to be iterable, but was instead greeted by a cryptic traceback.

```bash
AttributeError: request does not exist: '0'
```

Especially considering errors during `commands()` and anything with `@early` or `@late` in it doesn't provide accurate line numbers (as they are dynamically concatenated and `exec`'ed), there was little way of telling what actually caused this to happen.

In practice, I found myself doing e.g.:

```python
environ = {
  "any": {
    "PYTHONPATH": ["{root}/python"],
  },
  "maya": {
    "MAYA_PLUG_IN_PATH": ["{root}/maya/plugins"],
  }
}

def commands():
  environ = this.environ["any"].copy()

  for req in request:
    items.update(this.environ.get(req, {}))

  for key, values in items.items():
      for value in values:
        env[key].prepend(value)
```

An alternative (working) solution was this.

```python
for key, values in this.environ.items():
  if key not in request:
    continue

  result.update(values)
```

Which works, but isn't as nice to look at as the above.

For symmetry, I also added iteration support to the `resolve` object.