### PR TITLE
Close the amqp connection after message publish

### DIFF
--- a/src/rez/utils/amqp.py
+++ b/src/rez/utils/amqp.py
@@ -89,9 +89,12 @@ def _publish_message(host, amqp_settings, routing_key, data):
         )
     except Exception as e:
         print_error("Failed to publish message: %s" % (e))
-        return False
+        success = False
+    else:
+        success = True
 
-    return True
+    conn.close()
+    return success
 
 
 def _publish_messages_async():


### PR DESCRIPTION
Linked to [this](https://groups.google.com/forum/#!topic/rez-config/pkRKBrW_ZJ8) conversation.

The amqp connection is now closed after the message has been published. This prevents the connection from being kept alive as long a the context is.