### PR TITLE
Support for external PyYAML and Python 3

### DIFF
--- a/src/rez/vendor/yaml/__init__.py
+++ b/src/rez/vendor/yaml/__init__.py
@@ -9,12 +9,7 @@ from loader import *
 from dumper import *
 
 __version__ = '3.10'
-
-try:
-    from cyaml import *
-    __with_libyaml__ = True
-except ImportError:
-    __with_libyaml__ = False
+__with_libyaml__ = False
 
 def scan(stream, Loader=Loader):
     """


### PR DESCRIPTION
Bugfix.

If you install PyYAML for Python 3, it'll get picked up by Rez's own PyYAML vendor library due to their ugly method of detecting a C-compiled sibling library.

This PR strips the vendored PyYAML from looking outside of itself and thus facilitates a third-party PyYAML from co-existing as a Rez package.