### PR TITLE
Automatically create missing package repository dir

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import os.path
 import os
 import stat
+import errno
 import time
 
 from rez.package_repository import PackageRepository
@@ -583,9 +584,15 @@ class FileSystemPackageRepository(PackageRepository):
 
         # check repo exists on disk
         path = self.location
-        if not os.path.exists(path):
-            raise PackageRepositoryError(
-                "Package repository path does not exist: %s" % path)
+
+        try:
+            os.makedirs(path)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise PackageRepositoryError(
+                    "Package repository did not exist "
+                    "and could not be created."
+                )
 
         # install the variant
         def _create_variant():


### PR DESCRIPTION
```bash
$ rez build --install
09:34:22 ERROR    PackageRepositoryError: Package repository path does not exist: C:\Users\marcus\packages
$ rez pip --install six
09:34:22 ERROR    PackageRepositoryError: Package repository path does not exist: C:\Users\marcus\packages
```

As choosing a destination directory is either default to users home directory, or explicitly chosen as a config option, installing to a non-existing directory shouldn't throw an error.

This should also help users new to Rez with the `rez bind --quickstart` option which currently throws an exception at the user right after install.