### PR TITLE
Cross-platform rez-bind python

### DIFF
--- a/src/rez/bind/python.py
+++ b/src/rez/bind/python.py
@@ -3,14 +3,9 @@ Binds a python executable as a rez package.
 """
 from __future__ import absolute_import
 from rez.bind._utils import check_version, find_exe, extract_version, \
-    make_dirs, log, run_python_command
+    make_dirs, log
 from rez.package_maker__ import make_package
 from rez.system import system
-from rez.utils.lint_helper import env
-from rez.utils.platform_ import platform_
-from rez.vendor.version.version import Version
-import shutil
-import os.path
 
 
 def setup_parser(parser):
@@ -24,18 +19,6 @@ def commands():
     alias("python", "{this.exe}")
 
 
-def post_commands():
-    # these are the builtin modules for this python executable. If we don't
-    # include these, some python behavior can be incorrect.
-    import os
-    global this
-
-    path = os.path.join(this.root, "python")
-    for dirname in os.listdir(path):
-        path_ = os.path.join(path, dirname)
-        env.PYTHONPATH.append(path_)
-
-
 def bind(path, version_range=None, opts=None, parser=None):
     # find executable, determine version
     exepath = find_exe("python", opts.exe)
@@ -45,34 +28,8 @@ def bind(path, version_range=None, opts=None, parser=None):
     check_version(version, version_range)
     log("binding python: %s" % exepath)
 
-    # find builtin modules
-    builtin_paths = {}
-    entries = [("lib", "os"),
-               ("extra", "setuptools")]
-
-    for dirname, module_name in entries:
-        success, out, err = run_python_command([
-            "import %s" % module_name,
-            "print(%s.__file__)" % module_name])
-
-        if success:
-            pypath = os.path.dirname(out)
-            if os.path.basename(pypath) == module_name:
-                pypath = os.path.dirname(pypath)
-
-            if pypath not in builtin_paths.values():
-                builtin_paths[dirname] = pypath
-
-    # make the package
-    #
-
     def make_root(variant, root):
-        if builtin_paths:
-            pypath = make_dirs(root, "python")
-            for dirname, srcpath in builtin_paths.iteritems():
-                destpath = os.path.join(pypath, dirname)
-                log("Copying builtins from %s to %s..." % (srcpath, destpath))
-                shutil.copytree(srcpath, destpath)
+        make_dirs(root, "python")
 
     with make_package("python", path, make_root=make_root) as pkg:
         pkg.version = version
@@ -80,9 +37,6 @@ def bind(path, version_range=None, opts=None, parser=None):
         pkg.commands = commands
         pkg.variants = [system.variant]
         pkg.exe = exepath
-
-        if builtin_paths:
-            pkg.post_commands = post_commands
 
     return pkg.installed_variants
 


### PR DESCRIPTION
This previously used symlinks to reference a system-wide Python install, and is now using alias() for cross-platform compatibility.

```bash
$ rez bind python
```

This PR also solves #594, #399 and #400

Edit: It also depends on https://github.com/nerdvegas/rez/pull/607 being merged first, for Windows compatibility.