### PR TITLE
WIP No more "Terminate Batch Job? (Y/N)"

### DIFF
--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -134,7 +134,10 @@ def sigbase_handler(signum, frame):
     # kill all child procs
     # FIXME this kills parent procs as well
     if not _env_var_true("_REZ_NO_KILLPG"):
-        os.killpg(os.getpgid(0), signum)
+        if os.name == "nt":
+            os.kill(os.getpid(), signal.CTRL_C_EVENT)
+        else:
+            os.killpg(os.getpgid(0), signum)
     sys.exit(1)
 
 

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -151,7 +151,7 @@ class CMD(Shell):
                 else ("%s" + space + "$G")
             )
 
-            new_prompt = new_prompt % os.getenv("PROMPT", "")
+            new_prompt = new_prompt % os.getenv("PROMPT", "").rstrip()
             self._addline('set PROMPT=%s' % new_prompt)
 
     def spawn_shell(self, context_file, tmpdir, rcfile=None, norc=False,
@@ -182,8 +182,9 @@ class CMD(Shell):
             else:
                 cmd = pre_command
 
+        cmd_flags = []
         if shell_command:
-            cmd_flags = ['/Q', '/C']
+            cmd_flags[:] = ['/Q', '/C']
             executor.command(shell_command)
 
         elif shell_command is None:
@@ -192,14 +193,16 @@ class CMD(Shell):
             # passes '' and we do NOT want to keep
             # a shell open during a rex code
             # exec operation.
-            cmd_flags = ['/Q', '/K']
+            cmd_flags[:] = ['/Q', '/K']
 
-        elif not quiet:
-            # previously this was called with the /K flag, however
-            # that would leave spawn_shell hung on a blocked call
-            # waiting for the user to type "exit" into the shell that
-            # was spawned to run the rez context printout
-            executor.command('cmd /Q /C rez context')
+            if not quiet:
+                # previously this was called with the /K flag, however
+                # that would leave spawn_shell hung on a blocked call
+                # waiting for the user to type "exit" into the shell that
+                # was spawned to run the rez context printout
+                executor.command('cmd /Q /C rez context')
+        else:
+            executor.command('cmd /Q /C')
 
         # Example code
         #

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -4,10 +4,8 @@ Windows Command Prompt (DOS) shell.
 from rez.config import config
 from rez.rex import RexExecutor, OutputStyle, EscapedString
 from rez.shells import Shell
-from rez.system import system
 from rez.utils.system import popen
 from rez.utils.platform_ import platform_
-from rez.util import shlex_join
 from functools import partial
 import os
 import re
@@ -201,6 +199,8 @@ class CMD(Shell):
                 # waiting for the user to type "exit" into the shell that
                 # was spawned to run the rez context printout
                 executor.command('cmd /Q /C rez context')
+
+        # For selftest
         else:
             executor.command('cmd /Q /C')
 
@@ -292,7 +292,7 @@ class CMD(Shell):
         return "%%%s%%" % key
 
     def join(self, command):
-        return shlex_join(command).replace("'", '"')
+        return " ".join(command)
 
 
 def register_plugin():

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -2,7 +2,7 @@
 Windows Command Prompt (DOS) shell.
 """
 from rez.config import config
-from rez.rex import RexExecutor, literal, OutputStyle, EscapedString
+from rez.rex import RexExecutor, OutputStyle, EscapedString
 from rez.shells import Shell
 from rez.system import system
 from rez.utils.system import popen
@@ -139,36 +139,28 @@ class CMD(Shell):
     def _bind_interactive_rez(self):
         if config.set_prompt and self.settings.prompt:
             stored_prompt = os.getenv("REZ_STORED_PROMPT")
-            curr_prompt = stored_prompt or os.getenv("PROMPT", "")
-            if not stored_prompt:
-                self.setenv("REZ_STORED_PROMPT", curr_prompt)
 
-            new_prompt = "%%REZ_ENV_PROMPT%%"
-            new_prompt = (new_prompt + " %s") if config.prefix_prompt \
-                else ("%s " + new_prompt)
-            new_prompt = new_prompt % curr_prompt
+            space = ""
+            if not stored_prompt:
+                os.environ["REZ_STORED_PROMPT"] = "1"
+                space = " "
+
+            new_prompt = (
+                ("$G" + space + "%s")
+                if config.prefix_prompt
+                else ("%s" + space + "$G")
+            )
+
+            new_prompt = new_prompt % os.getenv("PROMPT", "")
             self._addline('set PROMPT=%s' % new_prompt)
 
     def spawn_shell(self, context_file, tmpdir, rcfile=None, norc=False,
                     stdin=False, command=None, env=None, quiet=False,
                     pre_command=None, **Popen_args):
 
-        startup_sequence = self.get_startup_sequence(rcfile, norc, bool(stdin), command)
-        shell_command = None
-
-        def _record_shell(ex, files, bind_rez=True, print_msg=False):
-            ex.source(context_file)
-            if startup_sequence["envvar"]:
-                ex.unsetenv(startup_sequence["envvar"])
-            if bind_rez:
-                ex.interpreter._bind_interactive_rez()
-            if print_msg and not quiet:
-                if system.is_production_rez_install:
-                    # previously this was called with the /K flag, however
-                    # that would leave spawn_shell hung on a blocked call
-                    # waiting for the user to type "exit" into the shell that
-                    # was spawned to run the rez context printout
-                    ex.command("cmd /Q /C rez context")
+        startup_sequence = self.get_startup_sequence(
+            rcfile, norc, bool(stdin), command)
+        shell_command = startup_sequence.get("command")
 
         def _create_ex():
             return RexExecutor(interpreter=self.new_shell(),
@@ -176,43 +168,12 @@ class CMD(Shell):
                                add_default_namespaces=False)
 
         executor = _create_ex()
+        executor.source(context_file)
 
-        if self.settings.prompt:
-            newprompt = '%%REZ_ENV_PROMPT%%%s' % self.settings.prompt
-            executor.interpreter._saferefenv('REZ_ENV_PROMPT')
-            executor.env.REZ_ENV_PROMPT = literal(newprompt)
+        if startup_sequence["envvar"]:
+            executor.unsetenv(startup_sequence["envvar"])
 
-        if startup_sequence["command"] is not None:
-            _record_shell(executor, files=startup_sequence["files"])
-            shell_command = startup_sequence["command"]
-        else:
-            _record_shell(executor, files=startup_sequence["files"], print_msg=(not quiet))
-
-        if shell_command:
-            # Launch the provided command in the configured shell and wait
-            # until it exits.
-            executor.command(shell_command)
-
-        # Test for None specifically because resolved_context.execute_rex_code
-        # passes '' and we do NOT want to keep a shell open during a rex code
-        # exec operation.
-        elif shell_command is None: 
-            # Launch the configured shell itself and wait for user interaction
-            # to exit.
-            executor.command('cmd /Q /K')
-            
-        # Exit the configured shell.
-        executor.command('exit %errorlevel%')
-
-        code = executor.get_output()
-        target_file = os.path.join(tmpdir, "rez-shell.%s"
-                                   % self.file_extension())
-
-        with open(target_file, 'w') as f:
-            f.write(code)
-
-        if startup_sequence["stdin"] and stdin and (stdin is not True):
-            Popen_args["stdin"] = stdin
+        executor.interpreter._bind_interactive_rez()
 
         cmd = []
         if pre_command:
@@ -223,14 +184,34 @@ class CMD(Shell):
 
         if shell_command:
             cmd_flags = ['/Q', '/C']
-        else:
+            executor.command(shell_command)
+
+        elif shell_command is None:
+            # Test for None specifically because
+            # resolved_context.execute_rex_code
+            # passes '' and we do NOT want to keep
+            # a shell open during a rex code
+            # exec operation.
             cmd_flags = ['/Q', '/K']
 
-        cmd = cmd + [self.executable] + cmd_flags + ['call {}'.format(target_file)]
-        is_detached = (cmd[0] == 'START')
+        elif not quiet:
+            # previously this was called with the /K flag, however
+            # that would leave spawn_shell hung on a blocked call
+            # waiting for the user to type "exit" into the shell that
+            # was spawned to run the rez context printout
+            executor.command('cmd /Q /C rez context')
 
-        p = popen(cmd, env=env, shell=is_detached, **Popen_args)
-        return p
+        # Example code
+        #
+        # call c:\users\me\appdata\local\temp\rez_context_rn3tn3\context.bat
+        # set PROMPT=$G$G (anima rez) $$
+        #
+        code = executor.get_output()
+        code = ' & '.join(code.splitlines())
+        cmd = cmd + [self.executable] + cmd_flags + [code]
+        is_detached = cmd[0] == 'START'
+
+        return popen(cmd, env=env, shell=is_detached, **Popen_args)
 
     def get_output(self, style=OutputStyle.file):
         if style == OutputStyle.file:
@@ -281,7 +262,7 @@ class CMD(Shell):
             try:
                 self.__class__._doskey = \
                     self.find_executable("doskey", check_syspaths=True)
-            except:
+            except Exception:
                 self._doskey = "doskey"
 
         self._addline("%s %s=%s" % (self._doskey, key, value))


### PR DESCRIPTION
Bugfix.

On Windows, existing a Rez context with CTRL+C:

1. Prompts the user with a "Terminate Batch Job? (Y/N)" question that terminates regardless of the answer; this is standard behavior for batch scripts on Windows, but isn't doing us any favours with Rez.
2. Throws an exception due to the Windows version of CTRL+C not being handled.

**Example**

```bash
$ rez env python-3 -- python -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...

Keyboard interrupt received, exiting.
Terminate batch job (Y/N)? y
Interrupted by user
Traceback (most recent call last):
  File "c:\Python27\Lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "c:\Python27\Lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "C:\Users\manima\Dropbox\dev\anima\github\nerdvegas\rez_install\Scripts\rez\rez.exe\__main__.py", line 2, in <module>
  File "c:\users\manima\dropbox\dev\anima\github\nerdvegas\rez_install\lib\site-packages\rez-2.29.1-py2.7.egg\rez\cli\_main.py", line 144, in run
    returncode = run_cmd()
  File "c:\users\manima\dropbox\dev\anima\github\nerdvegas\rez_install\lib\site-packages\rez-2.29.1-py2.7.egg\rez\cli\_main.py", line 136, in run_cmd
    return opts.func(opts, opts.parser, extra_arg_groups)
  File "c:\users\manima\dropbox\dev\anima\github\nerdvegas\rez_install\lib\site-packages\rez-2.29.1-py2.7.egg\rez\cli\env.py", line 249, in command
    block=True)
  File "c:\users\manima\dropbox\dev\anima\github\nerdvegas\rez_install\lib\site-packages\rez-2.29.1-py2.7.egg\rez\resolved_context.py", line 871, in _check
    return fn(self, *nargs, **kwargs)
  File "c:\users\manima\dropbox\dev\anima\github\nerdvegas\rez_install\lib\site-packages\rez-2.29.1-py2.7.egg\rez\resolved_context.py", line 1269, in execute_shell
    stdout, stderr = p.communicate()
  File "c:\Python27\Lib\subprocess.py", line 476, in communicate
    self.wait()
  File "c:\Python27\Lib\subprocess.py", line 689, in wait
    _subprocess.INFINITE)
  File "c:\users\manima\dropbox\dev\anima\github\nerdvegas\rez_install\lib\site-packages\rez-2.29.1-py2.7.egg\rez\cli\_util.py", line 148, in sigint_handler
    sigbase_handler(signum, frame)
  File "c:\users\manima\dropbox\dev\anima\github\nerdvegas\rez_install\lib\site-packages\rez-2.29.1-py2.7.egg\rez\cli\_util.py", line 137, in sigbase_handler
    os.killpg(os.getpgid(0), signum)
AttributeError: 'module' object has no attribute 'killpg'
```

This PR solves that.

```bash
$ rez env python-3 -- python -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...

Keyboard interrupt received, exiting.
Interrupted by user
^C
$
```

### Solution

Previously, a `rez_shell.bat` script was dynamically generated when entering `rez env`, which was then used as a form of startup-script for the sub-shell.

```bash
# Example
$ echo "echo Hello" >> rez_shell.bat
$ echo "echo World" > rez_shell.bat
$ cmd /K rez_shell.bat
```

With this PR, the sub-shell is handed commands via the `/K` and `/C` flag instead.

```bash
$ cmd /K echo Hello & echo World
```

> The `&` operator causes the next command to be called regardless of failure of  the prior command, as opposed to `&&` which is only called on success and `||` which is called on failure.

It's a rather big change to how contexts work on Windows, so I've added a WIP to the title until I'm confident it works.

Edit: Reworded the solution part, not sure what I was smoking when I first typed that!