### PR TITLE
WIP No more "Terminate Batch Job? (Y/N)" - Take 2

### DIFF
--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -134,7 +134,10 @@ def sigbase_handler(signum, frame):
     # kill all child procs
     # FIXME this kills parent procs as well
     if not _env_var_true("_REZ_NO_KILLPG"):
-        os.killpg(os.getpgid(0), signum)
+        if os.name == "nt":
+            os.kill(os.getpid(), signal.CTRL_C_EVENT)
+        else:
+            os.killpg(os.getpgid(0), signum)
     sys.exit(1)
 
 

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -193,7 +193,7 @@ class CMD(Shell):
                                    % self.file_extension())
 
         with open(target_file, 'w') as f:
-                f.write(code)
+            f.write(code)
 
         if startup_sequence["stdin"] and stdin and (stdin is not True):
             Popen_args["stdin"] = stdin
@@ -205,12 +205,17 @@ class CMD(Shell):
             else:
                 cmd = pre_command
 
-        if shell_command:
-            cmd_flags = ['/Q', '/C']
-        else:
+        # Test for None specifically because resolved_context.execute_rex_code
+        # passes '' and we do NOT want to keep a shell open during a rex code
+        # exec operation.
+        if shell_command is None:
             cmd_flags = ['/Q', '/K']
+        else:
+            cmd_flags = ['/Q', '/C']
 
-        cmd = cmd + [self.executable] + cmd_flags + ['call {}'.format(target_file)]
+        cmd += [self.executable]
+        cmd += cmd_flags
+        cmd += ['call {}'.format(target_file)]
 
         if shell_command:
             cmd += ["& " + shell_command]

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -188,22 +188,6 @@ class CMD(Shell):
         else:
             _record_shell(executor, files=startup_sequence["files"], print_msg=(not quiet))
 
-        if shell_command:
-            # Launch the provided command in the configured shell and wait
-            # until it exits.
-            executor.command(shell_command)
-
-        # Test for None specifically because resolved_context.execute_rex_code
-        # passes '' and we do NOT want to keep a shell open during a rex code
-        # exec operation.
-        elif shell_command is None: 
-            # Launch the configured shell itself and wait for user interaction
-            # to exit.
-            executor.command('cmd /Q /K')
-            
-        # Exit the configured shell.
-        executor.command('exit %errorlevel%')
-
         code = executor.get_output()
         target_file = os.path.join(tmpdir, "rez-shell.%s"
                                    % self.file_extension())
@@ -227,6 +211,10 @@ class CMD(Shell):
             cmd_flags = ['/Q', '/K']
 
         cmd = cmd + [self.executable] + cmd_flags + ['call {}'.format(target_file)]
+
+        if shell_command:
+            cmd += ["& " + shell_command]
+
         is_detached = (cmd[0] == 'START')
 
         p = popen(cmd, env=env, shell=is_detached, **Popen_args)

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -193,7 +193,7 @@ class CMD(Shell):
                                    % self.file_extension())
 
         with open(target_file, 'w') as f:
-            f.write(code)
+                f.write(code)
 
         if startup_sequence["stdin"] and stdin and (stdin is not True):
             Popen_args["stdin"] = stdin
@@ -296,7 +296,7 @@ class CMD(Shell):
         return "%%%s%%" % key
 
     def join(self, command):
-        return shlex_join(command).replace("'", '"')
+        return " ".join(command)
 
 
 def register_plugin():


### PR DESCRIPTION
Bugfix.

I found a better way to accomplish #626.

- Before, the Rez Python process launched a `cmd.exe` subshell followed by another `cmd.exe` subshell with the environment set up called `rez_shell.bat`
- Now, the Rez Python process launches a `cmd.exe` subshell, calling `rez_shell.bat` which then exits and puts the user in the original subshell.

The result is the same features and benefits, but one less layer to worry about. Most importantly, ctrl+c from a subshell doesn't exhibit the .bat prompt.

**Before**

```bash
$ rez env python-3 -- python -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...

Keyboard interrupt received, exiting.
Terminate batch job (Y/N)? y
Interrupted by user
Traceback (most recent call last):
...
AttributeError: 'module' object has no attribute 'killpg'
```

**After**

```bash
$ rez env python-3 -- python -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...

Keyboard interrupt received, exiting.
Interrupted by user
```

And, wouldn't you know it, this also solved #616, making `cmd.exe` a much better experience. Win!