### PR TITLE
[Feature] Pure python package detection

### DIFF
--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -19,7 +19,9 @@ from rez.system import System
 from tempfile import mkdtemp
 from StringIO import StringIO
 from pipes import quote
+from email.parser import Parser
 import subprocess
+import pkg_resources
 import os.path
 import shutil
 import sys
@@ -198,7 +200,7 @@ def pip_to_rez_package_name(distribution):
     return name
 
 
-def run_pip_command(command_args, pip_version=None, python_version=None):
+def run_pip_command(command_args, process_output=False, pip_version=None, python_version=None):
     """Run a pip command.
 
     Args:
@@ -210,7 +212,17 @@ def run_pip_command(command_args, pip_version=None, python_version=None):
     pip_exe, context = find_pip(pip_version, python_version)
     command = [pip_exe] + list(command_args)
 
-    if context is None:
+    if process_output:
+        try:
+            subprocess.check_output(command, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            regex = r"(?<=\(from versions:).*?(?=\))"
+            pattern = re.compile(regex)
+            match = pattern.search(e.output)
+            output = match.group(0).split(",")
+            return output
+
+    elif context is None:
         return popen(command)
     else:
         return context.execute_shell(command=command, block=False)
@@ -335,6 +347,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     """
     installed_variants = []
     skipped_variants = []
+    variant_types = []
 
     pip_exe, context = find_pip(pip_version, python_version)
 
@@ -370,6 +383,20 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
 
     _cmd(context=context, command=cmd)
     _system = System()
+
+    def pure_python_package(installed_dist):
+
+        true_table = {
+            "true": True,
+            "false": False
+        }
+
+        packages = pkg_resources.find_distributions(destpath)
+        dist = next((package for package in packages if package.key == installed_dist.key), None)
+        wheel_data = dist.get_metadata('WHEEL')
+        wheel_data = Parser().parsestr(wheel_data)
+
+        return true_table[wheel_data["Root-Is-Purelib"]]
 
     # Collect resulting python packages using distlib
     distribution_path = DistributionPath([destpath])
@@ -446,18 +473,29 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
                     shutil.copystat(source_file, destination_file)
 
         # determine variant requirements
-        # TODO detect if platform/arch/os necessary, no if pure python
         variant_reqs = []
-        variant_reqs.append("platform-%s" % _system.platform)
-        variant_reqs.append("arch-%s" % _system.arch)
-        variant_reqs.append("os-%s" % _system.os)
+
+        pure = pure_python_package(distribution)
+        if not pure:
+            variant_types.append("non-pure")
+            variant_reqs.append("platform-%s" % _system.platform)
+            variant_reqs.append("arch-%s" % _system.arch)
+        else:
+            variant_types.append("pure")
 
         if context is None:
             # since we had to use system pip, we have to assume system python version
-            py_ver = '.'.join(map(str, sys.version_info[:2]))
+            if pure:
+                py_ver = '.'.join(map(str, sys.version_info[:1]))
+            else:
+                py_ver = '.'.join(map(str, sys.version_info[:2]))
         else:
             python_variant = context.get_resolved_package("python")
-            py_ver = python_variant.version.trim(2)
+
+            if pure:
+                py_ver = python_variant.version.trim(1)
+            else:
+                py_ver = python_variant.version.trim(2)
 
         variant_reqs.append("python-%s" % py_ver)
 
@@ -487,7 +525,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     # cleanup
     shutil.rmtree(tmpdir)
 
-    return installed_variants, skipped_variants
+    return installed_variants, skipped_variants, variant_types
 
 
 def _cmd(context, command):

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -200,29 +200,17 @@ def pip_to_rez_package_name(distribution):
     return name
 
 
-def run_pip_command(command_args, process_output=False, pip_version=None, python_version=None):
+def run_pip_command(command_args, pip_version=None, python_version=None):
     """Run a pip command.
-
     Args:
         command_args (list of str): Args to pip.
-
     Returns:
         `subprocess.Popen`: Pip process.
     """
     pip_exe, context = find_pip(pip_version, python_version)
     command = [pip_exe] + list(command_args)
 
-    if process_output:
-        try:
-            subprocess.check_output(command, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            regex = r"(?<=\(from versions:).*?(?=\))"
-            pattern = re.compile(regex)
-            match = pattern.search(e.output)
-            output = match.group(0).split(",")
-            return output
-
-    elif context is None:
+    if context is None:
         return popen(command)
     else:
         return context.execute_shell(command=command, block=False)

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -335,7 +335,6 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     """
     installed_variants = []
     skipped_variants = []
-    variant_types = []
 
     pip_exe, context = find_pip(pip_version, python_version)
 

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -382,8 +382,10 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
         packages = pkg_resources.find_distributions(destpath)
         dist = next((package for package in packages if package.key == installed_dist.key), None)
         wheel_data = dist.get_metadata('WHEEL')
+        # see https://www.python.org/dev/peps/pep-0566/#json-compatible-metadata
         wheel_data = Parser().parsestr(wheel_data)
 
+        # see https://www.python.org/dev/peps/pep-0427/#what-s-the-deal-with-purelib-vs-platlib
         return true_table[wheel_data["Root-Is-Purelib"]]
 
     # Collect resulting python packages using distlib

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -465,11 +465,8 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
 
         pure = pure_python_package(distribution)
         if not pure:
-            variant_types.append("non-pure")
             variant_reqs.append("platform-%s" % _system.platform)
             variant_reqs.append("arch-%s" % _system.arch)
-        else:
-            variant_types.append("pure")
 
         if context is None:
             # since we had to use system pip, we have to assume system python version
@@ -513,7 +510,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     # cleanup
     shutil.rmtree(tmpdir)
 
-    return installed_variants, skipped_variants, variant_types
+    return installed_variants, skipped_variants
 
 
 def _cmd(context, command):


### PR DESCRIPTION
# Description

[Depends on PR #602, #654 #656]

## Update this PR has been split into 3 different PRs

**Since all 3 PRs are based on #656, it might make sense to resolve that one first.**

1. This PR #628 for pure python package detection

2. #657 for the experimental pip QOL commands

3. #658 for the schema and package request error fixes

### Pure python package detection

As we embrace modern Python and try to improve the way rez interfaces with pip by enforcing
Wheel package installation rather than the aging and legacy source and Egg distributions we can further improve rez-pip's functionality by taking advantage of the rich metadata that comes with Wheel distributions.

This PR introduces a purity detector for Python packages. As defined on the [Wheel Binary Package Format PEP491](https://www.python.org/dev/peps/pep-0491)

> Wheel preserves the "purelib" vs. "platlib" distinction, which is significant on some platforms. For example, Fedora installs pure Python packages to '/usr/lib/pythonX.Y/site-packages' and platform dependent packages to '/usr/lib64/pythonX.Y/site-packages'.

> A wheel with "Root-Is-Purelib: false" with all its files in {name}-{version}.data/purelib is equivalent to a wheel with "Root-Is-Purelib: true" with those same files in the root, and it is legal to have files in both the "purelib" and "platlib" categories.

> **In practice a wheel should have only one of "purelib" or "platlib" depending on whether it is pure Python or not and those files should be at the root with the appropriate setting given for "Root-is-purelib".**

This addition enables us to streamline  variant requirements:
 > TODO detect if platform/arch/os necessary, no if pure python

To further ensure compatibility with current platform this PR also adds some *experimental* features
such as package version listing, querying and Python version constraint based search. These features
use the most "reliable" source of package data being the PyPi via the new [JSON API](https://warehouse.readthedocs.io/api-reference/json/). 

The reason these features are marked experimental is because currently there is no standard of how the metadata should be defined and sometimes it varies widely between packages. According to my tests it seems to be working for the most part but still a lot of things to consider.

Relates # (issue)
rez #610, #575  maybe more...

## Breakdown

* pure/impure package detection

* pure packages now only use major Python version (for example python-2)

* drop os version dependency all together platform / architecture / (os) / python for all packages (pure and impure)

## Process

* Python package purity detector
  * this is using the Wheel metadata file named WHEEL. WHEEL is the wheel metadata specific to a build of the package. The Wheel metadata contents are defined [here](https://www.python.org/dev/peps/pep-0491/#file-contents)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Remarks

* Requires pip >=19.0
* Requires  distlib >= 0.28


# How Has This Been Tested?

I have installed a plethora of packages from known to obscure  in order to check the
purity detector with good success rate.
Some issues still occur (unable to build a wheel - very rare) depending on the platform but the same problems would also occur with the current implementation.

**Test Configuration**:
* Python version: 2.7.15, 2.7.16
* OS: Linux, Windows 10
* Toolchain: rez 2.33, pip 18.1, 19.1.1, distlib 0.2.9.post0

## Todos
- [ ] Tests

## Demo

* Pure / Impure package detector

![purity](https://user-images.githubusercontent.com/47409392/57917079-f0cbe080-78ce-11e9-8858-2849b4eeeefe.gif)