### PR TITLE
Expose Python standard module __file__ and __name__ to rezconfig

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -795,6 +795,12 @@ def _load_config_py(filepath):
     from rez.vendor.six.six import exec_
 
     reserved = dict(
+        # Standard Python module variables
+        # Made available from within the module,
+        # and later excluded from the `Config` class
+        __name__=os.path.splitext(os.path.basename(filepath))[0],
+        __file__=filepath,
+
         rez_version=__version__,
         ModifyList=ModifyList
     )


### PR DESCRIPTION
Now users can fetch the absolute path to a given `rezconfig` like from any other module.

**rezconfig.py**

```python
import os
print("The name of this rezconfig is %s" % __name__)
print("The absolute path is: %s" % os.path.dirname(__file__))
```

The `__name__` is computed rather than hardcoded, to account for `REZ_CONFIG_FILE` being able to take any arbitrary file name, along with avoiding anything hardcoded.

This is expected but missing behavior I think, but additionally one specific usecase was having my `rezconfig.py` at the root of my Rez packages, and wanting to set paths up relative this file.

```bash
/server/packages/rezconfig.py
/server/packages/int
/server/packages/ext
```

Oh, and I explicitly did *not* let these get carried into the resulting `Config` object, as that would make less sense, considering it is a result of potentially many different rezconfig.py files. Hence, writing a test for this was challenging.. if you have any ideas, I'd be happy to add some.