### PR TITLE
Ordered iter_packages

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -718,11 +718,11 @@ class FileSystemPackageRepository(PackageRepository):
         # tested regardless. Failed releases may cause 'building files' to be
         # left behind, so we need to clear these out also
         #
-        dirs = set()
+        dirs = list()
         building_dirs = set()
 
         # find dirs and dirs marked as 'building'
-        for name in os.listdir(root):
+        for name in sorted(os.listdir(root), reverse=True):
             if name.startswith('.'):
                 if not name.startswith(self.building_prefix):
                     continue
@@ -732,8 +732,8 @@ class FileSystemPackageRepository(PackageRepository):
 
             path = os.path.join(root, name)
 
-            if os.path.isdir(path) and not ignore_dir(name):
-                dirs.add(name)
+            if name not in dirs and os.path.isdir(path) and not ignore_dir(name):
+                dirs.append(name)
 
         # check 'building' dirs for validity
         for name in building_dirs:
@@ -745,7 +745,7 @@ class FileSystemPackageRepository(PackageRepository):
                 # package probably still being built
                 dirs.remove(name)
 
-        return list(dirs)
+        return dirs
 
     # True if `path` contains package.py or similar
     def _is_valid_package_directory(self, path):


### PR DESCRIPTION
Previously, `rez.packages_.iter_packages` yields results in a somewhat randomised order, based on how items are returned from the `set()` they are currently stored in once retrieved from the otherwise alphabetical `os.listdir`.

Now packages are yielded in reverse-alphabetical order, which means you're able to fetch the latest version like this.

**Before**

```python
it = iter_packages("maya")
latest = next(it)
for package in it:
  if package.version > latest.version:
    latest = package
```

**After**

```python
latest = next(iter_packages("maya"))
```

Which is not only easier on the eyes, it's also significantly cheaper, as it doesn't incur a filesystem call per available version of package.

### Why

The benefits are quite obvious I think, but for completeness; this is an optimisation in both network traffic and time spent for the user.

### Caveat

It's a backwards compatible change, but comes with a few gotchas.

1. The alphabetical order isn't always accurately representing the latest version, e.g. `1.80` is newer than `1.9`.
2. Versions may come from multiple directories (!)

Number 2 is the big one, consider for example.

```bash
~/
  packages/
    maya/
      2018/

/
  server/
    packages/
      maya/
        2019/
```

In this case, "latest" is relative the order these appear on your `REZ_PACKAGES_PATH`.

```bash
$ export REZ_PACKAGES_PATH=~/:/server/packages  # next(iter_packages) == 2018
$ export REZ_PACKAGES_PATH=/server/packages:~/  # next(iter_packages) == 2019
```

So the prerequisites for this to work, in its current form is to have each unique package come from a single repository. Note that you could still have multiple repositories, just not versions of the same package coming from two or more repositories.

### Discussion

I think we're close to making this work without caveats. The call to `os.listdir` is cheap compared to parsing the `package.py` which currently happens in tandem with directories returned.

(1) is easily solved by gathering versions from each directory (cheap) and comparing them via `Version(text)`.

(2) is a little more tricky, but perhaps not too far off. If we `os.listdir` all paths first, sort them, and then run them through the process of parsing the corresponding `package.py`, we should be able to get an ordered result, without sacrificing any functionality or performance.

What do you think?