### PR TITLE
Add a package_preprocess_mode (#609)

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -242,6 +242,13 @@ class OptionalStrOrFunction(Setting):
         return value
 
 
+class PreprocessMode_(Str):
+    @cached_class_property
+    def schema(cls):
+        from rez.developer_package import PreprocessMode
+        return Or(*(x.name for x in PreprocessMode))
+
+
 class BuildThreadCount_(Setting):
     # may be a positive int, or the values "physical" or "logical"
 
@@ -325,6 +332,7 @@ config_schema = Schema({
     "alias_fore":                                   OptionalStr,
     "alias_back":                                   OptionalStr,
     "package_preprocess_function":                  OptionalStrOrFunction,
+    "package_preprocess_mode":                      PreprocessMode_,
     "context_tracking_host":                        OptionalStr,
     "variant_shortlinks_dirname":                   OptionalStr,
     "build_thread_count":                           BuildThreadCount_,

--- a/src/rez/developer_package.py
+++ b/src/rez/developer_package.py
@@ -178,7 +178,6 @@ class DeveloperPackage(Package):
         package_preprocess_mode = self.config.package_preprocess_mode
 
         def _get_package_level():
-            print_info("Applying preprocess from package.py")
             return getattr(self, "preprocess", None)
 
         def _get_global_level():
@@ -233,7 +232,6 @@ class DeveloperPackage(Package):
                 print_error("Function '%s' not found" % package_preprocess_function)
                 return None
 
-            print_info("Applying preprocess function %s" % package_preprocess_function)
             return preprocess_func
 
         with add_sys_paths(config.package_definition_build_python_paths):
@@ -254,6 +252,9 @@ class DeveloperPackage(Package):
             for preprocessor in preprocessors:
                 if not preprocessor:
                     continue
+
+                level = "global" if preprocessor == global_preprocess else "local"
+                print_info("Applying {0} preprocess function".format(level))
 
                 # apply preprocessing
                 try:

--- a/src/rez/developer_package.py
+++ b/src/rez/developer_package.py
@@ -6,9 +6,18 @@ from rez.exceptions import PackageMetadataError, InvalidPackageError
 from rez.utils.system import add_sys_paths
 from rez.utils.sourcecode import SourceCode
 from rez.utils.logging_ import print_info, print_error
+from rez.vendor.enum import Enum
 from inspect import isfunction
 import os.path
 import stat
+
+
+class PreprocessMode(Enum):
+    """Defines when a package preprocess will be executed.
+    """
+    before = 0    # Package's preprocess function is executed before the global preprocess
+    after = 1     # Package's preprocess function is executed after the global preprocess
+    override = 2  # Package's preprocess function completely overrides the global preprocess.
 
 
 class DeveloperPackage(Package):
@@ -159,28 +168,36 @@ class DeveloperPackage(Package):
     def _get_preprocessed(self, data):
         """
         Returns:
-            (DeveloperPackage, new_data) 2-tuple IFF the preprocess function
+            (DeveloperPackage, new_data) 2-tuple IF the preprocess function
             changed the package; otherwise None.
         """
         from rez.serialise import process_python_objects
         from rez.utils.data_utils import get_dict_diff_str
         from copy import deepcopy
 
-        with add_sys_paths(config.package_definition_build_python_paths):
-            preprocess_func = getattr(self, "preprocess", None)
+        package_preprocess_mode = self.config.package_preprocess_mode
 
-            if preprocess_func:
-                print_info("Applying preprocess from package.py")
+        def _get_package_level():
+            print_info("Applying preprocess from package.py")
+            return getattr(self, "preprocess", None)
+
+        def _get_global_level():
+            # load globally configured preprocess function
+            package_preprocess_function = self.config.package_preprocess_function
+
+            if not package_preprocess_function:
+                return None
+
+            elif isfunction(package_preprocess_function):
+                preprocess_func = package_preprocess_function
 
             else:
-                # load globally configured preprocess function
-                package_preprocess_function = self.config.package_preprocess_function
-
-                if not package_preprocess_function:
+                if '.' not in package_preprocess_function:
+                    print_error(
+                        "Setting 'package_preprocess_function' must be of "
+                        "form 'module[.module.module...].funcname'. Package  "
+                        "preprocessing has not been applied.")
                     return None
-
-                elif isfunction(package_preprocess_function):
-                    preprocess_func = package_preprocess_function
 
                 elif isinstance(package_preprocess_function, basestring):
                     if '.' not in package_preprocess_function:
@@ -212,23 +229,41 @@ class DeveloperPackage(Package):
                     )
                     return None
 
-                print_info("Applying preprocess function %s" % preprocess_func)
-
             if not preprocess_func or not isfunction(preprocess_func):
                 print_error("Function '%s' not found" % package_preprocess_function)
                 return None
 
+            print_info("Applying preprocess function %s" % package_preprocess_function)
+            return preprocess_func
+
+        with add_sys_paths(config.package_definition_build_python_paths):
+
+            preprocess_mode = PreprocessMode[self.config.package_preprocess_mode]
+            package_preprocess = _get_package_level()
+            global_preprocess = _get_global_level()
+
+            if preprocess_mode == PreprocessMode.after:
+                preprocessors = [global_preprocess, package_preprocess]
+            elif preprocess_mode == PreprocessMode.before:
+                preprocessors = [package_preprocess, global_preprocess]
+            else:
+                preprocessors = [package_preprocess or global_preprocess]
+
             preprocessed_data = deepcopy(data)
 
-            # apply preprocessing
-            try:
-                preprocess_func(this=self, data=preprocessed_data)
-            except InvalidPackageError:
-                raise
-            except Exception as e:
-                print_error("Failed to apply preprocess: %s: %s"
-                            % (e.__class__.__name__, str(e)))
-                return None
+            for preprocessor in preprocessors:
+                if not preprocessor:
+                    continue
+
+                # apply preprocessing
+                try:
+                    preprocessor(this=self, data=preprocessed_data)
+                except InvalidPackageError:
+                    raise
+                except Exception as e:
+                    print_error("Failed to apply preprocess: %s: %s"
+                                % (e.__class__.__name__, str(e)))
+                    return None
 
         # if preprocess added functions, these may need to be converted to
         # SourceCode instances

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -372,8 +372,12 @@ package_commands_sourced_first = True
 # get $PATH from there; Windows inspects its registry).
 standard_system_paths = []
 
-# If you define this function, it will be called as the *preprocess function*
-# on every package that does not provide its own, as part of the build process.
+# If you define this function, by default it will be called as the
+# *preprocess function* on every package that does not provide its own,
+# as part of the build process. This behavior can be changed by using the
+# [package_preprocess_mode](#package_preprocess_mode) setting so that
+# it gets executed even if a package define its own preprocess function.
+#
 # The setting can be a function defined in your rezconfig.py, or a string.
 #
 # Example of a function to define the setting:
@@ -413,6 +417,18 @@ standard_system_paths = []
 #             raise InvalidPackageError("Invalid package name.")
 #
 package_preprocess_function = None
+
+# Defines in which order the [package_preprocess_function](#package_preprocess_function)
+# and the `preprocess` function inside a `package.py` are executed.
+#
+# Note that "global preprocess" means the preprocess defined by
+# [package_preprocess_function](#package_preprocess_function).
+#
+# Possible values are:
+# - "before": Package's preprocess function is executed before the global preprocess;
+# - "after": Package's preprocess function is executed after the global preprocess;
+# - "override": Package's preprocess function completely overrides the global preprocess.
+package_preprocess_mode = "override"
 
 
 ###############################################################################

--- a/src/rez/tests/data/packages/developer_dynamic_local_preprocess_additive/package.py
+++ b/src/rez/tests/data/packages/developer_dynamic_local_preprocess_additive/package.py
@@ -1,5 +1,5 @@
 
-name = "developer_dynamic_local_preprocess"
+name = "developer_dynamic_local_preprocess_additive"
 
 @early()
 def description():
@@ -10,8 +10,10 @@ requires = [
 ]
 
 def preprocess(this, data):
+    print 'Local preprocess'
     from early_utils import get_authors
     data["authors"] = get_authors()
+    data["dynamic_attribute_added"] = {"value_set_by": "local"}
     data["added_by_local_preprocess"] = True
 
 # make sure imported modules don't break developer packages

--- a/src/rez/tests/data/packages/developer_dynamic_local_preprocess_additive/package.py
+++ b/src/rez/tests/data/packages/developer_dynamic_local_preprocess_additive/package.py
@@ -1,4 +1,3 @@
-
 name = "developer_dynamic_local_preprocess_additive"
 
 @early()
@@ -10,7 +9,6 @@ requires = [
 ]
 
 def preprocess(this, data):
-    print 'Local preprocess'
     from early_utils import get_authors
     data["authors"] = get_authors()
     data["dynamic_attribute_added"] = {"value_set_by": "local"}

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -222,6 +222,7 @@ class TestPackages(TestBase, TempdirMixin):
         self.assertEqual(package.requires, [PackageRequest('versioned-3')])
         self.assertEqual(package.authors, ["tweedle-dee", "tweedle-dum"])
         self.assertFalse(hasattr(package, "added_by_global_preprocess"))
+        self.assertEqual(package.added_by_local_preprocess, True)
 
     def test_developer_dynamic_global_preprocess_string(self):
         """test developer package with a global preprocess function as string"""
@@ -257,6 +258,54 @@ class TestPackages(TestBase, TempdirMixin):
 
         self.assertEqual(package.description, "This.")
         self.assertEqual(package.dynamic_attribute_added, {'test': True})
+
+    def test_developer_dynamic_before(self):
+        """test developer package with both global and local preprocess in before mode"""
+        # a developer package with features such as expanding requirements,
+        # global preprocessing
+        def preprocess(this, data):
+            data["dynamic_attribute_added"] = {'value_set_by': 'global'}
+            data["added_by_global_preprocess"] = True
+
+        self.update_settings(
+            {
+                "package_preprocess_function": preprocess,
+                "package_preprocess_mode": "before"
+            }
+        )
+
+        path = os.path.join(self.packages_base_path, "developer_dynamic_local_preprocess_additive")
+        package = get_developer_package(path)
+
+        self.assertEqual(package.description, "This.")
+        self.assertEqual(package.authors, ["tweedle-dee", "tweedle-dum"])
+        self.assertEqual(package.dynamic_attribute_added, {'value_set_by': 'global'})
+        self.assertEqual(package.added_by_global_preprocess, True)
+        self.assertEqual(package.added_by_local_preprocess, True)
+
+    def test_developer_dynamic_after(self):
+        """test developer package with both global and local preprocess in after mode"""
+        # a developer package with features such as expanding requirements,
+        # global preprocessing
+        def preprocess(this, data):
+            data["dynamic_attribute_added"] = {'value_set_by': 'global'}
+            data["added_by_global_preprocess"] = True
+
+        self.update_settings(
+            {
+                "package_preprocess_function": preprocess,
+                "package_preprocess_mode": "after"
+            }
+        )
+
+        path = os.path.join(self.packages_base_path, "developer_dynamic_local_preprocess_additive")
+        package = get_developer_package(path)
+
+        self.assertEqual(package.description, "This.")
+        self.assertEqual(package.authors, ["tweedle-dee", "tweedle-dum"])
+        self.assertEqual(package.dynamic_attribute_added, {'value_set_by': 'local'})
+        self.assertEqual(package.added_by_global_preprocess, True)
+        self.assertEqual(package.added_by_local_preprocess, True)
 
     def test_6(self):
         """test variant iteration."""


### PR DESCRIPTION
This PR implements #609 , which is make it possible to have both a global and local preprocess function run when building a package.

That means it's now possible to have a global preprocess that applies to all packages, and also have specialized preprocesses per packages if need be. This is made possible by a new configuration called `package_preprocess_mode`. It accepts 3 values: `after`, `before` and `override`.

The default value is `override`, which mean we have the exact same behavior as before: If you defined `package_preprocess_function` and you also have a `preprocess` function in a package, only the package's `preprocess` function is called.

`after` and `before` are what I call the additive modes. They allow you to choose to execute a package's `preprocess` function before or after the global preprocess.

* I updated the docs;
* Wrote tests.