### PR TITLE
[Fix] Package schema and request errors

### DIFF
--- a/src/rez/package_maker__.py
+++ b/src/rez/package_maker__.py
@@ -128,6 +128,10 @@ class PackageMaker(AttrDictWrapper):
     def _get_data(self):
         data = self._data.copy()
 
+        if "requires" in data:
+            if None in data["requires"]:
+                data["requires"] = [x for x in data["requires"] if x is not None]
+
         data.pop("installed_variants", None)
         data.pop("skipped_variants", None)
         data.pop("package_cls", None)

--- a/src/rez/utils/formatting.py
+++ b/src/rez/utils/formatting.py
@@ -14,7 +14,7 @@ import re
 import time
 
 
-PACKAGE_NAME_REGSTR = "[a-zA-Z_0-9](\.?[a-zA-Z0-9_]+)*"
+PACKAGE_NAME_REGSTR = "[a-zA-Z_0-9](\.?[a-zA-Z0-9_-]+)*"
 PACKAGE_NAME_REGEX = re.compile(r"^%s\Z" % PACKAGE_NAME_REGSTR)
 
 ENV_VAR_REGSTR = r'\$(\w+|\{[^}]*\})'

--- a/src/rez/utils/formatting.py
+++ b/src/rez/utils/formatting.py
@@ -14,7 +14,7 @@ import re
 import time
 
 
-PACKAGE_NAME_REGSTR = "[a-zA-Z_0-9](\.?[a-zA-Z0-9_-]+)*"
+PACKAGE_NAME_REGSTR = "[a-zA-Z_0-9](\.?[a-zA-Z0-9_]+)*"
 PACKAGE_NAME_REGEX = re.compile(r"^%s\Z" % PACKAGE_NAME_REGSTR)
 
 ENV_VAR_REGSTR = r'\$(\w+|\{[^}]*\})'


### PR DESCRIPTION
# Description

[Depends on PR #602 #654 #656]

## This PR has been extracted from #628  (a lot of the relevant discussion still lives there)

### Package version schema and request errors

## Breakdown

* fix schema issue with packages including dashes for example importlib_metadata->=0.5

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Python version: 2.7.15, 2.7.16
* OS: Linux, Windows 10
* Toolchain: rez 2.33, pip 18.1, 19.1.1, distlib 0.2.9.post0

## Todos
- [ ] Tests