### PR TITLE
[Fix] Windows rez-bind pip

### DIFF
--- a/src/rez/bind/_pymodule.py
+++ b/src/rez/bind/_pymodule.py
@@ -34,14 +34,8 @@ def copy_module(name, destpath):
          "print(%s.__path__[0] if hasattr(%s, '__path__') else '')" % (name, name)])
 
     if out:
-        if name == "pip":
-            path = subprocess.check_output('python -c "import pip; print(pip.__path__)"', shell=True)
-            # retrieve second line since first is the Python 2 deprecation warning
-            srcpath = path.strip()[2:-2]
-            shutil.copytree(srcpath, os.path.join(destpath, name))
-        else:
-            srcpath = out
-            shutil.copytree(srcpath, os.path.join(destpath, name))
+        srcpath = out
+        shutil.copytree(srcpath, os.path.join(destpath, name))
     else:
         success, out, err = run_python_command(
             ["import %s" % name,
@@ -67,15 +61,10 @@ def bind(name, path, import_name=None, version_range=None, version=None,
     import_name = import_name or name
 
     if version is None:
-        if name == "pip":
-            ver = subprocess.check_output('python -c "import pip; print(pip.__version__)"', shell=True)
-            version = ver.strip()
-
-        else:
-            version = get_version_in_python(
-                name,
-                ["import %s" % import_name,
-                 "print(%s.__version__)" % import_name])
+        version = get_version_in_python(
+            name,
+            ["import %s" % import_name,
+             "print(%s.__version__)" % import_name])
 
     check_version(version, version_range)
 

--- a/src/rez/bind/_pymodule.py
+++ b/src/rez/bind/_pymodule.py
@@ -34,8 +34,14 @@ def copy_module(name, destpath):
          "print(%s.__path__[0] if hasattr(%s, '__path__') else '')" % (name, name)])
 
     if out:
-        srcpath = out
-        shutil.copytree(srcpath, os.path.join(destpath, name))
+        if name == "pip":
+            path = subprocess.check_output('python -c "import pip; print(pip.__path__)"', shell=True)
+            # retrieve second line since first is the Python 2 deprecation warning
+            srcpath = path.strip()[2:-2]
+            shutil.copytree(srcpath, os.path.join(destpath, name))
+        else:
+            srcpath = out
+            shutil.copytree(srcpath, os.path.join(destpath, name))
     else:
         success, out, err = run_python_command(
             ["import %s" % name,
@@ -61,10 +67,15 @@ def bind(name, path, import_name=None, version_range=None, version=None,
     import_name = import_name or name
 
     if version is None:
-        version = get_version_in_python(
-            name,
-            ["import %s" % import_name,
-             "print(%s.__version__)" % import_name])
+        if name == "pip":
+            ver = subprocess.check_output('python -c "import pip; print(pip.__version__)"', shell=True)
+            version = ver.strip()
+
+        else:
+            version = get_version_in_python(
+                name,
+                ["import %s" % import_name,
+                 "print(%s.__version__)" % import_name])
 
     check_version(version, version_range)
 

--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -120,9 +120,9 @@ def _run_command(args):
     log("running: %s" % cmd_str)
 
     if "Windows" in platform.system():
-        p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, universal_newlines=True)
     else:
-        p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 
 
     stdout, stderr = p.communicate()

--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -12,6 +12,7 @@ from pipes import quote
 import subprocess
 import os.path
 import os
+import platform
 
 
 def log(msg):
@@ -118,7 +119,12 @@ def _run_command(args):
     cmd_str = ' '.join(quote(x) for x in args)
     log("running: %s" % cmd_str)
 
-    p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    if "Windows" in platform.system():
+        p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    else:
+        p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
     stdout, stderr = p.communicate()
     return stdout, stderr, p.returncode
 

--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -118,7 +118,7 @@ def _run_command(args):
     cmd_str = ' '.join(quote(x) for x in args)
     log("running: %s" % cmd_str)
 
-    p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     stdout, stderr = p.communicate()
     return stdout, stderr, p.returncode
 

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -246,7 +246,7 @@ def find_pip(pip_version=None, python_version=None):
     # check pip version, must be >=19 to support PEP517
     try:
         pattern = r"pip\s(?P<ver>\d+\.*\d*\.*\d*)"
-        ver_str = subprocess.check_output([pip_exe, '-V'])
+        ver_str = subprocess.check_output('{} -V'.format(pip_exe), shell=True)
         match = re.search(pattern, ver_str)
         ver = match.group('ver')
         pip_major = ver.split('.')[0]

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -27,6 +27,7 @@ import shutil
 import sys
 import os
 import re
+import platform
 
 
 class InstallMode(Enum):
@@ -246,7 +247,12 @@ def find_pip(pip_version=None, python_version=None):
     # check pip version, must be >=19 to support PEP517
     try:
         pattern = r"pip\s(?P<ver>\d+\.*\d*\.*\d*)"
-        ver_str = subprocess.check_output('{} -V'.format(pip_exe), shell=True)
+
+        if "Windows" in platform.system():
+            ver_str = subprocess.check_output('{} -V'.format(pip_exe), shell=True)
+        else:
+            ver_str = subprocess.check_output('{} -V'.format(pip_exe))
+
         match = re.search(pattern, ver_str)
         ver = match.group('ver')
         pip_major = ver.split('.')[0]

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -249,9 +249,9 @@ def find_pip(pip_version=None, python_version=None):
         pattern = r"pip\s(?P<ver>\d+\.*\d*\.*\d*)"
 
         if "Windows" in platform.system():
-            ver_str = subprocess.check_output('{} -V'.format(pip_exe), shell=True)
+            ver_str = subprocess.check_output('{} -V'.format(pip_exe), shell=True, universal_newlines=True)
         else:
-            ver_str = subprocess.check_output('{} -V'.format(pip_exe))
+            ver_str = subprocess.check_output(['{}'.format(pip_exe), '-V'], universal_newlines=True)
 
         match = re.search(pattern, ver_str)
         ver = match.group('ver')

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -3,6 +3,7 @@ import sys
 import os
 import os.path
 import re
+import subprocess
 from rez.util import which
 from rez.utils.system import popen
 from rez.utils.data_utils import cached_property
@@ -496,6 +497,11 @@ class WindowsPlatform(Platform):
         # http://stackoverflow.com/questions/6260149/os-symlink-support-in-windows
         if callable(getattr(os, "symlink", None)):
             os.symlink(source, link_name)
+        elif "Windows-10" in platform.platform():
+            # Starting with Windows 10 Insiders build 14972, symlinks can be
+            # created without needing to elevate the console as administrator.
+            # https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/#joC5tFKhdXs2gGml.97
+            subprocess.check_output('mklink %s %s' % (link_name, source), shell=True)
         else:
             import ctypes
             csl = ctypes.windll.kernel32.CreateSymbolicLinkW


### PR DESCRIPTION
# Description

[Depends on PR #602, #654. #656]

Currently running rez-bind pip will create a broken package unless you run it with admin privileges. This has to do with symlinking pip, and as you can't do that on non-administrative accounts there are things missing from the package rendering it in a broken state. This can potentially cause the pip version check to fail because the pip exe will be set to the broken package. 

rez-bind pip on Windows causes an invalid pip package to be generated. I am not sure where the
mysterious 1.5.6 version comes from but is definitively not the same one as the one installed on the system.

![pip_bind_fail](https://user-images.githubusercontent.com/47409392/60481344-f0917400-9cc7-11e9-9b0b-bfdd3752a308.PNG)

Now the version check correctly picks up the wrong version and raises an error but it actually hides the fact that the system pip version might be >= 19, it also hides the original exception

![pip_bind_fail2](https://user-images.githubusercontent.com/47409392/60481713-8aa5ec00-9cc9-11e9-8c4a-69c7227bec1c.PNG)

Saying that, the VersionError exception might prompt the user towards the right direction but is still
confusing nonetheless.

### Remarks:
* Windows 10 users please try and let me know if at all possible
* Changes not final - still debugging
* I will wait for some feedback from Windows users

## Extra info

Linux:

```
Binding pip into /home/user/packages...
/home/user/.pyenv/versions/2.7.16/lib/python2.7/site-packages/pip OK
/home/user/packages/pip/19.1.1/platform-linux/arch-x86_64/os-Arch-rolling/python-2.7/python ??
````

Windows:

```
Binding pip into C:\Users\Joe\packages...
c:\users\joe\.rez\lib\site-packages\pip ???
C:\Users\Joe\packages\pip\1.5.6\platform-windows\arch-AMD64\os-windows-10.0.17763\python-2.7\python OK
```

On Linux rez correctly copies the pip directory tree from the Python that was used to install rez with
whereas on Windows, the directory tree that gets copied is quite different, it comes from the
lib directory of the rez itself?? That is where the weird 1.5.6 version seems to be coming from.

### Update:

After further investigation, I realized that at least on my Windows 10 machine, every time pip is referenced it points to the wrong one under lib which has the version 1.5.6 causing the pip check test to always fail. The root of the issue seems to be there. This happens with both admin and non 
admin privileges. **This seems to be the fact of not using shell=True when running the python commands to retrieve version and path for pip.**

I have managed to circumvent the issue during the bind that now also works without admin privileges
(only on Windows 10) by modifying the way the path and version to pip is retrieved. I would still like to know the reason pip has these issues so I will keep on looking.

#### pip now uses the correct path and displays the correct version

![pip_check_correct](https://user-images.githubusercontent.com/47409392/60557091-1b8acf00-9d7f-11e9-9328-e16da2c11b84.png)

#### pip with the correct path and version still raises the VersionError (uses lib one)

![pip_check_incorrect](https://user-images.githubusercontent.com/47409392/60557154-55f46c00-9d7f-11e9-8059-9f7c30dd27f6.png)

#### pip package correctly created without admin privileges

![pip_env_correct](https://user-images.githubusercontent.com/47409392/60557170-67d60f00-9d7f-11e9-87e3-602024707b38.PNG)

#### Results

#### correct install using pip package (non admin)

![correct_package](https://user-images.githubusercontent.com/47409392/60558353-e03ecf00-9d83-11e9-9335-ce331210f4f3.PNG)

#### correct install using pip system (non admin)

![correct_system](https://user-images.githubusercontent.com/47409392/60558379-fb114380-9d83-11e9-879e-cf30715e09c2.PNG)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The fixes for these issues have been tested with various packages using the following:

**Test Configuration**:
* Python version: 2.7.15, 2.7.16
* OS: Linux, Windows 10
* Toolchain: rez 2.33, pip 18.1, 19.1.1, distlib 0.2.9.post0