### PR TITLE
[Feature] Additional tools to Path

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -234,6 +234,13 @@ class RezToolsVisibility_(Str):
         return Or(*(x.name for x in RezToolsVisibility))
 
 
+class StandardPathVisibility_(Str):
+    @cached_class_property
+    def schema(cls):
+        from rez.shells import StandardPathVisibility
+        return Or(*(x.name for x in StandardPathVisibility))
+
+
 class OptionalStrOrFunction(Setting):
     schema = Or(None, basestring, callable)
 
@@ -271,6 +278,7 @@ config_schema = Schema({
     "plugin_path":                                  PathList,
     "bind_module_path":                             PathList,
     "standard_system_paths":                        PathList,
+    "standard_system_paths_visibility":             StandardPathVisibility_,
     "package_definition_build_python_paths":        PathList,
     "implicit_packages":                            StrList,
     "platform_map":                                 OptionalDict,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -366,10 +366,18 @@ rez_tools_visibility = "append"
 # scripts (such as .bashrc). If False, package commands are sourced after.
 package_commands_sourced_first = True
 
+# Defines how the standard_system_paths configuration acts on the $PATH:
+# - "replace":           Replace $PATH if standard_system_paths is set
+# - "append":            Append standard_system_paths to determined $PATH
+# - "prepend":           Prepend standard_system_paths to determined $PATH
+standard_system_paths_visibility = "replace"
+
 # Defines paths to initially set $PATH to, if a resolve appends/prepends $PATH.
 # If this is an empty list, then this initial value is determined automatically
 # depending on the shell (for example, *nix shells create a temp clean shell and
 # get $PATH from there; Windows inspects its registry).
+# The way the list is combined with $PATH is controlled via
+# rez_standard_system_paths_visibility.
 standard_system_paths = []
 
 # If you define this function, it will be called as the *preprocess function*

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -28,13 +28,17 @@ def syspaths_composer(func):
     """Decorator for Shell get_syspath methods, that handles
     standard_system_paths_visibility"""
     def wrapper(cls):
+
+        mode = StandardPathVisibility[config.standard_system_paths_visibility]
+
+        # Don't even load the shell syspaths if we are replacing them anyway
+        if config.standard_system_paths and mode == StandardPathVisibility.replace:
+            return config.standard_system_paths
+
         syspaths = list(func(cls))
 
         if config.standard_system_paths:
-            mode = StandardPathVisibility[config.standard_system_paths_visibility]
-            if mode == StandardPathVisibility.replace:
-                syspaths = config.standard_system_paths
-            elif mode == StandardPathVisibility.append:
+            if mode == StandardPathVisibility.append:
                 syspaths += config.standard_system_paths
             elif mode == StandardPathVisibility.prepend:
                 syspaths = config.standard_system_paths + syspaths

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -93,8 +93,10 @@ class Shell(ActionInterpreter):
 
     @classmethod
     def get_syspaths(cls):
-        """Implement and decorate with syspaths_composer to enable class
-        level caching and to compose the result based on config"""
+        """
+        Implement and decorate with syspaths_composer to compose the result
+        based on standard_system_paths_visibility
+        """
         raise NotImplementedError
 
     def __init__(self):

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -3,6 +3,7 @@ test shell invocation
 """
 from __future__ import print_function
 
+from rez.config import config
 from rez.system import system
 from rez.shells import create_shell
 from rez.resolved_context import ResolvedContext
@@ -327,6 +328,24 @@ class TestShells(TestBase, TempdirMixin):
         # We don't expect any output, the shell should just return with exit
         # code 0.
         _execute_code(_alias_after_path_manipulation)
+
+    @shell_dependent()
+    def test_standard_system_paths_visibility(self):
+
+        config.override("standard_system_paths_visibility", "replace")
+        config.override("standard_system_paths", ["SinglePath"])
+        sh = create_shell()
+        self.assertListEqual(sh.get_syspaths(), ["SinglePath"])
+
+        config.override("standard_system_paths_visibility", "prepend")
+        config.override("standard_system_paths", ["AnotherPath"])
+        sh = create_shell()
+        self.assertEqual(sh.get_syspaths()[0], "AnotherPath")
+
+        config.override("standard_system_paths_visibility", "append")
+        config.override("standard_system_paths", ["YetAnotherPath"])
+        sh = create_shell()
+        self.assertEqual(sh.get_syspaths()[-1], "YetAnotherPath")
 
 
 if __name__ == '__main__':

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -3,7 +3,7 @@ Windows Command Prompt (DOS) shell.
 """
 from rez.config import config
 from rez.rex import RexExecutor, literal, OutputStyle, EscapedString
-from rez.shells import Shell
+from rez.shells import Shell, syspaths_composer
 from rez.system import system
 from rez.utils.system import popen
 from rez.utils.platform_ import platform_
@@ -68,12 +68,9 @@ class CMD(Shell):
         )
 
     @classmethod
+    @syspaths_composer
     def get_syspaths(cls):
         if cls.syspaths is not None:
-            return cls.syspaths
-
-        if config.standard_system_paths:
-            cls.syspaths = config.standard_system_paths
             return cls.syspaths
 
         # detect system paths using registry

--- a/src/rezplugins/shell/csh.py
+++ b/src/rezplugins/shell/csh.py
@@ -7,7 +7,7 @@ import subprocess
 from rez.config import config
 from rez.utils.system import popen
 from rez.utils.platform_ import platform_
-from rez.shells import Shell, UnixShell
+from rez.shells import Shell, UnixShell, syspaths_composer
 from rez.rex import EscapedString
 
 
@@ -33,12 +33,9 @@ class CSH(UnixShell):
         return 'csh'
 
     @classmethod
+    @syspaths_composer
     def get_syspaths(cls):
         if cls.syspaths is not None:
-            return cls.syspaths
-
-        if config.standard_system_paths:
-            cls.syspaths = config.standard_system_paths
             return cls.syspaths
 
         # detect system paths using registry

--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -8,7 +8,7 @@ import subprocess
 from rez.config import config
 from rez.utils.system import popen
 from rez.utils.platform_ import platform_
-from rez.shells import Shell, UnixShell
+from rez.shells import Shell, UnixShell, syspaths_composer
 from rez.rex import EscapedString
 
 
@@ -33,12 +33,9 @@ class SH(UnixShell):
         return 'sh'
 
     @classmethod
+    @syspaths_composer
     def get_syspaths(cls):
         if cls.syspaths is not None:
-            return cls.syspaths
-
-        if config.standard_system_paths:
-            cls.syspaths = config.standard_system_paths
             return cls.syspaths
 
         # detect system paths using registry


### PR DESCRIPTION
Implements #660.

- [x] Backwards compatible
- [x] Unit tests
## Compatibility 

1. It is fully backwards compatible. A new config variable is introduced, that defaults to current behavior `replace`
2. Reuses the `standard_system_paths` variable usage
3. External shell plugins will not be affected but can remove the rezconfig logic and have to decorate `get_syspaths` with `syspaths_composer` to make use of the new feature.

## What do we gain?

- Ability to prepend / append paths to shell's syspath as opposed to only replacing it. Compare #660
- Removed control logic of `standard_system_paths` out of plugin implementation into central decorator `syspaths_composer`