### PR TITLE
[Fix] Sh failing in `test_shells.TeshShells.text_rex_code_alias`

### DIFF
--- a/src/rezplugins/shell/bash.py
+++ b/src/rezplugins/shell/bash.py
@@ -7,6 +7,7 @@ from rez.shells import Shell
 from rez.utils.platform_ import platform_
 from rezplugins.shell.sh import SH
 from rez import module_root_path
+from rez.rex import EscapedString
 
 
 class Bash(SH):
@@ -81,6 +82,11 @@ class Bash(SH):
             bind_files=bind_files,
             source_bind_files=True
         )
+
+    def alias(self, key, value):
+        value = EscapedString.disallow(value)
+        cmd = 'function {key}() {{ {value} "$@"; }};export -f {key};'
+        self._addline(cmd.format(key=key, value=value))
 
     def _bind_interactive_rez(self):
         super(Bash, self)._bind_interactive_rez()

--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -115,7 +115,7 @@ class SH(UnixShell):
 
     def alias(self, key, value):
         value = EscapedString.disallow(value)
-        cmd = 'function {key}() {{ {value} "$@"; }};export -f {key};'
+        cmd = '{key}() {{ {value} "$@"; }};'
         self._addline(cmd.format(key=key, value=value))
 
     def source(self, value):


### PR DESCRIPTION
SH uses a different function convention then bash, namely: ```functioname() { ...; }```
Compare http://www.skrenta.com/rt/man/sh.1.html

Currently using sh with rez-alias will result in an error like:
```
/tmp/rez_context_l7mlMa/rez-shell.sh: 5: /tmp/rez_context_l7mlMa/context.sh: Syntax error: "(" unexpected
```

I am not an expert on sh but I believe you can't/don't need to export the function afterwards.

## Compatibility
- Does not break compatibility
- External Shell-Plugins should be careful if sub-classing `Sh`, since its alias implementation now differs from `Bash`

## Tests passing 
- [x] Windows 10.0.17134
  - [x] cmd
- [x] Linux Ubuntu 18.04.2 LTS (WSL)
  - [x] tcsh
  - [x] sh
  - [x] bash
  - [x] csh