### PR TITLE
Fix pydot regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [2.37.1](https://github.com/nerdvegas/rez/tree/2.37.1) (2019-07-19)
+[Full Changelog](https://github.com/nerdvegas/rez/compare/2.37.0...2.37.1)
+
+**Notes**
+
+This fixes a regression introduced in `2.34.0`, which causes `rez-context -g` to
+fail. The pydot vendor package was updated, and the newer version includes a
+breaking change. Where `pydot.graph_from_dot_data` used to return a single graph
+object, it now returns a list of graph objects.
+
+**Merged pull requests:**
+
+- Fix pydot regression [\#XXX](https://github.com/nerdvegas/rez/pull/XXX) ([nerdvegas](https://github.com/nerdvegas))
+
 ## [2.37.0](https://github.com/nerdvegas/rez/tree/2.37.0) (2019-07-19)
 [Full Changelog](https://github.com/nerdvegas/rez/compare/2.36.2...2.37.0)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,8 @@ Here is an example changelog entry:
 
 **Notes**
 
-Fixed error in foo rex command on Windows.
+Describe the fixes the PR addresses here. It's ok if this is a summary of a longer
+description found in the PR itself, in fact that should be common.
 
 **Backwards Compatibility Issues**
 
@@ -49,11 +50,11 @@ reason.
 
 **Merged pull requests:**
 
-- Fix foo command [\#101](https://github.com/nerdvegas/rez/pull/101) ([jbloggs](https://github.com/jbloggs))
+- PR_TITLE_HERE [\#XXX](https://github.com/nerdvegas/rez/pull/XXX) ([USER](https://github.com/USER))
 
 **Closed issues:**
 
-- rex foo command broken [\#102](https://github.com/nerdvegas/rez/issues/102)
+- ISSUE_TITLE_HERE [\#YYY](https://github.com/nerdvegas/rez/issues/YYY)
 ```
 
 Please include the relevant issues that your PR closes, matching the syntax shown above. When the PR is merged to master, the PR info will be added to the same changelog entry by the maintainer. Don't be too concerned with the date and 'full changelog' line, this will also be patched by the maintainer.

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.37.0"
+_rez_version = "2.37.1"
 
 try:
     from rez.vendor.version.version import Version

--- a/src/rez/utils/graph_utils.py
+++ b/src/rez/utils/graph_utils.py
@@ -13,7 +13,6 @@ from rez.config import config
 from rez.vendor.pydot import pydot
 from rez.utils.system import popen
 from rez.utils.formatting import PackageRequest
-from rez.utils.logging_ import print_warning
 from rez.exceptions import PackageRequestError
 from rez.vendor.pygraph.readwrite.dot import read as read_dot
 from rez.vendor.pygraph.algorithms.accessibility import accessibility

--- a/src/rez/utils/graph_utils.py
+++ b/src/rez/utils/graph_utils.py
@@ -229,7 +229,7 @@ def save_graph(graph_str, dest_file, fmt=None, image_ratio=None):
             try:
                 dest_file_ = "%s.%d%s" % (path, i + 1, ext)
                 save_graph_object(g, dest_file_, fmt, image_ratio)
-                dest_files.append(dest_file)
+                dest_files.append(dest_file_)
             except:
                 pass
 


### PR DESCRIPTION
This fixes a regression introduced in `2.34.0`, which causes `rez-context -g` to
fail. The pydot vendor package was updated, and the newer version includes a
breaking change. Where `pydot.graph_from_dot_data` used to return a single graph
object, it now returns a list of graph objects.
