### PR TITLE
Adding (not latest) printout in resolves

### DIFF
--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -8,7 +8,7 @@ from rez.system import system
 from rez.config import config
 from rez.util import shlex_join, dedup
 from rez.utils.sourcecode import SourceCodeError
-from rez.utils.colorize import critical, heading, local, implicit, Printer
+from rez.utils.colorize import warning, critical, heading, local, implicit, Printer
 from rez.utils.formatting import columnise, PackageRequest, ENV_VAR_REGEX
 from rez.utils.data_utils import deep_del
 from rez.utils.filesystem import TempDirs
@@ -18,7 +18,7 @@ from rez.rex import RexExecutor, Python, OutputStyle
 from rez.rex_bindings import VersionBinding, VariantBinding, \
     VariantsBinding, RequirementsBinding
 from rez import package_order
-from rez.packages_ import get_variant, iter_packages
+from rez.packages_ import get_variant, iter_packages, get_latest_package
 from rez.package_filter import PackageFilterList
 from rez.shells import create_shell
 from rez.exceptions import ResolvedContextError, PackageCommandError, RezError
@@ -759,6 +759,10 @@ class ResolvedContext(object):
             if pkg.is_local:
                 t.append('local')
                 col = local
+
+            if get_latest_package(pkg.name).version > pkg.version:
+                t.append('not latest')
+                col = warning
 
             t = '(%s)' % ', '.join(t) if t else ''
             rows.append((pkg.qualified_package_name, location, t))


### PR DESCRIPTION
This is something we have had in our local branch for a long time.
In the resolve printout, it will show packages that are not the latest version.

like this:
![resolve](https://user-images.githubusercontent.com/3307899/61540559-1f387a00-aa3e-11e9-992c-9e0167d9ac79.png)

We have found this really useful for keeping our packages up to date.

I guess an extra `get_latest_package()` call could add a performance penalty and you might want to be able to configure this feature. We never bothered as we find the feature really useful and never felt any performance penalty.

Let me know if you want me to make it configurable or if you have any other concerns.