### PR TITLE
[Feature] Add native not operator (!) support to version ranges

### DIFF
--- a/src/rez/vendor/version/test.py
+++ b/src/rez/vendor/version/test.py
@@ -291,6 +291,17 @@ class TestVersionSchema(unittest.TestCase):
         _inv("3.5", "<3.5|3.5_+")
         self.assertTrue(~VersionRange() is None)
 
+        # negation
+        _eq("!3.5.6", "<3.5.6|3.5.6_+")
+        _eq("!==3.5.6", "<3.5.6|>3.5.6")
+        _eq("!3.5.6..6.5.0", "<3.5.6|>6.5.0")
+        _eq("!3.5.6+", "<3.5.6")
+        _eq("!>3.5.6", "<=3.5.6")
+        _eq("!>=3.5.6", "<3.5.6")
+        _eq("!<3.5.6", "3.5.6+")
+        _eq("!<=3.5.6", ">3.5.6")
+        _eq("!3.5.6+<6.5.0", "<3.5.6|6.5.0+")
+
         # odd (but valid) cases
         _eq(">", ">")       # greater than the empty version
         _eq("+", "")        # greater or equal to empty version (is all vers)

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -591,11 +591,11 @@ class _VersionRangeParser(object):
          "        (?P<range_upper_desc>"
          "           (?P<range_upper_desc_prefix><|<=)?"  # Upper bound is exclusive?
          "           (?P<range_upper_desc_version>{version_group})?"
-         "           (?(range_upper_desc_prefix)|\+)?"  # + only if upper bound is not exclusive
          "       )(?P<range_lower_desc>"
          "           (?(range_upper_desc_version),|)"  # Comma is not optional because we don't want to recognize something like "<4>3"
-         "           (?P<range_lower_desc_prefix><(?={version_group})|>=?)"  # >= or > only if followed by a version group
+         "           (?P<range_lower_desc_prefix>>(?={version_group})|>=)?"  # >= or > only if followed by a version group
          "           (?P<range_lower_desc_version>{version_group})?"
+         "           (?(range_lower_desc_prefix)|\+)?" # only if lower bound is not exclusive
          "       )"
          "    )$").format(version_group=version_group)
 


### PR DESCRIPTION
# Description

[Relates to issue #666 and PR #667 ]

## Extend the [VersionRange](https://github.com/nerdvegas/rez/blob/master/src/rez/vendor/version/version.py#L742) supported syntax

With the [various rez-pip improvements](#667 ) being added, rez-pip now supports conversion of pip version specifiers to equivalent rez requirements (PEP 440 --> rez compatible) as described below

  Example conversions (provided by Allan's PR 🙏 ):

        |   PEP440    |     rez     |
        |-------------|-------------|
        | ==1         | 1+<1.1      |
        | ==1.*       | 1           |
        | >1          | 1.1+        |
        | <1          | <1          |
        | >=1         | 1+          |
        | <=1         | <1.1        |
        | ~=1.2       | 1.2+<2      |
        | ~=1.2.3     | 1.2.3+<1.3  |
        | !=1         | <1|1.1+     |
        | !=1.2       | <1.2|1.2.1+ |
        | !=1.*       | <1|2+       |
        | !=1.2.*     | <1.2|1.3+   |
  

Although the pip version requirements including negation via the not operator (!) can now be correctly converted to rez compatible version ranges, the actual ```VersionRange``` class does not natively support the not operator syntax so currently negated version ranges cannot be generated directly but need to first be converted to match the supported syntax.

This PR extends the syntax of the `VersionRange` class to fully support the not operator and create the same rez-compatible version ranges as described in the table above. This is done by extending the regex to detect the leading `!` in the [_VersionRangeParser](https://github.com/nerdvegas/rez/blob/master/src/rez/vendor/version/version.py#L547) class.

## Breakdown

* Add '!' syntax to rez version ranges

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tried negating a wide array of version ranges to hopefully cover all edge cases. The results are outlined below:

```
>>> VersionRange("!3.5.6")
VersionRange('<3.5.6|3.5.6_+')

>>> VersionRange("!==3.5.6")
VersionRange('<3.5.6|>3.5.6')

>>> VersionRange("!3.5.6..6.5.0")
VersionRange('<3.5.6|>6.5.0')

>>> VersionRange("!3.5.6+")
VersionRange('<3.5.6')

>>> VersionRange("!>3.5.6")
VersionRange('<=3.5.6')

>>> VersionRange("!>=3.5.6")
VersionRange('<3.5.6')

>>> VersionRange("!<3.5.6")
VersionRange('3.5.6+')

>>> VersionRange("!<=3.5.6")
VersionRange('>3.5.6')

>>> VersionRange("!3.5.6+<6.5.0")
VersionRange('<3.5.6|6.5.0+')
```

**Test Configuration**:
* Python version: 2.7.16
* OS: Linux, Windows 10
* Toolchain: rez 2.38.1, pip 19.1.1

## Demo

* Version range negation

![negative](https://user-images.githubusercontent.com/47409392/61672059-26ed6c80-ad25-11e9-9264-aa71fdc6e420.gif)

## Changelog

## Point release
[Source](https://github.com/nerdvegas/rez/tree/2.38.1) | [Diff]()

**Notes**

Add native not operator (!) support to the vendored VersionRange class. Version requirements
can now be negated without prior conversion.

**Merged pull requests:**

- [Feature] Add native not operator (!) support to version ranges [\#XXX](https://github.com/nerdvegas/rez/pull/670) ([lambdaclan](https://github.com/lambdaclan))

**Closed issues:**

- Schema - VersionRange does not support ! (not) operator [\#666](https://github.com/nerdvegas/rez/issues/666)


### Edit

I have detected what I believe to be an issue with descending order ranges (both normal and negated does not work) therefore I will try to add the fix to this PR.

```
>>> VersionRange("<=2.0.0,1.0.0+")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/packages/rez/2.38.1/platform-linux/arch-x86_64/os-Arch-rolling/rez/vendor/version/version.py", line 822, in __init__
    % (range_str, str(e)))
rez.vendor.version.util.VersionError: Syntax error in version range '<=2.0.0,1.0.0+': Syntax error in version range '<=2.0.0,1.0.0+'
>>> 
```
