### PR TITLE
Fix missing import in powershell plugin

### DIFF
--- a/src/rezplugins/shell/powershell.py
+++ b/src/rezplugins/shell/powershell.py
@@ -82,6 +82,8 @@ class PowerShell(Shell):
             whitespace = r"[\s]+"
             return whitespace.join(parts)
 
+        # TODO: Research if there is an easier way to pull system PATH from
+        # registry in powershell
         paths = []
 
         cmd = [
@@ -257,6 +259,8 @@ class PowerShell(Shell):
 
     def alias(self, key, value):
         value = EscapedString.disallow(value)
+        # TODO: Find a way to properly escape paths in alias() calls that also
+        # contain args
         cmd = "function {key}() {{ {value} $args }}"
         self._addline(cmd.format(key=key, value=value))
 

--- a/src/rezplugins/shell/powershell.py
+++ b/src/rezplugins/shell/powershell.py
@@ -97,8 +97,8 @@ class PowerShell(Shell):
         ])
 
         p = popen(cmd,
-                  stdout=subprocess.PIPE,
-                  stderr=subprocess.PIPE,
+                  stdout=PIPE,
+                  stderr=PIPE,
                   universal_newlines=True,
                   shell=True)
         out_, _ = p.communicate()
@@ -117,8 +117,8 @@ class PowerShell(Shell):
         ])
 
         p = popen(cmd,
-                  stdout=subprocess.PIPE,
-                  stderr=subprocess.PIPE,
+                  stdout=PIPE,
+                  stderr=PIPE,
                   universal_newlines=True,
                   shell=True)
         out_, _ = p.communicate()


### PR DESCRIPTION
A missing import slipped into the last MR. I do think that the powershell plugin needs some more work. Most notably i would like it to properly escape paths on alias() calls. But that is way less trivial than it sounds at first. I also plan adding a second plugin for poweshell6+. It will be separate because it actually has differing feature sets and it also has a different executable name (pwsh).

The only functional change is the added import on top. The rest is auto-formatting for pep8 in vscode.