### PR TITLE
Change _rez_fwd to _rez-fwd as the entry point was renamed in 2.38.0

### DIFF
--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -56,8 +56,8 @@ def create_executable_script(filepath, body, program=None):
     # clean up the files once the test has run.  Temporarily we don't bother
     # setting the permissions, but this will need to change.
     if os.name == "posix":
-    	os.chmod(filepath, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
-             | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.chmod(filepath, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+                 | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def create_forwarding_script(filepath, module, func_name, *nargs, **kwargs):
@@ -77,7 +77,7 @@ def create_forwarding_script(filepath, module, func_name, *nargs, **kwargs):
         doc["kwargs"] = kwargs
 
     body = dump_yaml(doc)
-    create_executable_script(filepath, body, "_rez_fwd")
+    create_executable_script(filepath, body, "_rez-fwd")
 
 
 def dedup(seq):


### PR DESCRIPTION
Fixes #671 

As the code prior to 2.38.0 already had a TODO to rename the executable i assume it was done on purpose. This fixes the reference in util.py to match the new name.