### PR TITLE
Add missing import subprocess

### DIFF
--- a/src/rezplugins/shell/powershell.py
+++ b/src/rezplugins/shell/powershell.py
@@ -9,6 +9,7 @@ from rez.backport.shutilwhich import which
 from functools import partial
 import os
 import re
+import subprocess
 
 try:
     basestring


### PR DESCRIPTION
resolving a powershell environment in windows would otherwise give me "NameError: global name 'subprocess' is not defined" (powershell.py line 108)