### PR TITLE
initial implementation of zsh shell plugin

### DIFF
--- a/src/rezplugins/shell/rezconfig
+++ b/src/rezplugins/shell/rezconfig
@@ -10,6 +10,9 @@ csh:
 tcsh:
     prompt: '>'
 
+zsh:
+    prompt: '%'
+
 cmd:
     prompt: '$G'
 

--- a/src/rezplugins/shell/zsh.py
+++ b/src/rezplugins/shell/zsh.py
@@ -1,0 +1,104 @@
+"""
+Zsh shell
+"""
+import os
+import os.path
+from rez.shells import Shell
+from rez.utils.platform_ import platform_
+from rezplugins.shell.sh import SH
+from rez import module_root_path
+
+
+class Zsh(SH):
+    rcfile_arg = '--rcs'
+    norc_arg = '--no-rcs'
+    _executable = None
+
+    @property
+    def executable(cls):
+        if cls._executable is None:
+            cls._executable = Shell.find_executable('zsh')
+        return cls._executable
+
+    @classmethod
+    def name(cls):
+        return 'zsh'
+
+    @classmethod
+    def startup_capabilities(cls, rcfile=False, norc=False, stdin=False,
+                             command=False):
+        if norc:
+            cls._overruled_option('rcfile', 'norc', rcfile)
+            rcfile = False
+        if command is not None:
+            cls._overruled_option('stdin', 'command', stdin)
+            cls._overruled_option('rcfile', 'command', rcfile)
+            stdin = False
+            rcfile = False
+        if stdin:
+            cls._overruled_option('rcfile', 'stdin', rcfile)
+            rcfile = False
+        return (rcfile, norc, stdin, command)
+
+    @classmethod
+    def get_startup_sequence(cls, rcfile, norc, stdin, command):
+        rcfile, norc, stdin, command = \
+            cls.startup_capabilities(rcfile, norc, stdin, command)
+
+        files = []
+        envvar = None
+        do_rcfile = False
+
+        if rcfile or norc:
+            do_rcfile = True
+            if rcfile and os.path.exists(os.path.expanduser(rcfile)):
+                files.append(rcfile)
+        else:
+            for file_ in (
+                    "~/.zprofile",
+                    "~/.zlogin",
+                    "~/.zshrc",
+                    "~/.zshenv"):
+                if os.path.exists(os.path.expanduser(file_)):
+                    files.append(file_)
+
+        bind_files = [
+            "~/.zprofile",
+            "~/.zshrc"
+        ]
+
+        return dict(
+            stdin=stdin,
+            command=command,
+            do_rcfile=do_rcfile,
+            envvar=envvar,
+            files=files,
+            bind_files=bind_files,
+            source_bind_files=True
+        )
+
+    def _bind_interactive_rez(self):
+        super(Zsh, self)._bind_interactive_rez()
+        completion = os.path.join(module_root_path, "completion", "complete.sh")
+        self.source(completion)
+
+
+def register_plugin():
+    if platform_.name != "windows":
+        return Zsh
+
+
+# Copyright 2013-2016 Allan Johns.
+#
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
This is an initial pass at a zsh shell plugin. It isn't thoroughly tested because I don't know enough about zsh to really validate it in production, but it worked enough in basic tests doing things like rez-env and rez-build that I feel it is a good starter implementation to be tested by more people and added to. (Really, it's basically the bash shell plugin and equivalent bash ops/flags replaced by zsh ops/flags.
No backwards compatibility broken, etc etc.
semver and changelog is left to @nerdvegas discretion depending on when and with what this gets merged in.
Addresses at least a portion of #649 