### PR TITLE
[FIX] Make package resolve request respect case sensitivity -- Windows

### DIFF
--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -15,7 +15,6 @@ from rez.vendor.version.requirement import VersionedObject
 from rez.serialise import FileFormat
 from rez.config import config
 import sys
-import os
 
 
 # ------------------------------------------------------------------------------
@@ -750,20 +749,11 @@ def get_latest_package_from_string(txt, paths=None, error=False):
 
 def _get_families(name, paths=None):
     entries = []
-    valid = False
     for path in (paths or config.packages_path):
-        if not os.path.isdir(path):
-            continue
-        else:
-            if name in os.listdir(path):
-                valid = True
-            else:
-                continue
-        if valid:
-            repo = package_repository_manager.get_repository(path)
-            family_resource = repo.get_package_family(name)
-            if family_resource:
-                entries.append((repo, family_resource))
+        repo = package_repository_manager.get_repository(path)
+        family_resource = repo.get_package_family(name)
+        if family_resource:
+            entries.append((repo, family_resource))
 
     return entries
 

--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -15,6 +15,7 @@ from rez.vendor.version.requirement import VersionedObject
 from rez.serialise import FileFormat
 from rez.config import config
 import sys
+import os
 
 
 # ------------------------------------------------------------------------------
@@ -749,11 +750,20 @@ def get_latest_package_from_string(txt, paths=None, error=False):
 
 def _get_families(name, paths=None):
     entries = []
+    valid = False
     for path in (paths or config.packages_path):
-        repo = package_repository_manager.get_repository(path)
-        family_resource = repo.get_package_family(name)
-        if family_resource:
-            entries.append((repo, family_resource))
+        if not os.path.isdir(path):
+            continue
+        else:
+            if name in os.listdir(path):
+                valid = True
+            else:
+                continue
+        if valid:
+            repo = package_repository_manager.get_repository(path)
+            family_resource = repo.get_package_family(name)
+            if family_resource:
+                entries.append((repo, family_resource))
 
     return entries
 

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -16,6 +16,7 @@ import shutil
 import os
 import re
 import stat
+import platform
 
 
 class TempDirs(object):
@@ -124,6 +125,23 @@ def retain_cwd():
     finally:
         os.chdir(cwd)
 
+def get_case_canonical_path(path):
+    """Get the packages path in the canonical case.
+
+    Paths on windows are case-insensitive therefore the filesystem package repo
+    filepath should be lower()ed on windows so that stuff like the unique repo identifier,
+    and the local path that gets stored into variant handles, doesn't differ.
+
+    Args:
+        path (str): Packages path to convert the case.
+
+    Returns:
+        str: The packages path in the canonical case form (always lowered).
+    """
+    if "Windows" in platform.system():
+        return path.lower()
+    else:
+        return path
 
 def get_existing_path(path, topmost_path=None):
     """Get the longest parent path in `path` that exists.

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -786,16 +786,10 @@ class FileSystemPackageRepository(PackageRepository):
 
     def _get_family(self, name):
         is_valid_package_name(name, raise_error=True)
-        if "Windows" in platform.system():
-            if os.path.isdir(self.location):
-                if name in os.listdir(self.location):
-                    family = self.get_resource(
-                        FileSystemPackageFamilyResource.key,
-                        location=self.location,
-                        name=name)
-                    return family
-            return None
-        elif os.path.isdir(os.path.join(self.location, name)):
+        if os.path.isdir(os.path.join(self.location, name)):
+            # force case-sensitive match on pkg family, on case-insensitive platforms
+            if "Windows" in platform.system() and name not in os.listdir(self.location):
+                return None
             family = self.get_resource(
                 FileSystemPackageFamilyResource.key,
                 location=self.location,


### PR DESCRIPTION
# Description

[Relates to issue #685]

## Windows file systems are not case sensitive

Unlike Linux and Unix file systems, Windows paths are not case sensitive this means that requests to resolve packages via `rez-env` using the wrong case will go through and resolve successfully. This can cause potential issues on other platforms where using the same name with a different case for a package is valid.

This is [not a Python issue](https://stackoverflow.com/questions/17277566/check-os-path-isfilefilename-with-case-sensitive-in-python) as the path check to the package directory returns True since Windows ignores case sensitivity in path names.

## Issue

The root of the issue occurs at [`src/rezplugins/package_repository/filesystem.py`](https://github.com/nerdvegas/rez/blob/master/src/rezplugins/package_repository/filesystem.py#L787)
where the following check takes place

```
 if os.path.isdir(os.path.join(self.location, name)):
```
with location being the packages directories and name the requested package - this on Windows regardless of the case the name is using will return True if the names match.

### Considered equal

```
rez-env 3dsmax-2018
rez-env 3DSmax-2018
rez-env 3dsMAX-2018
rez-env 3dSmAx-2018
```
The issue goes through multiple channels and can be intercepted in a few places for example
[`src/rez/resolved_context.py`](https://github.com/nerdvegas/rez/blob/master/src/rez/resolved_context.py#L197) where the request takes place

```
self._package_requests = []        
for req in package_requests: - # name can also be checked here for case-sensitivity            
    if isinstance(req, basestring):               
        req = PackageRequest(req)            
    self._package_requests.append(req)
```

### Windows - Case insensitive file system

![win_case_01](https://user-images.githubusercontent.com/47409392/62673287-d3dc1080-b9d8-11e9-877f-7c22ef37b8e6.png)

### Linux - Case sensitive file system

![win_case_02](https://user-images.githubusercontent.com/47409392/62673297-df2f3c00-b9d8-11e9-9399-6f0d66fadcf7.png)

## Solution

This PR solves the issue by ensuring that the requested package exists as a directory in the
any of the packages directories. This is achieved through the use of `os.listdir` **which does give you the directory contents with their actual cases**.

~~In an attempt to get the same error message as case-sensitive systems, the fix has been added to src/rez/packages.py file in the get (package) families function. Failure to detect the package during to wrong case will return zero entries resulting in the expected flow.~~

See https://github.com/nerdvegas/rez/pull/689#pullrequestreview-273995063

## Breakdown

* Add case sensitivity check to package requests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tried resolving a series of packages using different case. The results (before, after) are outlined below:

### Before

![2](https://user-images.githubusercontent.com/47409392/62677035-c24e3500-b9e7-11e9-93ab-5cac99c1516b.PNG)

### After

![1](https://user-images.githubusercontent.com/47409392/62674283-be68e580-b9dc-11e9-96a0-38043f4a8fd4.PNG)

**Test Configuration**:
* Python version: 2.7.16
* OS: Linux, Windows 10
* Toolchain: rez 2.40.1 ~~2.38.2 (#688)~~, pip 19.2.1

## Changelog

## Point release
[Source](https://github.com/nerdvegas/rez/tree/2.40.0) | [Diff](https://github.com/nerdvegas/rez/compare/master...lambdaclan:fix/rez-env-case-sensitive-windows)

**Notes**

Add case sensitivity check to prevent issues during package resolve for OSes with case insensitive file systems.

**Merged pull requests:**

- [FIX] Make package resolve request respect case sensitivity -- Windows [\#689](https://github.com/nerdvegas/rez/pull/689) ([lambdaclan](https://github.com/lambdaclan))

**Closed issues:**

- Wrong case requests lead to packages resolved twice with different versions [\#685](https://github.com/nerdvegas/rez/issues/685)