### PR TITLE
Reverse order for plugins loading

### DIFF
--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -106,7 +106,7 @@ class RezPluginType(object):
         # 'rezplugins/type_name' sub-directory).
         paths = [package.__path__] if isinstance(package.__path__, basestring) \
             else package.__path__
-        for path in paths:
+        for path in reversed(paths):
             for loader, modname, ispkg in pkgutil.walk_packages(
                     [path], package.__name__ + '.'):
                 if loader is not None:


### PR DESCRIPTION
This commit reverses the loading order of the plugins.
Custom plugins are loaded before builtins rez's plugins.

This allows you to override the plugins builtins by your
own plugins for add/remove features or debugging purposes).

[Relates to issue #677]