### PR TITLE
Fixing error with changelog referenced before assigment

### DIFF
--- a/src/rez/cli/release.py
+++ b/src/rez/cli/release.py
@@ -97,7 +97,7 @@ def command(opts, parser, extra_arg_groups=None):
             try:
                 changelog = builder.get_changelog()
             except:
-                pass
+                changelog = None
 
             if changelog:
                 txt += ("\n\n%s This is for reference only - this line and all "

--- a/src/rez/cli/release.py
+++ b/src/rez/cli/release.py
@@ -96,7 +96,8 @@ def command(opts, parser, extra_arg_groups=None):
             # get stripped out again before being added as package release notes.
             try:
                 changelog = builder.get_changelog()
-            except:
+            except Exception as e:
+                print(e)
                 changelog = None
 
             if changelog:


### PR DESCRIPTION
In some cases when `builder.get_changelog()` throw, I experience following error from `rez-release`:
```
UnboundedLocalError: local variable 'changelog' referenced before assignment
```

I believe this happens because when exception is thrown, then `changelog` variable does not exist and if statement fails.

I believe this fix would let if statement proceed with no effect.