### PR TITLE
.next() to next()

### DIFF
--- a/src/rez/build_system.py
+++ b/src/rez/build_system.py
@@ -81,7 +81,7 @@ def create_build_system(working_dir, buildsys_type=None, package=None, opts=None
             raise BuildSystemError(("Source could be built with one of: %s; "
                                    "Please specify a build system") % s)
 
-        buildsys_type = iter(clss).next().name()
+        buildsys_type = next(iter(clss)).name()
 
     # create instance of build system
     cls_ = plugin_manager.get_plugin_class('build_system', buildsys_type)

--- a/src/rez/package_maker__.py
+++ b/src/rez/package_maker__.py
@@ -118,7 +118,7 @@ class PackageMaker(AttrDictWrapper):
         # retrieve the package from the new repository
         family_resource = repo.get_package_family(self.name)
         it = repo.iter_packages(family_resource)
-        package_resource = it.next()
+        package_resource = next(it)
 
         package = self.package_cls(package_resource)
 

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -119,7 +119,7 @@ class PerFamilyOrder(PackageOrder):
 
     def reorder(self, iterable, key=None):
         try:
-            item = iter(iterable).next()
+            item = next(iter(iterable))
         except:
             return None
 

--- a/src/rez/package_py_utils.py
+++ b/src/rez/package_py_utils.py
@@ -113,8 +113,8 @@ def expand_requirement(request, paths=None):
         # to detect this case and remap the uid-ified wildcard back here too.
         #
         for v, expanded_v in expanded_versions.iteritems():
-            if version == v.next():
-                return expanded_v.next()
+            if version == next(v):
+                return next(expanded_v)
 
         version_ = expand_version(version)
         if version_ is None:

--- a/src/rez/package_search.py
+++ b/src/rez/package_search.py
@@ -85,7 +85,7 @@ def get_reverse_dependency_tree(package_name, depth=None, paths=None,
             if not req.conflict:
                 lookup[req.name].add(package_name_)
 
-        bar.next()
+        next(bar)
 
     bar.finish()
 
@@ -142,7 +142,7 @@ def get_plugins(package_name, paths=None):
 
     plugin_pkgs = []
     for package_name_ in package_names:
-        bar.next()
+        next(bar)
         if package_name_ == package_name:
             continue  # not a plugin of itself
 

--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -537,7 +537,7 @@ def get_package(name, version, paths=None):
 
     it = iter_packages(name, range_, paths)
     try:
-        return it.next()
+        return next(it)
     except StopIteration:
         return None
 
@@ -687,7 +687,7 @@ def get_completions(prefix, paths=None, family_only=False):
         words = set(x.name for x in iter_package_families(paths=paths)
                     if x.name.startswith(prefix))
         if len(words) == 1:
-            fam = iter(words).next()
+            fam = next(iter(words))
 
     if family_only:
         return words

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -489,7 +489,7 @@ class ResolvedContext(object):
                 if variant.name not in overrides:
                     if len(variant.version) >= rank:
                         version = variant.version.trim(rank - 1)
-                        version = version.next()
+                        version = next(version)
                         req = "~%s<%s" % (variant.name, str(version))
                         rank_limiters.append(req)
             request += rank_limiters

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -626,7 +626,7 @@ class Python(ActionInterpreter):
 
         if hasattr(value, '__iter__'):
             it = iter(value)
-            cmd = EscapedString.disallow(it.next())
+            cmd = EscapedString.disallow(next(it))
             value = [cmd] + [self.escape_string(x) for x in it]
         else:
             value = EscapedString.disallow(value)
@@ -823,7 +823,7 @@ class EscapedString(object):
             return EscapedString('')
 
         it = iter(values)
-        result = EscapedString.promote(it.next())
+        result = EscapedString.promote(next(it))
 
         for value in it:
             result = result + sep
@@ -888,7 +888,7 @@ class NamespaceFormatter(Formatter):
 
     def format(self, format_string, *args, **kwargs):
         def escape_envvar(matchobj):
-            value = (x for x in matchobj.groups() if x is not None).next()
+            value = next((x for x in matchobj.groups() if x is not None))
             return "${{%s}}" % value
 
         format_string_ = re.sub(self.ENV_VAR_REGEX, escape_envvar, format_string)

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -381,7 +381,7 @@ class UnixShell(Shell):
     def command(self, value):
         if hasattr(value, '__iter__'):
             it = iter(value)
-            cmd = EscapedString.disallow(it.next())
+            cmd = EscapedString.disallow(next(it))
             args_str = ' '.join(self.escape_string(x) for x in it)
             value = "%s %s" % (cmd, args_str)
         else:

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -761,7 +761,7 @@ class _PackageVariantSlice(_Common):
             if self.pr:
                 if common_fams:
                     if len(common_fams) == 1:
-                        reason_str = iter(common_fams).next()
+                        reason_str = next(iter(common_fams))
                     else:
                         reason_str = ", ".join(common_fams)
                 else:

--- a/src/rez/status.py
+++ b/src/rez/status.py
@@ -240,7 +240,7 @@ class Status(object):
                     msg = "Packages (in conflict): %s" % vars_str
                     _pr(msg, critical)
                 else:
-                    variant = iter(variants).next()
+                    variant = next(iter(variants))
                     _pr("Package:  %s" % variant.qualified_package_name)
                 return True
 

--- a/src/rez/suite.py
+++ b/src/rez/suite.py
@@ -584,7 +584,7 @@ class Suite(object):
                 if verbose:
                     package = ", ".join(x.qualified_package_name for x in variant)
                 else:
-                    v = iter(variant).next()
+                    v = next(iter(variant))
                     package = "%s (+%d more)" % (v.qualified_package_name,
                                                  len(variant) - 1)
             else:

--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -124,7 +124,7 @@ class System(object):
             elif (shell not in shells) and ("bash" in shells):
                 shell = "bash"  # failed detection, fall back on 'bash'
             elif shell not in shells:
-                shell = iter(shells).next()  # give up - just choose a shell
+                shell = next(iter(shells))  # give up - just choose a shell
 
             # sh has to be handled as a special case
             if shell == "sh":
@@ -146,7 +146,7 @@ class System(object):
                             if "bash" in shells:
                                 shell = "bash"  # fall back on bash
                             else:
-                                shell = iter(shells).next()  # give up - just choose a shell
+                                shell = next(iter(shells))  # give up - just choose a shell
 
             # TODO: remove this when/if dash support added
             if shell == "dash":

--- a/src/rez/tests/test_copy_package.py
+++ b/src/rez/tests/test_copy_package.py
@@ -114,7 +114,7 @@ class TestCopyPackage(TestBase, TempdirMixin):
         # check the copied package exists and matches
         dest_pkg = self._get_dest_pkg("floob", "1.2.0")
         result_variant = result["copied"][0][1]
-        dest_variant = dest_pkg.iter_variants().next()
+        dest_variant = next(dest_pkg.iter_variants())
         self.assertEqual(dest_variant.handle, result_variant.handle)
 
         pyfile = os.path.join(dest_pkg.base, "python")
@@ -237,7 +237,7 @@ class TestCopyPackage(TestBase, TempdirMixin):
         # check copied variant is the one we expect
         dest_pkg = self._get_dest_pkg("flaab", "5.4.1")
         result_variant = result["copied"][0][1]
-        dest_variant = dest_pkg.iter_variants().next()
+        dest_variant = next(dest_pkg.iter_variants())
         self.assertEqual(dest_variant.handle, result_variant.handle)
 
     def test_5(self):
@@ -312,7 +312,7 @@ class TestCopyPackage(TestBase, TempdirMixin):
         )
 
         dest_pkg = self._get_dest_pkg("foo", "1.1.0")
-        dest_variant = dest_pkg.iter_variants().next()
+        dest_variant = next(dest_pkg.iter_variants())
 
         # do a resolve
         ctxt = ResolvedContext(

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -348,14 +348,14 @@ class TestPackages(TestBase, TempdirMixin):
             package = get_developer_package(path)
 
             # install variants of the developer package into new repo
-            variant = package.iter_variants().next()
+            variant = next(package.iter_variants())
             result = variant.install(repo_path, dry_run=True)
             self.assertEqual(result, None)
 
             for variant in package.iter_variants():
                 variant.install(repo_path)
 
-            variant = package.iter_variants().next()
+            variant = next(package.iter_variants())
             result = variant.install(repo_path, dry_run=True)
             self.assertNotEqual(result, None)
 
@@ -371,7 +371,7 @@ class TestPackages(TestBase, TempdirMixin):
 
             # install a variant again. Even though the variant is already installed,
             # this should update the package, because data outside the variant changed.
-            variant = package.iter_variants().next()
+            variant = next(package.iter_variants())
             result = variant.install(repo_path, dry_run=True)
             self.assertEqual(result, None)
             variant.install(repo_path)
@@ -477,7 +477,7 @@ class TestMemoryPackages(TestBase):
         desc = 'the foo package'
         package = create_package('foo', {'description': desc})
         self.assertEqual(package.description, desc)
-        variant = package.iter_variants().next()
+        variant = next(package.iter_variants())
         parent_package = variant.parent
         self.assertEqual(package.description, desc)
 

--- a/src/rez/wrapper.py
+++ b/src/rez/wrapper.py
@@ -216,7 +216,7 @@ class Wrapper(object):
             if len(variants) > 1:
                 self._print_conflicting(variants)
             else:
-                variant = iter(variants).next()
+                variant = next(iter(variants))
                 print("Package:  %s" % variant.qualified_package_name)
         return 0
 
@@ -230,7 +230,7 @@ class Wrapper(object):
                 return 1
             else:
                 from rez.packages_ import iter_packages
-                variant = iter(variants).next()
+                variant = next(iter(variants))
                 it = iter_packages(name=variant.name)
                 rows = []
                 colors = []

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -979,7 +979,7 @@ class FileSystemPackageRepository(PackageRepository):
         if existing_package:
             if variant.index is None:
                 existing_installed_variant = \
-                    self.iter_variants(existing_package).next()
+                    next(self.iter_variants(existing_package))
             else:
                 variant_requires = variant.variant_requires
 


### PR DESCRIPTION
consequence of:
https://www.python.org/dev/peps/pep-3114/
`next()` calls the `__next__()` method that `.next()` was moved to, so is the py2/py3 compatible route to use.