### PR TITLE
replace async with block to avoid py3 async keyword

### DIFF
--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1520,7 +1520,7 @@ class ResolvedContext(object):
             amqp_settings=config.context_tracking_amqp,
             routing_key=routing_key,
             data=data,
-            async=True
+            block=False
         )
 
     @classmethod

--- a/src/rez/utils/amqp.py
+++ b/src/rez/utils/amqp.py
@@ -16,7 +16,7 @@ _thread = None
 _num_pending = 0
 
 
-def publish_message(host, amqp_settings, routing_key, data, async=False):
+def publish_message(host, amqp_settings, routing_key, data, block=True):
     """Publish an AMQP message.
 
     Returns:
@@ -32,7 +32,7 @@ def publish_message(host, amqp_settings, routing_key, data, async=False):
         "data": data
     }
 
-    if not async:
+    if block:
         return _publish_message(**kwargs)
 
     if _thread is None:


### PR DESCRIPTION
async is a py3 keyword, so we must use something else instead. block seems appropriate.