### PR TITLE
import StringIO from six.moves

### DIFF
--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -3,7 +3,6 @@ Read and write data from file. File caching via a memcached server is supported.
 """
 from contextlib import contextmanager
 from inspect import isfunction, ismodule, getargspec
-from StringIO import StringIO
 import sys
 import stat
 import os
@@ -21,6 +20,7 @@ from rez.utils.system import add_sys_paths
 from rez.config import config
 from rez.vendor.atomicwrites import atomic_write
 from rez.vendor.enum import Enum
+from rez.vendor.six.six.moves import StringIO
 from rez.vendor import yaml
 
 

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -211,7 +211,7 @@ def get_cli_output(args):
     """
 
     import sys
-    from StringIO import StringIO
+    from rez.vendor.six.six.moves import StringIO
 
     command = args[0]
     other_args = list(args[1:])


### PR DESCRIPTION
StringIO has some py2 / py3 peculiarities which six alleviates.