### PR TITLE
swap between getargspec and getfullargspec due to getargspec deprecation

### DIFF
--- a/src/rez/cli/_bez.py
+++ b/src/rez/cli/_bez.py
@@ -55,9 +55,13 @@ def run():
                   targets=%(targets)s,
                   build_args=%(build_args)s)
 
-    import inspect
-    args = inspect.getargspec(buildfunc).args
-    kwargs = dict((k, v) for k, v in kwargs.iteritems() if k in args)
+    try:
+        from inspect import getfullargspec as getargspec
+    except ImportError:
+        from inspect import getargspec
+        pass
+    args = getargspec(buildfunc).args
+    kwargs = {k: v for k, v in kwargs.items() if k in args}
 
     buildfunc(**kwargs)
 

--- a/src/rez/cli/forward.py
+++ b/src/rez/cli/forward.py
@@ -18,8 +18,11 @@ def command(opts, parser, extra_arg_groups=None):
     from rez.exceptions import RezSystemError
     from rez.vendor import yaml
     from rez.vendor.yaml.error import YAMLError
-    import inspect
     import os.path
+    if six.PY2:
+        from inspect import getargspec
+    else:
+        from inspect import getfullargspec as getargspec
 
     # we don't usually want warnings printed in a wrapped tool. But in cases
     # where we do (for debugging) we leave a backdoor - setting $REZ_QUIET=0
@@ -57,7 +60,7 @@ def command(opts, parser, extra_arg_groups=None):
         module = plugin_manager.get_plugin_module(plugin_type, plugin_name)
 
     target_func = getattr(module, func_name)
-    func_args = inspect.getargspec(target_func).args
+    func_args = getargspec(target_func).args
     if "_script" in func_args:
         kwargs["_script"] = yaml_file
     if "_cli_args" in func_args:

--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -2,7 +2,7 @@
 Read and write data from file. File caching via a memcached server is supported.
 """
 from contextlib import contextmanager
-from inspect import isfunction, ismodule, getargspec
+from inspect import isfunction, ismodule
 import sys
 import stat
 import os
@@ -20,9 +20,14 @@ from rez.utils.system import add_sys_paths
 from rez.config import config
 from rez.vendor.atomicwrites import atomic_write
 from rez.vendor.enum import Enum
+from rez.vendor.six import six
 from rez.vendor.six.six.moves import StringIO
 from rez.vendor import yaml
 
+if six.PY2:
+    from inspect import getargspec
+else:
+    from inspect import getfullargspec as getargspec
 
 tmpdir_manager = TempDirs(config.tmpdir, prefix="rez_write_")
 debug_print = config.debug_printer("file_loads")

--- a/src/rez/utils/memcached.py
+++ b/src/rez/utils/memcached.py
@@ -5,10 +5,15 @@ from rez.vendor.memcache.memcache import Client as Client_, SERVER_MAX_KEY_LENGT
 from threading import local
 from contextlib import contextmanager
 from functools import update_wrapper
-from inspect import getargspec, isgeneratorfunction
+from inspect import isgeneratorfunction
 from hashlib import md5
 from uuid import uuid4
 from rez.vendor.six import six
+
+if six.PY2:
+    from inspect import getargspec
+else:
+    from inspect import getfullargspec as getargspec
 
 basestring = six.string_types[0]
 


### PR DESCRIPTION
this is arguably the most dangerous change we need to make for py3 compatibility, and I'm not altogether sure what the consequences are, we could use some very careful review of this set of changes.