### PR TITLE
address py3.8 deprecation of collections direct ABC access

### DIFF
--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -180,8 +180,13 @@ def _atexit():
 def is_non_string_iterable(arg):
     """Python 2 and 3 compatible non-string iterable identifier"""
 
+    if six.PY2:
+        iterable_class = collections.Iterable
+    else:
+        iterable_class = collections.abc.Iterable
+
     return (
-        isinstance(arg, collections.Iterable)
+        isinstance(arg, iterable_class)
         and not isinstance(arg, six.string_types)
     )
 


### PR DESCRIPTION
"Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working"