### PR TITLE
py3 finalizations

### DIFF
--- a/src/rez/bind/rez.py
+++ b/src/rez/bind/rez.py
@@ -31,7 +31,7 @@ def bind(path, version_range=None, opts=None, parser=None):
     with make_package("rez", path, make_root=make_root) as pkg:
         pkg.version = version
         pkg.commands = commands
-        pkg.requires = ["python-2.6+<3"]
+        pkg.requires = ["python-2.7+<4"]
         pkg.variants = [system.variant]
 
     return pkg.installed_variants

--- a/src/rez/package_filter.py
+++ b/src/rez/package_filter.py
@@ -69,7 +69,7 @@ class PackageFilterBase(object):
 
     @property
     def sha1(self):
-        return sha1(str(self)).hexdigest()
+        return sha1(str(self).encode("utf-8")).hexdigest()
 
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, str(self))

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -124,7 +124,7 @@ class TestBuild(TestBase, TempdirMixin):
         proc = context.execute_command(['test_ghetto'], stdout=PIPE)
         stdout = proc.communicate()[0]
         self.assertEqual('sup dogg - how is dis shizzle doin today?',
-                         stdout.strip())
+                         stdout.decode("utf-8").strip())
 
     @shell_dependent()
     @install_dependent
@@ -170,7 +170,7 @@ class TestBuild(TestBase, TempdirMixin):
 
         proc = context.execute_command(['hai'], stdout=PIPE)
         stdout = proc.communicate()[0]
-        self.assertEqual('Oh hai!', stdout.strip())
+        self.assertEqual('Oh hai!', stdout.decode("utf-8").strip())
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -59,7 +59,7 @@ class TestContext(TestBase, TempdirMixin):
         r = ResolvedContext(["hello_world"])
         p = r.execute_command(["hello_world"], stdout=subprocess.PIPE)
         stdout, _ = p.communicate()
-        stdout = stdout.strip()
+        stdout = stdout.decode("utf-8").strip()
         self.assertEqual(stdout, "Hello Rez World!")
 
     def test_execute_command_environ(self):
@@ -77,7 +77,7 @@ class TestContext(TestBase, TempdirMixin):
                               stdout=subprocess.PIPE)
         stdout, _ = p.communicate()
         stdout = stdout.strip()
-        parts = [x.strip() for x in stdout.split('\n')]
+        parts = [x.strip() for x in stdout.decode("utf-8").split('\n')]
 
         self.assertEqual(parts, ["covfefe", "hello"])
 

--- a/src/rez/tests/test_formatter.py
+++ b/src/rez/tests/test_formatter.py
@@ -4,6 +4,7 @@ test rex string formatting
 import unittest
 from rez.tests.util import TestBase
 from rez.rex import NamespaceFormatter
+from rez.vendor.six import six
 import sys
 
 
@@ -49,34 +50,34 @@ class TestFormatter(TestBase):
         self.assert_formatter_equal("The year is {0.year}", "The year is 2007", d)
 
         # classes we'll use for testing
-        class C:
+        class C(object):
             def __init__(self, x=100):
                 self._x = x
             def __format__(self, spec):
                 return spec
 
-        class D:
+        class D(object):
             def __init__(self, x):
                 self.x = x
             def __format__(self, spec):
                 return str(self.x)
 
         # class with __str__, but no __format__
-        class E:
+        class E(object):
             def __init__(self, x):
                 self.x = x
             def __str__(self):
                 return 'E(' + self.x + ')'
 
         # class with __repr__, but no __format__ or __str__
-        class F:
+        class F(object):
             def __init__(self, x):
                 self.x = x
             def __repr__(self):
                 return 'F(' + self.x + ')'
 
         # class with __format__ that forwards to string, for some format_spec's
-        class G:
+        class G(object):
             def __init__(self, x):
                 self.x = x
             def __str__(self):
@@ -87,7 +88,7 @@ class TestFormatter(TestBase):
                 return object.__format__(self, format_spec)
 
         # class that returns a bad type from __format__
-        class H:
+        class H(object):
             def __format__(self, format_spec):
                 return 1.0
 
@@ -176,11 +177,15 @@ class TestFormatter(TestBase):
         self.assert_formatter_equal('{0}', '{}', {})
         self.assert_formatter_equal('{0}', '[]', [])
         self.assert_formatter_equal('{0}', '[1]', [1])
-        self.assert_formatter_equal('{0}', 'E(data)', E('data'))
-        self.assert_formatter_equal('{0:^10}', ' E(data)  ', E('data'))
-        self.assert_formatter_equal('{0:^10s}', ' E(data)  ', E('data'))
+
+        if six.PY2:
+            # Classes without __format__ are not supported in Python 3
+            self.assert_formatter_equal('{0}', 'E(data)', E('data'))
+            self.assert_formatter_equal('{0:^10}', ' E(data)  ', E('data'))
+            self.assert_formatter_equal('{0:^10s}', ' E(data)  ', E('data'))
+            self.assert_formatter_equal('{0:>15s}', ' string is data', G('data'))
+
         self.assert_formatter_equal('{0:d}', 'G(data)', G('data'))
-        self.assert_formatter_equal('{0:>15s}', ' string is data', G('data'))
         self.assert_formatter_equal('{0!s}', 'string is data', G('data'))
 
         self.assert_formatter_equal("{0:date: %Y-%m-%d}", "date: 2007-08-27",
@@ -215,11 +220,16 @@ class TestFormatter(TestBase):
         self.assert_formatter_raises("}{", ValueError)
         self.assert_formatter_raises("{", ValueError)
         self.assert_formatter_raises("}", ValueError)
-        self.assert_formatter_raises("abc{0:{}", ValueError)
+        self.assert_formatter_raises(r"abc{0:{}", ValueError)
         self.assert_formatter_raises("{0", ValueError)
         self.assert_formatter_raises("{0.}", IndexError)
         self.assert_formatter_raises("{0.}", ValueError, 0)
-        self.assert_formatter_raises("{0[}", IndexError)
+
+        if six.PY2:
+            self.assert_formatter_raises("{0[}", IndexError)
+        else:
+            self.assert_formatter_raises("{0[}", ValueError)
+
         self.assert_formatter_raises("{0[}", ValueError, [])
         self.assert_formatter_raises("{0]}", KeyError)
         self.assert_formatter_raises("{0.[]}", ValueError, 0)
@@ -238,9 +248,14 @@ class TestFormatter(TestBase):
         # in python 2.7 onwards, string.Formatter raises KeyError here, rather
         # than ValueError. In rex we keep this as ValueError (the change is due
         # to implicit positional arguments, not applicable in rex).
-        self.assert_formatter_raises("{:}", ValueError)
-        self.assert_formatter_raises("{:s}", ValueError)
-        self.assert_formatter_raises("{}", ValueError)
+        if six.PY2:
+            self.assert_formatter_raises("{:}", ValueError)
+            self.assert_formatter_raises("{:s}", ValueError)
+            self.assert_formatter_raises("{}", ValueError)
+        else:
+            self.assert_formatter_raises("{:}", IndexError)
+            self.assert_formatter_raises("{:s}", IndexError)
+            self.assert_formatter_raises("{}", IndexError)
 
         # issue 6089
         self.assert_formatter_raises("{0[0]x}", ValueError, [None])

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -65,7 +65,7 @@ class TestShells(TestBase, TempdirMixin):
                                 stdout=subprocess.PIPE)
 
             self.assertEqual(
-                _stdout(p), '',
+                _stdout(p).decode("utf-8"), '',
                 "This test and others will fail, because one or more of your "
                 "startup scripts are printing to stdout. Please remove the "
                 "printout and try again.")
@@ -83,7 +83,7 @@ class TestShells(TestBase, TempdirMixin):
             r = self._create_context(["hello_world"])
             p = r.execute_shell(command="hello_world",
                                 stdout=subprocess.PIPE)
-            self.assertEqual(_stdout(p), "Hello Rez World!")
+            self.assertEqual(_stdout(p).decode("utf-8"), "Hello Rez World!")
 
     @shell_dependent(exclude=["cmd"])
     def test_command_returncode(self):
@@ -113,7 +113,7 @@ class TestShells(TestBase, TempdirMixin):
             p = r.execute_shell(norc=True,
                                 command="hello_world",
                                 stdout=subprocess.PIPE)
-            self.assertEqual(_stdout(p), "Hello Rez World!")
+            self.assertEqual(_stdout(p).decode("utf-8"), "Hello Rez World!")
 
     @shell_dependent()
     def test_stdin(self):
@@ -143,7 +143,7 @@ class TestShells(TestBase, TempdirMixin):
             p = r.execute_shell(rcfile=path,
                                 command="hello_world -q",
                                 stdout=subprocess.PIPE)
-            self.assertEqual(_stdout(p), "Hello Rez World!")
+            self.assertEqual(_stdout(p).decode("utf-8"), "Hello Rez World!")
             os.remove(path)
 
     @shell_dependent(exclude=["cmd"])
@@ -159,7 +159,7 @@ class TestShells(TestBase, TempdirMixin):
         cmd = [os.path.join(system.rez_bin_path, "rez-env"), "--", "echo", "hey"]
         process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         sh_out, _ = process.communicate()
-        out = str(sh_out).strip()
+        out = str(sh_out.decode("utf-8")).strip()
         self.assertEqual(out, "hey")
 
     @shell_dependent()
@@ -191,7 +191,7 @@ class TestShells(TestBase, TempdirMixin):
             out, _ = p.communicate()
             self.assertEqual(p.returncode, 0)
             token = '\r\n' if platform_.name == 'windows' else '\n'
-            output = out.strip().split(token)
+            output = out.decode("utf-8").strip().split(token)
             self.assertEqual(output, expected_output)
 
         def _rex_assigning():

--- a/src/rez/utils/memcached.py
+++ b/src/rez/utils/memcached.py
@@ -167,7 +167,7 @@ class Client(object):
 
     @classmethod
     def _key_hash(cls, key):
-        return md5(key).hexdigest()
+        return md5(key.encode("utf-8")).hexdigest()
 
     @classmethod
     def _debug_key_hash(cls, key):

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -201,7 +201,7 @@ class LinuxPlatform(_UnixPlatform):
         def _parse(txt, distributor_key, release_key):
             distributor_ = None
             release_ = None
-            lines = txt.strip().split('\n')
+            lines = txt.decode("utf-8").strip().split('\n')
             for line in lines:
                 if line.startswith(distributor_key):
                     s = line[len(distributor_key):].strip()

--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -50,7 +50,7 @@ class SH(UnixShell):
         if p.returncode:
             paths = []
         else:
-            lines = out_.split('\n')
+            lines = out_.decode("utf-8").split('\n')
             line = [x for x in lines if "__PATHS_" in x.split()][0]
             paths = line.strip().split()[-1].split(os.pathsep)
 


### PR DESCRIPTION
save this PR for last as it contains a rez-bind update to the package range and modifies specific tests to pass under py3 conditions as well as python text encoding changes which should be well-tested.