### PR TITLE
Fix py3 errors and warnings

### DIFF
--- a/src/rez/cli/_bez.py
+++ b/src/rez/cli/_bez.py
@@ -64,7 +64,7 @@ def run():
     else:
         args = inspect.getargspec(buildfunc).args
 
-    kwargs = dict((k, v) for k, v in kwargs.iteritems() if k in args)
+    kwargs = dict((k, v) for k, v in kwargs.items() if k in args)
 
     buildfunc(**kwargs)
 

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -987,6 +987,16 @@ class EnvironmentDict(DictMixin):
     def __contains__(self, key):
         return (key in self._var_cache)
 
+    def __delitem__(self, key):
+        del self._var_cache[key]
+
+    def __iter__(self):
+        for key in self._var_cache.keys():
+            yield key
+
+    def __len__(self):
+        return len(self._var_cache)
+
 
 class EnvironmentVariable(object):
     '''

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -27,7 +27,7 @@ basestring = six.string_types[0]
 if six.PY2:
     from UserDict import DictMixin
 else:
-    from collections import MutableMapping as DictMixin
+    from collections.abc import MutableMapping as DictMixin
 
 
 #===============================================================================

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Rez configuration settings. Do not change this file.
 
 Settings are determined in the following way (higher number means higher

--- a/src/rez/utils/data_utils.py
+++ b/src/rez/utils/data_utils.py
@@ -3,9 +3,13 @@ Utilities related to managing data types.
 """
 from rez.vendor.schema.schema import Schema, Optional
 from rez.exceptions import RexError
-from collections import MutableMapping
 from threading import Lock
 from rez.vendor.six import six
+
+if six.PY2:
+    from collections import MutableMapping
+else:
+    from collections.abc import MutableMapping
 
 
 basestring = six.string_types[0]

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -201,7 +201,7 @@ class LinuxPlatform(_UnixPlatform):
         def _parse(txt, distributor_key, release_key):
             distributor_ = None
             release_ = None
-            lines = txt.decode("utf-8").strip().split('\n')
+            lines = txt.strip().split('\n')
             for line in lines:
                 if line.startswith(distributor_key):
                     s = line[len(distributor_key):].strip()

--- a/src/rez/utils/sourcecode.py
+++ b/src/rez/utils/sourcecode.py
@@ -1,12 +1,22 @@
 from rez.utils.formatting import indent
 from rez.utils.data_utils import cached_property
 from rez.utils.logging_ import print_debug
+from rez.vendor.six import six
 from inspect import getsourcelines
 from textwrap import dedent
 from glob import glob
 import traceback
 import os.path
-import imp
+
+
+if six.PY2:
+    import imp
+    def load_source(name, path, fileHandle):
+        return imp.load_source('mod', path, fileHandle)
+else:
+    from importlib.machinery import SourceFileLoader
+    def load_source(name, path, fileHandle):
+        return SourceFileLoader('mod', path).load_module()
 
 
 def early():
@@ -336,7 +346,7 @@ class IncludeModuleManager(object):
             print_debug("Loading include sourcefile: %s" % filepath)
 
         with open(filepath) as f:
-            module = imp.load_source(name, filepath, f)
+            module = load_source(name, filepath, f)
 
         self.modules[hash_str] = module
         return module


### PR DESCRIPTION
This is a batch of commits that fixes errors and warnings that we have in the master branch. Each commit contains a unique change.

- There was an error with bez with python 3 due to the usage of iteritems.
- Importing `collections.MutableMapping` is deprecated and it will stop to work in Python 3.8. The import needs to be `collections.abc.MutableMapping` instead.
- When subclassing `MutableMapping` in python 3, we need to re-implement the abstract methods `__delitem__`, `__iter__` and `__len__`.
- Fixed a deprecation warning inside `rezconfig.py` that was to do with a `\` in the docstring.
- Fixed a crqash in `platform_` due to the method `decode` that doesn't exit on type `str` in python 3.
- Module `imp` is deprecated in Python 3. So I changed it to use `importlib` when in python 3.

I ran the tests under Linux with python 2.7, 3.4, 3.5, 3.6 and 3.7. If someone could confirm that everything is working in Windows, that would be great.

The only change I'm not sure of is the `decode`. No comments was made in the commit that introduced it to explain why it was needed.

Once that is merged, I'll do a pass at updating the vendored libs that cause other warnings.