### PR TITLE
use subprocess in 'text' mode in most cases

### DIFF
--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -132,7 +132,8 @@ def _run_command(args):
         args,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        shell=use_shell
+        shell=use_shell,
+        text=True
     )
 
     stdout, stderr = p.communicate()

--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -132,8 +132,7 @@ def _run_command(args):
         args,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        shell=use_shell,
-        universal_newlines=True
+        shell=use_shell
     )
 
     stdout, stderr = p.communicate()

--- a/src/rez/package_py_utils.py
+++ b/src/rez/package_py_utils.py
@@ -169,7 +169,7 @@ def exec_command(attr, cmd):
     """
     import subprocess
 
-    p = popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     out, err = p.communicate()
 
     if p.returncode:
@@ -197,7 +197,7 @@ def exec_python(attr, src, executable="python"):
         src = [src]
 
     p = popen([executable, "-c", "; ".join(src)],
-              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+              stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     out, err = p.communicate()
 
     if p.returncode:
@@ -237,7 +237,7 @@ def find_site_python(module_name, paths=None):
     py_cmd = 'import {x}; print({x}.__path__)'.format(x=module_name)
 
     p = popen(["python", "-c", py_cmd], stdout=subprocess.PIPE,
-               stderr=subprocess.PIPE)
+               stderr=subprocess.PIPE, text=True)
     out, err = p.communicate()
 
     if p.returncode:

--- a/src/rez/release_vcs.py
+++ b/src/rez/release_vcs.py
@@ -208,7 +208,7 @@ class ReleaseVCS(object):
             print_debug("Running command: %s" % cmd_str)
 
         p = popen(nargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                  cwd=self.pkg_root)
+                  cwd=self.pkg_root, text=True)
         out, err = p.communicate()
 
         if p.returncode:

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1092,7 +1092,7 @@ class ResolvedContext(object):
         return path
 
     @_on_success
-    def execute_command(self, args, parent_environ=None, **subprocess_kwargs):
+    def execute_command(self, args, parent_environ=None, **Popen_args):
         """Run a command within a resolved context.
 
         This applies the context to a python environ dict, then runs a
@@ -1109,7 +1109,7 @@ class ResolvedContext(object):
             args: Command arguments, can be a string.
             parent_environ: Environment to interpret the context within,
                 defaults to os.environ if None.
-            subprocess_kwargs: Args to pass to subprocess.Popen.
+            Popen_args: Args to pass to subprocess.Popen.
 
         Returns:
             A subprocess.Popen object.
@@ -1126,7 +1126,7 @@ class ResolvedContext(object):
 
         executor = self._create_executor(interpreter, parent_environ)
         self._execute(executor)
-        return interpreter.subprocess(args, **subprocess_kwargs)
+        return interpreter.subprocess(args, **Popen_args)
 
     @_on_success
     def execute_rex_code(self, code, filename=None, shell=None,

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -121,10 +121,10 @@ class TestBuild(TestBase, TempdirMixin):
         from subprocess import PIPE
         self._test_build("sup_world", "3.8")
         context = self._create_context("sup_world==3.8")
-        proc = context.execute_command(['test_ghetto'], stdout=PIPE)
+        proc = context.execute_command(['test_ghetto'], stdout=PIPE, text=True)
         stdout = proc.communicate()[0]
         self.assertEqual('sup dogg - how is dis shizzle doin today?',
-                         stdout.decode("utf-8").strip())
+                         stdout.strip())
 
     @per_available_shell()
     @install_dependent()

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -58,9 +58,9 @@ class TestContext(TestBase, TempdirMixin):
                           " executable.")
 
         r = ResolvedContext(["hello_world"])
-        p = r.execute_command(["hello_world"], stdout=subprocess.PIPE)
+        p = r.execute_command(["hello_world"], stdout=subprocess.PIPE, text=True)
         stdout, _ = p.communicate()
-        stdout = stdout.decode("utf-8").strip()
+        stdout = stdout.strip()
         self.assertEqual(stdout, "Hello Rez World!")
 
     def test_execute_command_environ(self):

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.47.3"
+_rez_version = "2.47.4"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -226,8 +226,10 @@ class LinuxPlatform(_UnixPlatform):
         # next, try getting the output of the lsb_release program
         import subprocess
 
-        p = popen(['/usr/bin/env', 'lsb_release', '-a'],
-                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = popen(
+            ['/usr/bin/env', 'lsb_release', '-a'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
         txt = p.communicate()[0]
 
         if not p.returncode:
@@ -370,7 +372,10 @@ class LinuxPlatform(_UnixPlatform):
     def _physical_cores_from_lscpu(self):
         import subprocess
         try:
-            p = popen(['lscpu'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = popen(
+                ['lscpu'], stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, text=True
+            )
         except (OSError, IOError):
             return None
 
@@ -437,8 +442,11 @@ class OSXPlatform(_UnixPlatform):
     def _physical_cores_from_osx_sysctl(self):
         import subprocess
         try:
-            p = popen(['sysctl', '-n', 'hw.physicalcpu'],
-                      stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = popen(
+                ['sysctl', '-n', 'hw.physicalcpu'],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True
+            )
         except (OSError, IOError):
             return None
 
@@ -526,8 +534,11 @@ class WindowsPlatform(Platform):
         # windows
         import subprocess
         try:
-            p = popen('wmic cpu get NumberOfCores /value'.split(),
-                      stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = popen(
+                'wmic cpu get NumberOfCores /value'.split(),
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True
+            )
         except (OSError, IOError):
             return None
 

--- a/src/rez/utils/py23.py
+++ b/src/rez/utils/py23.py
@@ -39,3 +39,19 @@ def load_module_from_file(name, filepath):
     else:
         from importlib.machinery import SourceFileLoader
         return SourceFileLoader(name, filepath).load_module()
+
+
+def subprocess_Popen(args, **kwargs):
+    """subprocess.Popen.
+    """
+    import subprocess
+
+    # Add support for the new py3 "text" arg, which is equivalent to
+    # "universal_newlines".
+    # https://docs.python.org/3/library/subprocess.html#frequently-used-arguments
+    #
+    if "text" in kwargs:
+        kwargs["universal_newlines"] = True
+        del kwargs["text"]
+
+    return subprocess.Popen(args, **kwargs)

--- a/src/rez/utils/system.py
+++ b/src/rez/utils/system.py
@@ -16,7 +16,7 @@ def add_sys_paths(paths):
         sys.path = original_syspath
 
 
-def popen(args, **kwargs):
+def popen(args, text=True, **kwargs):
     """Wrapper for `subprocess.Popen`.
 
     Avoids python bug described here: https://bugs.python.org/issue3905. This
@@ -25,6 +25,10 @@ def popen(args, **kwargs):
     In newer version of maya and katana, the sys.stdin object can also become
     replaced by an object with no 'fileno' attribute, this is also taken into
     account.
+
+    Note also the use of 'text'. This matches subprocess in python3. See the
+    section on 'universal_newlines' in:
+    https://docs.python.org/3/library/subprocess.html#frequently-used-arguments.
     """
     if "stdin" not in kwargs:
         try:
@@ -34,5 +38,8 @@ def popen(args, **kwargs):
 
         if file_no not in (0, 1, 2):
             kwargs["stdin"] = subprocess.PIPE
+
+    if text:
+        kwargs["universal_newlines"] = True
 
     return subprocess.Popen(args, **kwargs)

--- a/src/rez/utils/system.py
+++ b/src/rez/utils/system.py
@@ -1,3 +1,4 @@
+from rez.utils import py23
 from contextlib import contextmanager
 import subprocess
 import sys
@@ -16,7 +17,7 @@ def add_sys_paths(paths):
         sys.path = original_syspath
 
 
-def popen(args, text=True, **kwargs):
+def popen(args, **kwargs):
     """Wrapper for `subprocess.Popen`.
 
     Avoids python bug described here: https://bugs.python.org/issue3905. This
@@ -25,10 +26,6 @@ def popen(args, text=True, **kwargs):
     In newer version of maya and katana, the sys.stdin object can also become
     replaced by an object with no 'fileno' attribute, this is also taken into
     account.
-
-    Note also the use of 'text'. This matches subprocess in python3. See the
-    section on 'universal_newlines' in:
-    https://docs.python.org/3/library/subprocess.html#frequently-used-arguments.
     """
     if "stdin" not in kwargs:
         try:
@@ -39,7 +36,4 @@ def popen(args, text=True, **kwargs):
         if file_no not in (0, 1, 2):
             kwargs["stdin"] = subprocess.PIPE
 
-    if text:
-        kwargs["universal_newlines"] = True
-
-    return subprocess.Popen(args, **kwargs)
+    return py23.subprocess_Popen(args, **kwargs)

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -95,7 +95,6 @@ class PowerShellBase(Shell):
         p = popen(cmd,
                   stdout=PIPE,
                   stderr=PIPE,
-                  universal_newlines=True,
                   shell=True)
         out_, _ = p.communicate()
         out_ = out_.strip()
@@ -115,7 +114,6 @@ class PowerShellBase(Shell):
         p = popen(cmd,
                   stdout=PIPE,
                   stderr=PIPE,
-                  universal_newlines=True,
                   shell=True)
         out_, _ = p.communicate()
         out_ = out_.strip()

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -92,10 +92,8 @@ class PowerShellBase(Shell):
             "REG_(EXPAND_)?SZ", "(.*)"
         ])
 
-        p = popen(cmd,
-                  stdout=PIPE,
-                  stderr=PIPE,
-                  shell=True)
+        p = popen(cmd, stdout=PIPE, stderr=PIPE,
+                  shell=True, text=True)
         out_, _ = p.communicate()
         out_ = out_.strip()
 
@@ -111,10 +109,8 @@ class PowerShellBase(Shell):
             "(.*)"
         ])
 
-        p = popen(cmd,
-                  stdout=PIPE,
-                  stderr=PIPE,
-                  shell=True)
+        p = popen(cmd, stdout=PIPE, stderr=PIPE,
+                  shell=True, text=True)
         out_, _ = p.communicate()
         out_ = out_.strip()
 

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -98,9 +98,9 @@ class CMD(Shell):
         ])
 
         p = popen(cmd, stdout=subprocess.PIPE,
-                  stderr=subprocess.PIPE, shell=True)
+                  stderr=subprocess.PIPE, shell=True, text=True)
         out_, _ = p.communicate()
-        out_ = out_.decode('utf-8').strip()
+        out_ = out_.strip()
 
         if p.returncode == 0:
             match = re.match(expected, out_)
@@ -123,9 +123,9 @@ class CMD(Shell):
         ])
 
         p = popen(cmd, stdout=subprocess.PIPE,
-                  stderr=subprocess.PIPE, shell=True)
+                  stderr=subprocess.PIPE, shell=True, text=True)
         out_, _ = p.communicate()
-        out_ = out_.decode('utf-8').strip()
+        out_ = out_.strip()
 
         if p.returncode == 0:
             match = re.match(expected, out_)

--- a/src/rezplugins/shell/csh.py
+++ b/src/rezplugins/shell/csh.py
@@ -38,7 +38,7 @@ class CSH(UnixShell):
         cmd = "cmd=`which %s`; unset PATH; $cmd %s 'echo __PATHS_ $PATH'" \
               % (cls.name(), cls.command_arg)
         p = popen(cmd, stdout=subprocess.PIPE,
-                  stderr=subprocess.PIPE, shell=True)
+                  stderr=subprocess.PIPE, shell=True, text=True)
         out_, err_ = p.communicate()
         if p.returncode:
             paths = []

--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -38,12 +38,12 @@ class SH(UnixShell):
         cmd = "cmd=`which %s`; unset PATH; $cmd %s %s 'echo __PATHS_ $PATH'" \
               % (cls.name(), cls.norc_arg, cls.command_arg)
         p = popen(cmd, stdout=subprocess.PIPE,
-                  stderr=subprocess.PIPE, shell=True)
+                  stderr=subprocess.PIPE, shell=True, text=True)
         out_, err_ = p.communicate()
         if p.returncode:
             paths = []
         else:
-            lines = out_.decode("utf-8").split('\n')
+            lines = out_.split('\n')
             line = [x for x in lines if "__PATHS_" in x.split()][0]
             paths = line.strip().split()[-1].split(os.pathsep)
 


### PR DESCRIPTION
This returns an str rather than bytes, which is typically what we want. The "universal_newlines" arg is equivalent, but misleading (hence the rename to 'text' in py3).

I haven't been able to repro, but I know that @maxnbk was hitting an issue related to this. I expect this PR to probably fix that.
