### PR TITLE
add __bool__ operator

### DIFF
--- a/src/rez/package_filter.py
+++ b/src/rez/package_filter.py
@@ -149,6 +149,8 @@ class PackageFilter(PackageFilterBase):
     def __nonzero__(self):
         return bool(self._excludes)
 
+    __bool__ = __nonzero__  # py3 compat
+
     @cached_property
     def cost(self):
         """Get the approximate cost of this filter.
@@ -270,6 +272,8 @@ class PackageFilterList(PackageFilterBase):
 
     def __nonzero__(self):
         return any(self.filters)
+
+    __bool__ = __nonzero__  # py3 compat
 
     def __str__(self):
         filters = sorted(self.filters, key=lambda x: (x.cost, str(x)))

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -1050,6 +1050,8 @@ class EnvironmentVariable(object):
     def __nonzero__(self):
         return bool(self.value())
 
+    __bool__ = __nonzero__  # py3 compat
+
     def __eq__(self, value):
         if isinstance(value, EnvironmentVariable):
             value = value.value()

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -117,6 +117,8 @@ class _Printer(object):
     def __nonzero__(self):
         return self.verbosity
 
+    __bool__ = __nonzero__  # py3 compat
+
 
 class SolverState(object):
     """Represent the current state of the solver instance for use with a

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -115,7 +115,7 @@ class _Printer(object):
         print(txt % args, file=self.buf)
 
     def __nonzero__(self):
-        return self.verbosity
+        return self.verbosity > 0
 
     __bool__ = __nonzero__  # py3 compat
 

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.47.3"
+_rez_version = "2.47.4"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/utils/logging_.py
+++ b/src/rez/utils/logging_.py
@@ -59,6 +59,8 @@ class _Printer(object):
     def __nonzero__(self):
         return bool(self.printer_function)
 
+    __bool__ = __nonzero__  # py3 compat
+
 
 @contextmanager
 def log_duration(printer, msg):

--- a/src/rez/utils/memcached.py
+++ b/src/rez/utils/memcached.py
@@ -27,7 +27,10 @@ class Client(object):
     - ability to cache None.
     """
     class _Miss(object):
-        def __nonzero__(self): return False
+        def __nonzero__(self):
+            return False
+        __bool__ = __nonzero__  # py3 compat
+
     miss = _Miss()
 
     logger = config.debug_printer("memcache")
@@ -49,6 +52,8 @@ class Client(object):
 
     def __nonzero__(self):
         return bool(self.servers)
+
+    __bool__ = __nonzero__  # py3 compat
 
     @property
     def client(self):

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -384,6 +384,8 @@ class Version(_Comparable):
         """The empty version equates to False."""
         return bool(self.tokens)
 
+    __bool__ = __nonzero__  # py3 compat
+
     def __eq__(self, other):
         return isinstance(other, Version) and self.tokens == other.tokens
 


### PR DESCRIPTION
https://portingguide.readthedocs.io/en/latest/core-obj-misc.html#customizing-truthiness-bool

This issue was causing the trackback @maxnbk hit:
```
Traceback (most recent call last):
  File "/rez/bin/rez/rez-env", line 8, in <module>
    sys.exit(run_rez_env())
  File "/rez/lib/python3.7/site-packages/rez/cli/_entry_points.py", line 152, in run_rez_env
    return run("env")
  File "/rez/lib/python3.7/site-packages/rez/cli/_main.py", line 152, in run
    returncode = run_cmd()
  File "/rez/lib/python3.7/site-packages/rez/cli/_main.py", line 144, in run_cmd
    return opts.func(opts, opts.parser, extra_arg_groups)
  File "/rez/lib/python3.7/site-packages/rez/cli/env.py", line 206, in command
    print_stats=opts.stats)
  File "/rez/lib/python3.7/site-packages/rez/resolved_context.py", line 282, in __init__
    resolver.solve()
  File "/rez/lib/python3.7/site-packages/rez/utils/memcached.py", line 249, in wrapper
    return func(*nargs, **kwargs)
  File "/rez/lib/python3.7/site-packages/rez/resolver.py", line 111, in solve
    solver_dict = self._get_cached_solve()
  File "/rez/lib/python3.7/site-packages/rez/resolver.py", line 298, in _get_cached_solve
    if _packages_changed(key, data) or _releases_since_solve(key, data):
  File "/rez/lib/python3.7/site-packages/rez/resolver.py", line 227, in _packages_changed
    solver_dict, _, variant_states_dict = data
TypeError: cannot unpack non-iterable _Miss object
```

Because the _Miss object was not considered boolean False by py3, it was getting returned from a function when it should not have been. Will close #726 in favour of this PR.

Note that there would presumably be other lurking bugs that this PR will also address.
