### PR TITLE
fix cores detection error on win due to bytes-like from subprocess

### DIFF
--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -541,7 +541,7 @@ class WindowsPlatform(Platform):
         # N is the number of physical cores in the machine: this will be exactly one half the
         # number of logical cores (ie from multiprocessing.cpu_count) if HyperThreading is
         # enabled on the CPU(s)
-        result = re.findall(r'NumberOfCores=(\d+)', stdout.strip())
+        result = re.findall(r'NumberOfCores=(\d+)', stdout.decode("utf-8").strip())
 
         if not result:
             # don't know what's wrong... should get back a result like:


### PR DESCRIPTION
Addresses:
`22:30:51 ERROR    Error detecting physical core count, defaulting to 1: cannot use a string pattern on a bytes-like object`