### PR TITLE
rez-pip: Assume pip provided by python package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## 2.48.0 (yyyy-mm-dd)
+[Source](https://github.com/repos/nerdvegas/rez/tree/2.48.0) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.4...2.48.0)
+
+**Notes**
+
+* Rez-pip: Add a new logic to find which pip will be used to install pip packages.
+* Rez-pip: New deprecation warning when --pip-version is used.
+* See https://github.com/nerdvegas/rez/wiki/Pip for more details on rez-pip.
+
+**Merged pull requests:**
+
+- rez-pip: Assume pip provided by python package [\#757](https://github.com/nerdvegas/rez/pull/757) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
+
+**Closed issues:**
+
+- rez-pip should assume python provided pip [\#706](https://github.com/nerdvegas/rez/issues/706)
+
+
 ## 2.47.4 (2019-10-11)
 [Source](https://github.com/repos/nerdvegas/rez/tree/2.47.4) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.3...2.47.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 **Closed issues:**
 
 - rez-pip should assume python provided pip [\#706](https://github.com/nerdvegas/rez/issues/706)
+- rez-pip python 3 error [\#764](https://github.com/nerdvegas/rez/issues/764)
 
 
 ## 2.47.4 (2019-10-11)

--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -6,13 +6,14 @@ from __future__ import print_function
 
 def setup_parser(parser, completions=False):
     parser.add_argument(
-        "--pip-version", dest="pip_ver", metavar="VERSION",
-        help="pip version (rez package) to use, default is latest")
-    parser.add_argument(
         "--python-version", dest="py_ver", metavar="VERSION",
         help="python version (rez package) to use, default is latest. Note "
         "that the pip package(s) will be installed with a dependency on "
         "python-MAJOR.MINOR.")
+    parser.add_argument(
+        "--pip-version", dest="pip_ver", metavar="VERSION",
+        help="pip version (rez package) to use, default is latest."
+        " This option is deprecated and will be removed in the future.")
     parser.add_argument(
         "-i", "--install", action="store_true",
         help="install the package")
@@ -31,6 +32,7 @@ def setup_parser(parser, completions=False):
 def command(opts, parser, extra_arg_groups=None):
     from rez.pip import pip_install_package, run_pip_command
     import sys
+    import warnings
 
     if not (opts.search or opts.install):
         parser.error("Expected one of: --install, --search")
@@ -39,6 +41,15 @@ def command(opts, parser, extra_arg_groups=None):
         p = run_pip_command(["search", opts.PACKAGE])
         p.wait()
         return
+
+    if opts.pip_ver:
+        with warnings.catch_warnings():
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            warnings.warn(
+                "The option --pip-version is deprecated and will be removed in a future version",
+                category=DeprecationWarning
+            )
 
     installed_variants, skipped_variants = pip_install_package(
         opts.PACKAGE,

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -36,17 +36,6 @@ class InstallMode(Enum):
     # only install dependencies that we have to. If an existing rez package
     # satisfies a dependency already, it will be used instead. The default.
     min_deps = 1
-    # install dependencies even if an existing rez package satisfies the
-    # dependency, if the dependency is newer.
-    new_deps = 2
-    # install dependencies even if a rez package of the same version is already
-    # available, if possible. For example, if you are performing a local install,
-    # a released (central) package may match a dependency; but with this mode
-    # enabled, a new local package of the same version will be installed as well.
-    #
-    # Typically, if performing a central install with the rez-pip --release flag,
-    # max_deps is equivalent to new_deps.
-    max_deps = 3
 
 
 def is_exe(fpath):

--- a/wiki/pages/Pip.md
+++ b/wiki/pages/Pip.md
@@ -1,0 +1,129 @@
+## Overview
+
+Rez is language agnostic.
+But since python is so much used in the VFX industry (and outside),
+it knows how to convert/translate it into a rez package.
+To do so, it provides a `rez-pip` command.
+
+> [[media/icons/warning.png]] It doesn't know how to translate its own packages
+into pip packages.
+
+### Usage
+
+```
+usage: rez pip [-h] [--python-version VERSION] [--pip-version VERSION] [-i]
+               [-s] [-r] [-v]
+               PACKAGE
+
+Install a pip-compatible python package, and its dependencies, as rez
+packages.
+
+positional arguments:
+  PACKAGE               package to install or archive/url to install from
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --python-version VERSION
+                        python version (rez package) to use, default is
+                        latest. Note that the pip package(s) will be installed
+                        with a dependency on python-MAJOR.MINOR.
+  --pip-version VERSION
+                        pip version (rez package) to use, default is latest.
+                        This option is deprecated and will be removed in the
+                        future.
+  -i, --install         install the package
+  -s, --search          search for the package on PyPi
+  -r, --release         install as released package; if not set, package is
+                        installed locally only
+  -v, --verbose         verbose mode, repeat for more verbosity
+```
+
+The `rez-pip` command allows you to do two main things.
+
+1. Install or release a pip package as a rez package.
+2. Search for a package on PyPI
+
+### Which pip will be used?
+
+`rez-pip` uses a fallback mechanism to find which pip will be used to run the commands.
+The logic is as follow:
+
+1. Search for pip in the rezified `python` package specified with `--python-version`, or
+the latest version if not specified;
+2. If found, use it;
+3. If not found, search for pip in the rezified `pip` package specified with `--pip-version`,
+or latest version if not specified.
+
+   **Note that this is deprecated and will be removed in the future**;
+
+4. If rezified `pip` is found, use it;
+5. If not found, fall back to pip installed in rez own virtualenv.
+
+> [[media/icons/info.png]] In all of these options, we also check if the version of pip is greater
+or equal than 19.0. This is a hard requirement of `rez-pip`.
+
+Note that rez-pip output should tell you what it tries and which pip it will use.
+
+It is extremely important to know which pip is used and understand why it is used. Pip packages
+define which python version they are compatible with.
+When you install a pip package, pip checks which python version it is
+currently running under to determine if a package can be downloaded and installed.
+Not only this but it also checks which python implementation is used (CPython, PyPy,
+IronPython, etc), the architecture python was built with, and other variables. So the thing you
+really need to know first is which python you want to use and from there you should know
+which pip is used. Knowing the pip version comes in second place.
+
+At some point, we supported the `--pip-version` argument, but considering what was just said
+above, we decided to deprecate it (but not yet removed) just for backward compatibility reasons.
+Pip is too much (read tightly) coupled to the python version/interpreter it is installed with
+for us to support having pip as a rez package. We just can't garantee that pip can be
+install once in a central way and work with multiple different python version, and potentially
+different implementations.
+
+### How should I install pip?
+
+Following the [Which pip will be used?](#which-pip-will-be-used) section, we recommend to install
+pip inside your python packages. For Python 2, this can be done when you compile it with the
+`--with-ensurepip` flag of the `configure` script. This will install a version older than 19.0
+though, so you will need to upgrade it. For Python 3, it is already installed by default.
+Though your milleage may vary for the version installed, depending on which Python version you
+installed. So check the pip version and update it if necessary. We also encourage you
+to install `wheel` and possibly update `setuptools`. `pip`, `setuptools` and `wheel`
+are perfectly fine when installed in the interpreter directly as they are pretty core
+packages and all have no dependencies (and that's what `virtualenv` does by default too).
+
+Tip: When installing something in an interpreter, make sure you really install in this interpreter.
+That means using somehting like:
+
+```
+/path/to/python -E -s -m pip install <package>
+```
+
+`-E` will render any `PYTHON*` environment variable to not be used and `-s` will
+remove your [user site](https://docs.python.org/3.7/library/site.html) from the equation.
+
+#### Install/release
+
+You have two options when you want to convert a pip package to a rez package. You can
+install it, or release it. Install means that it will install in your
+[local_packages_path](Configuring-Rez#local_packages_path), while
+release means it will be installed in your
+[release_packages_path](Configuring-Rez#release_packages_path).
+
+You can (and we recommend) use the `--python-version` to choose for which python
+version you want to install a given package. This will make `rez-pip` to resolve
+the given version of the `python` rez package and use it to run the `pip install`.
+See [Which pip will be used?](#which-pip-will-be-used) for more details.
+If the pip package is not pure (so contains `.so` for example), you will need to
+call `rez-pip` for each python version you want to install the pip package for.
+
+> [[media/icons/warning.png]] `--pip-version` is deprecated and will be removed in the future.
+> See [How should I install pip?](#how-should-i-install-pip) on how we recommend
+> to install pip from now on.
+
+
+#### Search
+
+With `rez-pip --search <query>`, you can search for a package in PyPI. The main
+advantage of using it over using `pip search <query>` is that `rez-pip --search`
+uses the same logic as `rez-pip --install` and `--release` to find which pip to use.


### PR DESCRIPTION
This PR closes #706 and closes #764 

This PR adds a new logic to find which `pip` will be used to install pip packages.

The logic is as follow:

1. Search for pip in the rezified `python` package specified with `--python-version`, or
the latest version if not specified;
2. If found, use it;
3. If not found, search for pip in the rezified `pip` package specified with `--pip-version`,
or latest version if not specified.
4. If rezified `pip` is found, use it;
5. If not found, fall back to pip installed in rez own virtualenv.

I also added a deprecation warning when `--pip-version` is used.

Lastly, I added a wiki page to explain what is `rez-pip` and how it really works under the hood. This, I hope, will save us some questions and will help us remember what are the good practices when it comes to pip + rez.

I've tested this with most (if not all) scenarios, but I invite everybody to also try on their side to verify that it works for everybody in all sort of environment (windows, osx, linux, etc).