### PR TITLE
Rez test release hook

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -373,6 +373,7 @@ config_schema = Schema({
     "warn_none":                                    Bool,
     "debug_file_loads":                             Bool,
     "debug_plugins":                                Bool,
+    "debug_hooks":                                  Bool,
     "debug_package_release":                        Bool,
     "debug_bind_modules":                           Bool,
     "debug_resources":                              Bool,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -516,6 +516,9 @@ debug_file_loads = False
 # Print debugging info when loading plugins
 debug_plugins = False
 
+# Print debugging info inside hooks
+debug_hooks = False
+
 # Print debugging info such as VCS commands during package release. Note that
 # rez-pip installations are controlled with this setting also.
 debug_package_release = False
@@ -582,7 +585,7 @@ build_thread_count = "physical_cores"
 # release hook plugin being loaded does not mean it will run - it needs to be
 # listed here as well. Several built-in release hooks are available, see
 # rezplugins/release_hook.
-release_hooks = []
+release_hooks = ["rez_test"]
 
 # Prompt for release message using an editor. If set to False, there will be
 # no editor prompt.

--- a/src/rezplugins/release_hook/rez_test.py
+++ b/src/rezplugins/release_hook/rez_test.py
@@ -1,0 +1,56 @@
+"""
+Pre-release hook checking if the package contains test that need to be run successfully before unleashing the package
+"""
+import subprocess
+import os
+
+from rez.release_hook import ReleaseHook
+from rez.exceptions import ReleaseHookCancellingError
+
+from rez.utils.logging_ import print_debug
+
+
+class RezTestReleaseHook(ReleaseHook):
+
+    @classmethod
+    def name(cls):
+        return "rez_test"
+
+    def __init__(self, source_path):
+        super(RezTestReleaseHook, self).__init__(source_path)
+
+    def post_release(self, install_path='', **kwargs):
+
+        tests = self.package.tests
+        testPath = list(self.package.config.nonlocal_packages_path)
+        testPath.insert(0, install_path)
+
+        if tests:
+            for testName, testDetails in tests.iteritems():
+
+                args = ['rez', 'test', self.package.name, testName]
+
+                stdout, stderr, retcode = self._run_command(args, testPath)
+
+                if retcode:
+                    raise ReleaseHookCancellingError(
+                        "Running %s test (command: %s) returned code %s\n" % (testName, testDetails['command'], retcode))
+                else:
+                    print stdout
+        else:
+            print_debug("Package does not have rez test. Continuing with release ...", module="hooks")
+
+    def _run_command(self, args, packages_path):
+        cmd_str = ' '.join(args)
+        os.environ['REZ_PACKAGES_PATH'] = os.path.pathsep.join(packages_path)
+
+        print_debug("Running: %s   with packages path %s " % (cmd_str, os.environ['REZ_PACKAGES_PATH']), module="hooks")
+
+        p = subprocess.Popen(args, env=os.environ, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        return stdout, stderr, p.returncode
+
+
+def register_plugin():
+    return RezTestReleaseHook


### PR DESCRIPTION
A simple pre-release test hook that we have been using at AL for more than a year.

It just run `rez test packageName==Version` if the package that is being released contains the `tests` field

Related to https://github.com/nerdvegas/rez/issues/665

