### PR TITLE
Skip `test_build_cmake` on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,12 @@ like any other package:
 * Has a memcached-based caching system, for caching environment resolves;
 * Has a package filtering feature, allowing for staged package releases such as
   alpha and beta packages.
+
+## Known issues and limitations
+
+* Currently CMake builds do not function on Windows with Rez and
+  the related tests are skipped. A fix requires multiple changes that are on
+  the roadmap. Users have successfully implemented workarounds to utilize
+  CMake with Rez under Windows, but the goal is to provide a seamless experience
+  on any platform in the future. For details checkout
+  https://github.com/nerdvegas/rez/issues/703

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -9,6 +9,7 @@ from rez.exceptions import BuildError, BuildContextResolveError,\
 import unittest
 from rez.tests.util import TestBase, TempdirMixin, find_file_in_path, \
     per_available_shell, install_dependent, program_dependent
+from rez.utils.platform_ import platform_
 import shutil
 import os.path
 
@@ -155,6 +156,11 @@ class TestBuild(TestBase, TempdirMixin):
     @program_dependent("cmake")
     def test_build_cmake(self):
         """Test a cmake-based package."""
+        if platform_.name == "windows":
+            self.skipTest("This test does not run on Windows due to temporary"
+                          "limitations of the cmake build_system plugin"
+                          " implementation.")
+
         self.assertRaises(PackageFamilyNotFoundError, self._create_context,
                           "sup_world==3.8")
         self._test_build_translate_lib()


### PR DESCRIPTION
The goal is to have better visibility of failure on Windows in our
automated tests, while the CMake issues are being addressed.
Added a known issues and limitations section in the README.