### PR TITLE
rez.util.ProgressBar checks `Bar.__del__` exists before invocation #769

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 2.47.9 (2019-10-24)
+[Source](https://github.com/nerdvegas/rez/tree/2.47.9) | [Diff](https://github.com/nerdvegas/rez/compare/2.47.8...2.47.9)
+
+**Notes**
+
+Fixes rez.util.ProgressBar - only calls `Bar.__del__` if hasattr.
+
+**Closed issues:**
+
+- rez-depends -- AttributeError: type object 'Bar' has no attribute '__del__' (win, py-3, rez-2.47.7) [\#YYY](https://github.com/nerdvegas/rez/issues/769)
+
+
 ## 2.47.8 (2019-10-24)
 [Source](https://github.com/repos/nerdvegas/rez/tree/2.47.8) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.7...2.47.8)
 

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -29,7 +29,8 @@ class ProgressBar(Bar):
     def __del__(self):
         if self.close_file:
             self.file.close()
-        Bar.__del__(self)
+        if hasattr(Bar, '__del__'):
+            Bar.__del__(self)
 
 
 def dedup(seq):

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.47.8"
+_rez_version = "2.47.9"
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
A tiny update to fix #769 .

Since `Bar` refers to `rez.vendor.progress` (and I'm guessing vendor indicates a 3rd party package) rather than removing `Bar.__del__(self)` I am using a `hasattr` check in case it later introduces a destructor.