### PR TITLE
Unwanted debug printing

### DIFF
--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -116,7 +116,8 @@ class RezPluginType(object):
         paths = reversed(paths)
 
         for path in paths:
-            print_debug("searching plugin path %s...", path)
+            if config.debug("plugins"):
+                print_debug("searching plugin path %s...", path)
 
             for loader, modname, ispkg in pkgutil.iter_modules(
                     [path], package.__name__ + '.'):


### PR DESCRIPTION
Prevent rez from printing debug messages such as:

> 09:25:21 DEBUG searching plugin path <path_to_plugin>

even when debug_plugins is False.

(Introduce in 6f0e5db8ff50dbe8c32982dd57db374b2b679d1d).