### PR TITLE
Updated actions badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Core](https://github.com/nerdvegas/rez/workflows/Core/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3ACore+branch%3Amaster)
 [![Ubuntu](https://github.com/nerdvegas/rez/workflows/Ubuntu/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AUbuntu+branch%3Amaster)
 [![MacOS](https://github.com/nerdvegas/rez/workflows/MacOS/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AMacOS+branch%3Amaster)
-[![Compose Windows Docker Image](https://github.com/nerdvegas/rez/workflows/Compose%20Windows%20Docker%20Image/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3A%22Compose+Windows+Docker+Image%22+branch%3Amaster)
 [![Windows Docker](https://github.com/nerdvegas/rez/workflows/Windows%20Docker/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3A%22Compose+Windows+Docker+Image%22+branch%3Amaster)
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-![](https://github.com/nerdvegas/rez/workflows/Core/badge.svg)
-![](https://github.com/nerdvegas/rez/workflows/Ubuntu/badge.svg)
-![](https://github.com/nerdvegas/rez/workflows/MacOS/badge.svg)
-![](https://github.com/nerdvegas/rez/workflows/Windows/badge.svg)
+[![Core](https://github.com/nerdvegas/rez/workflows/Core/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3ACore+branch%3Amaster)
+[![Ubuntu](https://github.com/nerdvegas/rez/workflows/Ubuntu/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AUbuntu+branch%3Amaster)
+[![MacOS](https://github.com/nerdvegas/rez/workflows/MacOS/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AMacOS+branch%3Amaster)
+[![Compose Windows Docker Image](https://github.com/nerdvegas/rez/workflows/Compose%20Windows%20Docker%20Image/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3A%22Compose+Windows+Docker+Image%22+branch%3Amaster)
+[![Windows Docker](https://github.com/nerdvegas/rez/workflows/Windows%20Docker/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3A%22Compose+Windows+Docker+Image%22+branch%3Amaster)
 
 
 ![logo](media/rez_banner_256.png)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Core](https://github.com/nerdvegas/rez/workflows/Core/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3ACore+branch%3Amaster)
 [![Ubuntu](https://github.com/nerdvegas/rez/workflows/Ubuntu/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AUbuntu+branch%3Amaster)
 [![MacOS](https://github.com/nerdvegas/rez/workflows/MacOS/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AMacOS+branch%3Amaster)
-[![Windows Docker](https://github.com/nerdvegas/rez/workflows/Windows%20Docker/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3A%22Compose+Windows+Docker+Image%22+branch%3Amaster)
+![](https://github.com/nerdvegas/rez/workflows/Windows/badge.svg)
 
 
 ![logo](media/rez_banner_256.png)


### PR DESCRIPTION
Closes #785

Updated `README.md` badges:

[![Core](https://github.com/nerdvegas/rez/workflows/Core/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3ACore+branch%3Amaster)
[![Ubuntu](https://github.com/nerdvegas/rez/workflows/Ubuntu/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AUbuntu+branch%3Amaster)
[![MacOS](https://github.com/nerdvegas/rez/workflows/MacOS/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AMacOS+branch%3Amaster)

- Change badges to only show for `master` branch runs
- Added/fixed missing Windows workflows
- Added links to workflows pages for each badge
- Added alt text to each badge image

Edits: 
1. Removed from PR: [![Compose Windows Docker Image](https://github.com/nerdvegas/rez/workflows/Compose%20Windows%20Docker%20Image/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3A%22Compose+Windows+Docker+Image%22+branch%3Amaster)
2. Let #789 implement [![Windows](https://github.com/nerdvegas/rez/workflows/Windows/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3A%22Windows%22+branch%3Amaster)

   ```markdown
   [![Windows](https://github.com/nerdvegas/rez/workflows/Windows/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3A%22Windows%22+branch%3Amaster)`
   ```