### PR TITLE
Fix for windows docker login error

### DIFF
--- a/.github/workflows/windows-docker.yaml
+++ b/.github/workflows/windows-docker.yaml
@@ -36,12 +36,12 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
     - name: Login to docker repository
       run: |
         ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-        '${{ secrets.DOCKERHUB_TOKEN }}' | docker login -u ${gh_user} --password-stdin
+        docker login -u ${gh_user} -p ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - uses: actions/checkout@v1
     - name: Pull docker image
       run: |
         ${gh_user} = ("${{ github.repository }}" -Split '/')[0]


### PR DESCRIPTION
It seems like the windows image composing works correctly, but the subsequent pulls fail to login to docker. That is with the exact same code!

In worst case I can just use the -u -p options directly and rely on github doing the right masking in the logs due to the variable being a secret.

**WIP**
Trying to find a fix that would only affect the windows image. The only difference I can spot is the checkout action being triggered earlier in this workflow.