### PR TITLE
Windows ci fail on forked pr

### DIFF
--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -22,9 +22,9 @@ on:
   push:
     # Will only trigger building a docker image if any of these changed
     paths:
-    - '.github/docker/rez-win-base/**'
-    - '.github/docker/rez-win-py/**'
-    - '.github/workflows/windows-docker-image.yaml'
+      - '.github/docker/rez-win-base/**'
+      - '.github/docker/rez-win-py/**'
+      - '.github/workflows/windows-docker-image.yaml'
 
 jobs:
 
@@ -46,7 +46,9 @@ jobs:
       #
       # By using dockers experimental CLI features we don't need to pull an
       # image to check if it exists.
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v1
+
       - name: Build docker image if needed
         run: |
           ${Env:LAST_DOCKER_BASE_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
@@ -100,4 +102,3 @@ jobs:
           cd .github\docker\rez-win-py
           docker build --tag ${gh_user}/rez-win-py:${{ matrix.python-version }}-${ENV:DOCKER_TAG} --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${ENV:LAST_DOCKER_BASE_REVISION} .
           docker push ${gh_user}/rez-win-py:${{ matrix.python-version }}-${ENV:DOCKER_TAG}
-

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Login to docker repository
         run: |
-          if(${Env:DOCKERHUB_TOKEN} != '') {
+          if(${Env:DOCKERHUB_TOKEN} -ne '') {
             ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
             '${Env:DOCKERHUB_TOKEN}' | docker login -u ${gh_user} --password-stdin
           }

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -26,17 +26,6 @@ jobs:
   main:
     runs-on: windows-2019
 
-    # Test will not succeed for forked PRs, so skip these (user will not have
-    # access to secrets). This is a bit of a hack since that user could have an
-    # unrelated DOCKERHUB_TOKEN secret, but it will do for now. There's a good
-    # chance this will have to change anyway (with possible move to github pkg
-    # registry).
-    #
-    # Note that github actions doesn't currently have a 'user' context to test
-    # a user's repo access, so we can't do it that way.
-    #
-    if: secrets.DOCKERHUB_TOKEN != ''
-
     strategy:
       matrix:
         # Needs to match python version of images (see windows-docker-image.yaml)
@@ -52,8 +41,12 @@ jobs:
 
       - name: Login to docker repository
         run: |
-          ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          '${{ secrets.DOCKERHUB_TOKEN }}' | docker login -u ${gh_user} --password-stdin
+          if(${Env:DOCKERHUB_TOKEN} != '') {
+            ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
+            '${Env:DOCKERHUB_TOKEN}' | docker login -u ${gh_user} --password-stdin
+          }
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Pull docker image
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           if(${Env:DOCKERHUB_TOKEN} -ne '') {
             ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-            '${Env:DOCKERHUB_TOKEN}' | docker login -u ${gh_user} --password-stdin
+            "${Env:DOCKERHUB_TOKEN}" | docker login -u ${gh_user} --password-stdin
           }
         env:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -26,6 +26,17 @@ jobs:
   main:
     runs-on: windows-2019
 
+    # Test will not succeed for forked PRs, so skip these (user will not have
+    # access to secrets). This is a bit of a hack since that user could have an
+    # unrelated DOCKERHUB_TOKEN secret, but it will do for now. There's a good
+    # chance this will have to change anyway (with possible move to github pkg
+    # registry).
+    #
+    # Note that github actions doesn't currently have a 'user' context to test
+    # a user's repo access, so we can't do it that way.
+    #
+    if: secrets.DOCKERHUB_TOKEN != ''
+
     strategy:
       matrix:
         # Needs to match python version of images (see windows-docker-image.yaml)

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -50,13 +50,21 @@ jobs:
 
       - name: Pull docker image
         run: |
-          ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          echo "Pulling rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}"
-          docker pull ${gh_user}/rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}
+          if(${Env:DOCKERHUB_TOKEN} -ne '') {
+            ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
+            ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+            echo "Pulling rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}"
+            docker pull ${gh_user}/rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}
+          }
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run Docker image (installs and tests rez)
         run: |
-          ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          docker run ${gh_user}/rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION} ${{ github.repository }} ${{ github.sha }}
+          if(${Env:DOCKERHUB_TOKEN} -ne '') {
+            ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
+            ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+            docker run ${gh_user}/rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION} ${{ github.repository }} ${{ github.sha }}
+          }
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Fixes #790 (sort of)

This is a fairly hacky fix for failing windows tests, but there don't seem to be many good options.

Windows test is failing on forked PRs, because forks don't have access to secrets, and thus `secrets.DOCKERHUB_TOKEN` evals to empty string.

This PR forces the windows test to be a no-op in this situation. It's not ideal, but neither is removing pull-requests as an event, because this _should_ be working for collaborators and it would be a shame to lose that.

The clumsy approach you see wrt setting DOCKERHUB_TOKEN envvar in each step is explained here: https://github.community/t5/GitHub-Actions/If-expression-with-context-variable/td-p/34556. Basically, you can't use `jobs.{jobname}.if` because this doesn't have access to the `secrets` context (why??).

Anyway the aim of this PR is to have windows test in as good a shape as it can be currently. Happy to revert this to something else later. 

ps:

It's also not great because the fork user may have an unrelated DOCKERHUB_TOKEN secret. Chances of that are low, and this is hopefully a semi-temporary fix, so I think we can live with this for now. Unfortunately there's no such thing as a 'user' context in github Actions where you might check user permissions and have an if condition on that :/
