### PR TITLE
Fixes #792 cmd empty echo

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -250,6 +250,7 @@ class TestShells(TestBase, TempdirMixin):
             _print("ello")
             _print(literal("ello"))
             _print(expandable("ello"))
+            info('')
             _print("\\")
             _print("\\'")
             _print("\\\"")
@@ -291,6 +292,7 @@ class TestShells(TestBase, TempdirMixin):
             "ello",
             "ello",
             "ello",
+            "",
             "\\",
             "\\'",
             "\\\"",
@@ -331,8 +333,9 @@ class TestShells(TestBase, TempdirMixin):
 
         # We are wrapping all variable outputs in quotes in order to make sure
         # our shell isn't interpreting our output as instructions when echoing
-        # it but this means we need to wrap our expected output as well.
-        expected_output = ['"{}"'.format(o) for o in expected_output]
+        # it but this means we need to wrap our expected output as well. Only
+        # exception is empty string, which is just passed through.
+        expected_output = ['"{}"'.format(o) if o else o for o in expected_output]
 
         _execute_code(_rex_assigning, expected_output)
 

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -321,7 +321,10 @@ class CMD(Shell):
         for line in value.split('\n'):
             line = self.escape_string(line)
             line = self.convert_tokens(line)
-            self._addline('echo %s' % line)
+            if line:
+                self._addline('echo %s' % line)
+            else:
+                self._addline('echo.')
 
     def error(self, value):
         for line in value.split('\n'):

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -77,7 +77,7 @@ class CMD(Shell):
 
         # detect system paths using registry
         def gen_expected_regex(parts):
-            whitespace = "[\s]+"
+            whitespace = r"[\s]+"
             return whitespace.join(parts)
 
         paths = []


### PR DESCRIPTION
Without it `info('')` generates `echo is ON.` on cmd's stdout.

EDIT: More context
In `cmd` and `info('')` results in `echo ""` which is interpreted as command to show the current state of echo.
The way to echo an empty line is `echo.`.

I've also added a test that makes sure that info('') is interpreted as empty line.