### PR TITLE
Rep001 1 (rez-test improvements)

### DIFF
--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -15,6 +15,10 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "-s", "--stop-on-fail", action="store_true",
         help="stop on first test failure")
+    parser.add_argument(
+        "--inplace", action="store_true",
+        help="run tests in the current environment. Any test whose requirements "
+        "are not met by the current environment is skipped")
     PKG_action = parser.add_argument(
         "--extra-packages", nargs='+', metavar="PKG",
         help="extra packages to add to test environment")
@@ -55,6 +59,7 @@ def command(opts, parser, extra_arg_groups=None):
         extra_package_requests=opts.extra_packages,
         dry_run=opts.dry_run,
         stop_on_fail=opts.stop_on_fail,
+        use_current_env=opts.inplace,
         verbose=True
     )
 

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -64,8 +64,9 @@ def command(opts, parser, extra_arg_groups=None):
     )
 
     test_names = runner.get_test_names()
+    uri = runner.get_package().uri
+
     if not test_names:
-        uri = runner.get_package().uri
         print("No tests found in %s" % uri, file=sys.stderr)
         sys.exit(0)
 
@@ -76,7 +77,16 @@ def command(opts, parser, extra_arg_groups=None):
     if opts.TEST:
         run_test_names = opts.TEST
     else:
-        run_test_names = test_names
+        # if no tests are explicitly specified, then run only those with a
+        # 'default' run_on tag
+        run_test_names = runner.get_test_names(run_on=["default"])
+
+        if not run_test_names:
+            print(
+                "No tests with 'default' run_on tag found in %s" % uri,
+                file=sys.stderr
+            )
+            sys.exit(0)
 
     for test_name in run_test_names:
         if not runner.stopped_on_fail:

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -14,6 +14,10 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "--nl", "--no-local", dest="no_local", action="store_true",
         help="don't load local packages")
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="dry-run mode: show what tests would have been run, but do not "
+        "run them")
     PKG_action = parser.add_argument(
         "--extra-packages", nargs='+', metavar="PKG",
         help="extra packages to add to test environment")
@@ -42,10 +46,13 @@ def command(opts, parser, extra_arg_groups=None):
         pkg_paths = opts.paths.split(os.pathsep)
         pkg_paths = [os.path.expanduser(x) for x in pkg_paths if x]
 
-    runner = PackageTestRunner(package_request=opts.PKG,
-                               package_paths=pkg_paths,
-                               extra_package_requests=opts.extra_packages,
-                               verbose=True)
+    runner = PackageTestRunner(
+        package_request=opts.PKG,
+        package_paths=pkg_paths,
+        extra_package_requests=opts.extra_packages,
+        dry_run=opts.dry_run,
+        verbose=True
+    )
 
     test_names = runner.get_test_names()
     if not test_names:

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -9,18 +9,21 @@ def setup_parser(parser, completions=False):
         "-l", "--list", action="store_true",
         help="list package's tests and exit")
     parser.add_argument(
+        "--dry-run", action="store_true",
+        help="dry-run mode: show what tests would have been run, but do not "
+        "run them")
+    parser.add_argument(
+        "-s", "--stop-on-fail", action="store_true",
+        help="stop on first test failure")
+    PKG_action = parser.add_argument(
+        "--extra-packages", nargs='+', metavar="PKG",
+        help="extra packages to add to test environment")
+    parser.add_argument(
         "--paths", type=str, default=None,
         help="set package search path")
     parser.add_argument(
         "--nl", "--no-local", dest="no_local", action="store_true",
         help="don't load local packages")
-    parser.add_argument(
-        "--dry-run", action="store_true",
-        help="dry-run mode: show what tests would have been run, but do not "
-        "run them")
-    PKG_action = parser.add_argument(
-        "--extra-packages", nargs='+', metavar="PKG",
-        help="extra packages to add to test environment")
     PKG_action = parser.add_argument(
         "PKG",
         help="package run tests on")
@@ -51,6 +54,7 @@ def command(opts, parser, extra_arg_groups=None):
         package_paths=pkg_paths,
         extra_package_requests=opts.extra_packages,
         dry_run=opts.dry_run,
+        stop_on_fail=opts.stop_on_fail,
         verbose=True
     )
 
@@ -70,7 +74,7 @@ def command(opts, parser, extra_arg_groups=None):
         run_test_names = test_names
 
     for test_name in run_test_names:
-        returncode = runner.run_test(test_name)
+        if not runner.stopped_on_fail:
+            runner.run_test(test_name)
 
-        if returncode:
-            sys.exit(returncode)
+    runner.print_summary()

--- a/src/rez/package_maker__.py
+++ b/src/rez/package_maker__.py
@@ -31,7 +31,13 @@ tests_schema = Schema({
         Or(basestring, [basestring]),
         {
             "command": Or(basestring, [basestring]),
-            Optional("requires"): [package_request_schema]
+            Optional("requires"): [package_request_schema],
+            Optional("on_variants"): Or(
+                bool,
+                {
+                    "requires": [package_request_schema]
+                }
+            )
         }
     )
 })

--- a/src/rez/package_maker__.py
+++ b/src/rez/package_maker__.py
@@ -32,6 +32,7 @@ tests_schema = Schema({
         {
             "command": Or(basestring, [basestring]),
             Optional("requires"): [package_request_schema],
+            Optional("run_on"): Or(basestring, [basestring]),
             Optional("on_variants"): Or(
                 bool,
                 {

--- a/src/rez/package_resources_.py
+++ b/src/rez/package_resources_.py
@@ -93,6 +93,7 @@ tests_schema = Schema({
             Optional("requires"): [
                 Or(PackageRequest, And(basestring, Use(PackageRequest)))
             ],
+            Optional("run_on"): Or(basestring, [basestring]),
             Optional("on_variants"): Or(
                 bool,
                 {

--- a/src/rez/package_resources_.py
+++ b/src/rez/package_resources_.py
@@ -92,7 +92,15 @@ tests_schema = Schema({
             "command": Or(basestring, [basestring]),
             Optional("requires"): [
                 Or(PackageRequest, And(basestring, Use(PackageRequest)))
-            ]
+            ],
+            Optional("on_variants"): Or(
+                bool,
+                {
+                    "requires": [
+                        Or(PackageRequest, And(basestring, Use(PackageRequest)))
+                    ]
+                }
+            )
         }
     )
 })

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -56,7 +56,13 @@ tests_schema = Schema({
         Or(basestring, [basestring]),
         {
             "command": Or(basestring, [basestring]),
-            Optional("requires"): [package_request_schema]
+            Optional("requires"): [package_request_schema],
+            Optional("on_variants"): Or(
+                bool,
+                {
+                    "requires": [package_request_schema]
+                }
+            )
         }
     )
 })

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -57,6 +57,7 @@ tests_schema = Schema({
         {
             "command": Or(basestring, [basestring]),
             Optional("requires"): [package_request_schema],
+            Optional("run_on"): Or(basestring, [basestring]),
             Optional("on_variants"): Or(
                 bool,
                 {

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -53,7 +53,7 @@ class PackageTestRunner(object):
     """
     def __init__(self, package_request, use_current_env=False,
                  extra_package_requests=None, package_paths=None, stdout=None,
-                 stderr=None, verbose=False, **context_kwargs):
+                 stderr=None, verbose=False, dry_run=False, **context_kwargs):
         """Create a package tester.
 
         Args:
@@ -68,6 +68,7 @@ class PackageTestRunner(object):
             stdout (file-like object): Defaults to sys.stdout.
             stderr (file-like object): Defaults to sys.stderr.
             verbose (bool): Verbose mode.
+            dry_run (bool): If True, do everything except actually run tests.
             context_kwargs: Extra arguments which are passed to the
                 `ResolvedContext` instances used to run the tests within.
                 Ignored if `use_current_env` is True.
@@ -78,6 +79,7 @@ class PackageTestRunner(object):
         self.stdout = stdout or sys.stdout
         self.stderr = stderr or sys.stderr
         self.verbose = verbose
+        self.dry_run = dry_run
         self.context_kwargs = context_kwargs
 
         self.package_paths = (config.packages_path if package_paths is None
@@ -208,6 +210,11 @@ class PackageTestRunner(object):
                     cmd_str = ' '.join(map(quote, command))
 
                 print_header("\nRunning test command: %s\n", cmd_str)
+
+            if self.dry_run:
+                print("(Skipped - dry-run mode is enabled)")
+                #continue
+                break
 
             retcode, _, _ = context.execute_shell(
                 command=command,

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1277,6 +1277,25 @@ class ResolvedContext(object):
         else:
             return p
 
+    @_on_success
+    def get_resolve_as_exact_requests(self):
+        """Convert to a package request list of exact resolved package versions.
+
+            >>> r = ResolvedContext(['foo']
+            >>> r.get_resolve_as_exact_requests()
+            ['foo==1.2.3', 'bah==1.0.1', 'python==2.7.12']
+
+        Returns:
+            `RequirementList`: Context as a list of exact version requirements.
+        """
+        def to_req(pkg):
+            if pkg.version:
+                return PackageRequest(pkg.name + "==" + str(pkg.version))
+            else:
+                return PackageRequest(pkg.name)
+
+        return map(to_req, self.resolved_packages)
+
     def to_dict(self, fields=None):
         """Convert context to dict containing only builtin types.
 

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.47.14"
+_rez_version = "2.48.0"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/wiki/pages/Package-Definition-Guide.md
+++ b/wiki/pages/Package-Definition-Guide.md
@@ -663,11 +663,15 @@ give you the latest possible version.
         "unit": "python -m unittest discover -s {root}/python/tests",
         "lint": {
             "command": "pylint mymodule",
-            "requires": ["pylint"]
+            "requires": ["pylint"],
+            "run_on": ["default", "pre_release"]
         },
-        "CI": {
+        "maya_CI": {
             "command": "python {root}/ci_tests/maya.py",
-            "requires": ["maya-2017"]
+            "on_variants": {
+                "requires": ["maya"]
+            },
+            "run_on": "explicit"
         }
     }
 
@@ -676,11 +680,25 @@ run a linter on the package *maya_utils* with the *test* attribute above, you wo
 
     ]$ rez-test maya_utils lint
 
-If a test entry is a string or list of strings, this is interpreted as the command to run. If you
-provide a nested dict, you can specify extra package requirements as well (in the *requires* key),
-and the command itself under *command*.
+If a test entry is a string or list of strings, this is interpreted as the command to run. Command
+strings will expand any references to package attributes, such as *{root}*.
 
-Command strings will expand any references to package attributes, such as *{root}*.
+If you provide a nested dict, you can specify extra fields per test, as follows:
+
+* **requires**: Extra package requirements to include in the test's runtime env.
+* **run_on**: When to run this test. Valid values are:
+  * `default` (the default): Run when `rez-test` is run with no `TEST` args specified.
+  * `pre_release`: Run before a release, and abort the release on fail.
+  * `explicit`: Only run if specified as `TEST` when `rez-test` is run.
+* **on_variants**: Which variants the test should be run on. Valid values are:
+  * True: Run the test on all variants.
+  * False (the default): Run the test only on one variant (ie the variant you get by
+    default when the test env is resolved). This is useful for tests like linting,
+    where variants are irrelevant.
+  * A dict containing a "requires" field. This is a variant selection mechanism. In the example
+    above, the "maya_CI" test will run only on those variants that directly require `maya` (or a
+    package within this range, eg `maya-2019`). (TODO add a "testing" page to the wiki, and link
+    to it from here).
 
 ### tools
 *List of string*


### PR DESCRIPTION
This updates rez-test behaviour wrt https://github.com/nerdvegas/rez/issues/665.

Not all of the REP is addressed here. This PR includes:

* addition of `run_on` tests field (however this is not fully acted on yet - pre_release does nothing atm)
* Addition of `--inplace` option, to run a test in the current env (if necessary requirements are present)
* Better handling of variant iteration (there was none previously), and a new `on_variants` tests field to give granular control over this.
* Updated wiki docs wrt `tests` package attrib.

Note: It would also make sense to have tests for the `PackageTestRunner` class. However I'd like to hold off until we port to `pytest` - I think it's going to be significantly simpler to do something like have a fixture for installing a set of packages into a fake fs. The way packages are built and tested on currently is haphazard and I'd rather not increase our technical debt for the sake of this fairly non-critical part of the code. https://github.com/nerdvegas/rez/issues/808.
