### PR TITLE
Rep001 2 hooks

### DIFF
--- a/src/rez/build_process_.py
+++ b/src/rez/build_process_.py
@@ -5,6 +5,7 @@ from rez.exceptions import BuildProcessError, BuildContextResolveError, \
     ReleaseHookCancellingError, RezError, ReleaseError, BuildError, \
     ReleaseVCSError
 from rez.utils.logging_ import print_warning
+from rez.utils.colorize import heading, Printer
 from rez.resolved_context import ResolvedContext
 from rez.release_hook import create_release_hooks
 from rez.resolver import ResolverStatus
@@ -14,6 +15,7 @@ from contextlib import contextmanager
 from pipes import quote
 import getpass
 import os.path
+import sys
 
 
 debug_print = config.debug_printer("package_release")
@@ -415,12 +417,13 @@ class BuildProcessHelper(BuildProcess):
 
         self._print('')
         if n <= 1:
-            self._print('-' * 80)
-            self._print(txt)
-            self._print('-' * 80)
+            br = '=' * 80
+            title = "%s\n%s\n%s" % (br, txt, br)
         else:
-            self._print(txt)
-            self._print('-' * len(txt))
+            title = "%s\n%s" % (txt, '-' * len(txt))
+
+        pr = Printer(sys.stdout)
+        pr(title, heading)
 
     def _n_of_m(self, variant):
         num_variants = max(self.package.num_variants, 1)

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -60,7 +60,7 @@ def command(opts, parser, extra_arg_groups=None):
         dry_run=opts.dry_run,
         stop_on_fail=opts.stop_on_fail,
         use_current_env=opts.inplace,
-        verbose=2
+        verbose=(3 if opts.verbose else 2)
     )
 
     test_names = runner.get_test_names()

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -92,5 +92,6 @@ def command(opts, parser, extra_arg_groups=None):
         if not runner.stopped_on_fail:
             runner.run_test(test_name)
 
+    print("\n")
     runner.print_summary()
-    print()
+    print('')

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -60,7 +60,7 @@ def command(opts, parser, extra_arg_groups=None):
         dry_run=opts.dry_run,
         stop_on_fail=opts.stop_on_fail,
         use_current_env=opts.inplace,
-        verbose=True
+        verbose=2
     )
 
     test_names = runner.get_test_names()
@@ -93,3 +93,4 @@ def command(opts, parser, extra_arg_groups=None):
             runner.run_test(test_name)
 
     runner.print_summary()
+    print()

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -46,6 +46,13 @@ def command(opts, parser, extra_arg_groups=None):
     import os.path
     import sys
 
+    # note that argparse doesn't support mutually exclusive arg groups
+    if opts.inplace and (opts.extra_packages or opts.paths or opts.no_local):
+        parser.error(
+            "Cannot use --inplace in combination with "
+            "--extra-packages/--paths/--no-local"
+        )
+
     if opts.paths is None:
         pkg_paths = (config.nonlocal_packages_path
                      if opts.no_local else None)
@@ -53,6 +60,7 @@ def command(opts, parser, extra_arg_groups=None):
         pkg_paths = opts.paths.split(os.pathsep)
         pkg_paths = [os.path.expanduser(x) for x in pkg_paths if x]
 
+    # run test(s)
     runner = PackageTestRunner(
         package_request=opts.PKG,
         package_paths=pkg_paths,
@@ -60,7 +68,7 @@ def command(opts, parser, extra_arg_groups=None):
         dry_run=opts.dry_run,
         stop_on_fail=opts.stop_on_fail,
         use_current_env=opts.inplace,
-        verbose=(3 if opts.verbose else 2)
+        verbose=2
     )
 
     test_names = runner.get_test_names()
@@ -71,6 +79,9 @@ def command(opts, parser, extra_arg_groups=None):
         sys.exit(0)
 
     if opts.list:
+        if sys.stdout.isatty():
+            print("Tests defined in %s:" % uri)
+
         print('\n'.join(test_names))
         sys.exit(0)
 
@@ -88,10 +99,16 @@ def command(opts, parser, extra_arg_groups=None):
             )
             sys.exit(0)
 
+    exitcode = 0
+
     for test_name in run_test_names:
         if not runner.stopped_on_fail:
-            runner.run_test(test_name)
+            ret = runner.run_test(test_name)
+            if ret and not exitcode:
+                exitcode = ret
 
     print("\n")
     runner.print_summary()
     print('')
+
+    sys.exit(exitcode)

--- a/src/rez/package_maker__.py
+++ b/src/rez/package_maker__.py
@@ -36,7 +36,8 @@ tests_schema = Schema({
             Optional("on_variants"): Or(
                 bool,
                 {
-                    "requires": [package_request_schema]
+                    "type": "requires",
+                    "value": [package_request_schema]
                 }
             )
         })

--- a/src/rez/package_maker__.py
+++ b/src/rez/package_maker__.py
@@ -1,5 +1,5 @@
 from rez.utils._version import _rez_version
-from rez.utils.schema import Required, schema_keys
+from rez.utils.schema import Required, schema_keys, extensible_schema_dict
 from rez.utils.filesystem import retain_cwd
 from rez.utils.formatting import PackageRequest
 from rez.utils.data_utils import AttrDictWrapper
@@ -29,7 +29,7 @@ package_request_schema = Or(And(basestring, Use(expand_requirement)),
 tests_schema = Schema({
     Optional(basestring): Or(
         Or(basestring, [basestring]),
-        {
+        extensible_schema_dict({
             "command": Or(basestring, [basestring]),
             Optional("requires"): [package_request_schema],
             Optional("run_on"): Or(basestring, [basestring]),
@@ -39,7 +39,7 @@ tests_schema = Schema({
                     "requires": [package_request_schema]
                 }
             )
-        }
+        })
     )
 })
 

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -175,6 +175,24 @@ class PackageRepository(object):
 
         If any directories are created on disk for the variant to install into,
         this is called before that happens.
+
+        Note that it is the responsibility of the `BuildProcess` to call this
+        function at the appropriate time.
+        """
+        pass
+
+    def on_variant_install_cancelled(self, variant_resource):
+        """Called when a variant installation is cancelled.
+
+        This is called after `pre_variant_install`, but before `install_variant`,
+        which is not expected to be called.
+
+        Variant install cancellation usually happens for one of two reasons -
+        either the variant installation failed (ie a build error occurred), or
+        one or more of the package tests failed, aborting the installation.
+
+        Note that it is the responsibility of the `BuildProcess` to call this
+        function at the appropriate time.
         """
         pass
 

--- a/src/rez/package_resources_.py
+++ b/src/rez/package_resources_.py
@@ -97,7 +97,8 @@ tests_schema = Schema({
             Optional("on_variants"): Or(
                 bool,
                 {
-                    "requires": [
+                    "type": "requires",
+                    "value": [
                         Or(PackageRequest, And(basestring, Use(PackageRequest)))
                     ]
                 }

--- a/src/rez/package_resources_.py
+++ b/src/rez/package_resources_.py
@@ -1,5 +1,5 @@
 from rez.utils.resources import Resource
-from rez.utils.schema import Required, schema_keys
+from rez.utils.schema import Required, schema_keys, extensible_schema_dict
 from rez.utils.logging_ import print_warning
 from rez.utils.sourcecode import SourceCode
 from rez.utils.data_utils import cached_property, AttributeForwardMeta, \
@@ -88,7 +88,7 @@ package_family_schema_dict = base_resource_schema_dict.copy()
 tests_schema = Schema({
     Optional(basestring): Or(
         Or(basestring, [basestring]),
-        {
+        extensible_schema_dict({
             "command": Or(basestring, [basestring]),
             Optional("requires"): [
                 Or(PackageRequest, And(basestring, Use(PackageRequest)))
@@ -102,7 +102,7 @@ tests_schema = Schema({
                     ]
                 }
             )
-        }
+        })
     )
 })
 

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -5,6 +5,7 @@ from rez.serialise import FileFormat
 from rez.package_resources_ import help_schema, late_bound
 from rez.vendor.schema.schema import Schema, Optional, And, Or, Use
 from rez.vendor.version.version import Version
+from rez.utils.schema import extensible_schema_dict
 from rez.utils.sourcecode import SourceCode
 from rez.utils.formatting import PackageRequest, indent, \
     dict_to_attributes_code, as_block_string
@@ -54,7 +55,7 @@ source_code_schema = Or(SourceCode, And(basestring, Use(SourceCode)))
 tests_schema = Schema({
     Optional(basestring): Or(
         Or(basestring, [basestring]),
-        {
+        extensible_schema_dict({
             "command": Or(basestring, [basestring]),
             Optional("requires"): [package_request_schema],
             Optional("run_on"): Or(basestring, [basestring]),
@@ -64,7 +65,7 @@ tests_schema = Schema({
                     "requires": [package_request_schema]
                 }
             )
-        }
+        })
     )
 })
 

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -62,7 +62,8 @@ tests_schema = Schema({
             Optional("on_variants"): Or(
                 bool,
                 {
-                    "requires": [package_request_schema]
+                    "type": "requires",
+                    "value": [package_request_schema]
                 }
             )
         })

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -360,14 +360,14 @@ class PackageTestRunner(object):
             if self.verbose:
                 if self.verbose > 1:
                     context.print_info(self.stdout)
-                    print()
+                    print('')
 
                 if isinstance(command, basestring):
                     cmd_str = command
                 else:
                     cmd_str = ' '.join(map(quote, command))
 
-                self._print_header("Running test command: %s\n", cmd_str)
+                self._print_header("Running test command: %s", cmd_str)
 
             if self.dry_run:
                 self._set_test_result(
@@ -415,7 +415,7 @@ class PackageTestRunner(object):
         from rez.utils.formatting import columnise
 
         self._print_header(
-            "\n\nResults:\n%s",
+            "Test results:\n%s",
             '-' * 80
         )
 

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -211,7 +211,7 @@ class PackageTestRunner(object):
         if package is None:
             return []
 
-        return self.get_package_test_names(package)
+        return self.get_package_test_names(package, run_on=run_on)
 
     @property
     def num_tests(self):

--- a/src/rez/packages_.py
+++ b/src/rez/packages_.py
@@ -227,6 +227,15 @@ class Package(PackageBaseResourceWrapper):
         o = VersionedObject.construct(self.name, self.version)
         return str(o)
 
+    def as_exact_requirement(self):
+        """Get the package, as an exact requirement string.
+
+        Returns:
+            Equivalent requirement string, eg "maya==2016.1"
+        """
+        o = VersionedObject.construct(self.name, self.version)
+        return o.as_exact_requirement()
+
     @cached_property
     def parent(self):
         """Get the parent package family.

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1286,13 +1286,11 @@ class ResolvedContext(object):
             ['foo==1.2.3', 'bah==1.0.1', 'python==2.7.12']
 
         Returns:
-            `RequirementList`: Context as a list of exact version requirements.
+            List of `PackageRequest`: Context as a list of exact version
+            requests.
         """
-        def to_req(pkg):
-            if pkg.version:
-                return PackageRequest(pkg.name + "==" + str(pkg.version))
-            else:
-                return PackageRequest(pkg.name)
+        def to_req(variant):
+            return PackageRequest(variant.parent.as_exact_requirement())
 
         return map(to_req, self.resolved_packages)
 

--- a/src/rez/resolver.py
+++ b/src/rez/resolver.py
@@ -1,5 +1,5 @@
 from rez.solver import Solver, SolverStatus, PackageVariantCache
-from rez.package_repository import PackageRepositoryManager, package_repository_manager
+from rez.package_repository import package_repository_manager
 from rez.packages_ import get_variant, get_last_release_time
 from rez.package_filter import PackageFilterList, TimestampRule
 from rez.utils.memcached import memcached_client, pool_memcached_connections
@@ -32,10 +32,9 @@ class Resolver(object):
     package request as quickly as possible.
     """
     def __init__(self, context, package_requests, package_paths, package_filter=None,
-                 resource_pool=None, package_orderers=None, timestamp=0,
-                 callback=None, building=False, verbosity=False, buf=None,
-                 package_load_callback=None, caching=True, suppress_passive=False,
-                 print_stats=False):
+                 package_orderers=None, timestamp=0, callback=None, building=False,
+                 verbosity=False, buf=None, package_load_callback=None, caching=True,
+                 suppress_passive=False, print_stats=False):
         """Create a Resolver.
 
         Args:
@@ -43,9 +42,6 @@ class Resolver(object):
                 request.
             package_paths: List of paths to search for pkgs.
             package_filter (`PackageFilterList`): Package filter.
-            resource_pool (`ResourcePool`): Provide this
-                if you need to perform a resolve that does not alter the global
-                resource cache.
             package_orderers (list of `PackageOrder`): Custom package ordering.
             callback: See `Solver`.
             package_load_callback: If not None, this callable will be called
@@ -69,14 +65,6 @@ class Resolver(object):
         self.buf = buf
         self.suppress_passive = suppress_passive
         self.print_stats = print_stats
-
-        if resource_pool:
-            # use a local repo manager
-            self.package_repository_manager = \
-                PackageRepositoryManager(resource_pool=resource_pool)
-        else:
-            # use global resource pool + repo manager
-            self.package_repository_manager = package_repository_manager
 
         # store hash of package orderers. This is used in the memcached key
         if package_orderers:
@@ -372,7 +360,7 @@ class Resolver(object):
         request = tuple(map(str, self.package_requests))
         repo_ids = []
         for path in self.package_paths:
-            repo = self.package_repository_manager.get_repository(path)
+            repo = package_repository_manager.get_repository(path)
             repo_ids.append(repo.uid)
 
         t = ["resolve",

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.49.0"
+_rez_version = "2.49.1"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.48.0"
+_rez_version = "2.49.0"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/utils/schema.py
+++ b/src/rez/utils/schema.py
@@ -2,7 +2,7 @@
 Utilities for working with dict-based schemas.
 """
 from rez.vendor.six import six
-from rez.vendor.schema.schema import Schema, Optional, Use, And
+from rez.vendor.schema.schema import Schema, Optional, Use, And, Optional
 
 
 basestring = six.string_types[0]
@@ -74,6 +74,20 @@ def dict_to_schema(schema_dict, required, allow_custom_keys=True, modifier=None)
         return schema
 
     return _to(schema_dict)
+
+
+def extensible_schema_dict(schema_dict):
+    """Create schema dict that allows arbitrary extra keys.
+
+    This helps to keep newer configs or package definitions compatible with
+    older rez versions, that may not support newer schema fields.
+    """
+    result = {
+        Optional(basestring): object
+    }
+
+    result.update(schema_dict)
+    return result
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/vendor/version/requirement.py
+++ b/src/rez/vendor/version/requirement.py
@@ -56,6 +56,19 @@ class VersionedObject(_Common):
         """Version of the object."""
         return self.version_
 
+    def as_exact_requirement(self):
+        """Get the versioned object, as an exact requirement string.
+
+        Returns:
+            Equivalent requirement string, eg "maya==2016.1"
+        """
+        sep_str = ''
+        ver_str = ''
+        if self.version_:
+            sep_str = "=="
+            ver_str = str(self.version_)
+        return self.name_ + sep_str + ver_str
+
     def __eq__(self, other):
         return (isinstance(other, VersionedObject)
                 and (self.name_ == other.name_)

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -482,7 +482,11 @@ class LocalBuildProcess(BuildProcessHelper):
             runner.print_summary()
 
         if runner.num_failed:
-            raise PackageTestError("%d tests failed" % runner.num_failed)
+            print('')
+            raise PackageTestError(
+                "%d tests failed; the installation has been cancelled"
+                % runner.num_failed
+            )
 
 
 def register_plugin():

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -251,7 +251,7 @@ class LocalBuildProcess(BuildProcessHelper):
             if not build_result.get("success"):
                 # delete the possibly partially installed variant payload
                 if install:
-                    self._rmtree(build_result["variant_install_path"])
+                    self._rmtree(variant_install_path)
 
                 raise BuildError("The %s build system failed." % build_system_name)
 

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -307,8 +307,8 @@ class LocalBuildProcess(BuildProcessHelper):
     def _rmtree(self, path):
         try:
             shutil.rmtree(path)
-        except e:
-            print_warning("Failed to delete %s", path)
+        except Exception as e:
+            print_warning("Failed to delete %s - %s", path, e)
 
     def _build_variant(self, variant, install_path=None, clean=False,
                        install=False, **kwargs):

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -571,6 +571,27 @@ class FileSystemPackageRepository(PackageRepository):
         with open(filepath, 'w'):  # create empty file
             pass
 
+    def on_variant_install_cancelled(self, variant_resource):
+        """
+        TODO:
+            Currently this will not delete a newly created package version
+            directory. The reason is because behaviour with multiple rez procs
+            installing variants of the same package in parallel is not well
+            tested and hasn't been fully designed for yet. Currently, if this
+            did delete the version directory, it could delete it while another
+            proc is performing a successful variant install into the same dir.
+
+            Note though that this does do useful work, if the cancelled variant
+            was getting installed into an existing package. In this case, the
+            .building file is deleted, because the existing package.py is valid.
+
+            Work has to be done to change the way that new variant dirs and the
+            .building file are created, so that we can safely delete cancelled
+            variant dirs in the presence of multiple rez procs.
+        """
+        family_path = os.path.join(self.location, variant_resource.name)
+        self._delete_stale_build_tagfiles(family_path)
+
     def install_variant(self, variant_resource, dry_run=False, overrides=None):
         overrides = overrides or {}
 

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -153,7 +153,13 @@ class FileSystemPackageResource(PackageResourceHelper):
 
     @property
     def base(self):
-        return self.path
+        # Note: '_redirected_base' is a special attribute set by the build
+        # process in order to perform pre-install/release package testing. See
+        # `LocalBuildProcess._run_tests()`
+        #
+        redirected_base = self._data.get("_redirected_base")
+
+        return redirected_base or self.path
 
     @cached_property
     def path(self):

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -588,6 +588,8 @@ class FileSystemPackageRepository(PackageRepository):
             Work has to be done to change the way that new variant dirs and the
             .building file are created, so that we can safely delete cancelled
             variant dirs in the presence of multiple rez procs.
+
+            See https://github.com/nerdvegas/rez/issues/810
         """
         family_path = os.path.join(self.location, variant_resource.name)
         self._delete_stale_build_tagfiles(family_path)

--- a/wiki/pages/Package-Definition-Guide.md
+++ b/wiki/pages/Package-Definition-Guide.md
@@ -688,7 +688,7 @@ If you provide a nested dict, you can specify extra fields per test, as follows:
 * **requires**: Extra package requirements to include in the test's runtime env.
 * **run_on**: When to run this test. Valid values are:
   * `default` (the default): Run when `rez-test` is run with no `TEST` args specified.
-  # `pre_install`: Run before an install (ie `rez-build -i`), and abort the install on fail.
+  * `pre_install`: Run before an install (ie `rez-build -i`), and abort the install on fail.
   * `pre_release`: Run before a release, and abort the release on fail.
   * `explicit`: Only run if specified as `TEST` when `rez-test` is run.
 * **on_variants**: Which variants the test should be run on. Valid values are:

--- a/wiki/pages/Package-Definition-Guide.md
+++ b/wiki/pages/Package-Definition-Guide.md
@@ -688,13 +688,14 @@ If you provide a nested dict, you can specify extra fields per test, as follows:
 * **requires**: Extra package requirements to include in the test's runtime env.
 * **run_on**: When to run this test. Valid values are:
   * `default` (the default): Run when `rez-test` is run with no `TEST` args specified.
+  # `pre_install`: Run before an install (ie `rez-build -i`), and abort the install on fail.
   * `pre_release`: Run before a release, and abort the release on fail.
   * `explicit`: Only run if specified as `TEST` when `rez-test` is run.
 * **on_variants**: Which variants the test should be run on. Valid values are:
   * True: Run the test on all variants.
   * False (the default): Run the test only on one variant (ie the variant you get by
     default when the test env is resolved). This is useful for tests like linting,
-    where variants are irrelevant.
+    where variants may be irrelevant.
   * A dict containing a "requires" field. This is a variant selection mechanism. In the example
     above, the "maya_CI" test will run only on those variants that directly require `maya` (or a
     package within this range, eg `maya-2019`). (TODO add a "testing" page to the wiki, and link

--- a/wiki/pages/Package-Definition-Guide.md
+++ b/wiki/pages/Package-Definition-Guide.md
@@ -669,7 +669,8 @@ give you the latest possible version.
         "maya_CI": {
             "command": "python {root}/ci_tests/maya.py",
             "on_variants": {
-                "requires": ["maya"]
+                "type": "requires",
+                "value": ["maya"]
             },
             "run_on": "explicit"
         }
@@ -696,10 +697,9 @@ If you provide a nested dict, you can specify extra fields per test, as follows:
   * False (the default): Run the test only on one variant (ie the variant you get by
     default when the test env is resolved). This is useful for tests like linting,
     where variants may be irrelevant.
-  * A dict containing a "requires" field. This is a variant selection mechanism. In the example
-    above, the "maya_CI" test will run only on those variants that directly require `maya` (or a
-    package within this range, eg `maya-2019`). (TODO add a "testing" page to the wiki, and link
-    to it from here).
+  * A dict. This is a variant selection mechanism. In the example above, the "maya_CI" test will
+    run only on those variants that directly require `maya` (or a package within this range, eg
+    `maya-2019`). Note that "requires" is the only filter type currently available.
 
 ### tools
 *List of string*


### PR DESCRIPTION
Implements pre-install/release running of package tests.

Note that this is not done as a pre-release hook plugin, because the way this works doesn't match up to the places in which these hooks are run.

The way pre-install (and release) tests are run is like so:

* variant (ie its payload) is installed to correct location (package.py is not yet updated)
* separate temp package is created, containing just the installed variant
* this tmp pkg uses a new internal attrib (`_redirected_base`) to point back to the true package install location
* the tests are run on this temp pkg
* if tests fail, true variant payload is deleted
* if tests succeed, package.py is then updated as per usual, and new variant becomes visible.

Note that https://github.com/nerdvegas/rez/pull/807 must be merged before this PR.

