### PR TITLE
Bug/819 enable colorization on windows

### DIFF
--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -793,6 +793,13 @@ documentation_url = " http://nerdvegas.github.io/rez/"
 # When force is used, will generally be set through an environment variable, eg:
 #
 #     echo $(REZ_COLOR_ENABLED=force python -c "from rez.utils.colorize import Printer, local; Printer()('foo', local)")
+
+# TODO: Colorama is documented to work on Windows and trivial test case
+# proves this to be the case, but it doesn't work in Rez (with cmd.exe).
+# If the initialise is called in sec/rez/__init__.py then it does work,
+# however this is not always desirable.
+# As it does with with some Windows shells it can be enabled in rezconfig
+
 color_enabled = (os.name == "posix")
 
 ### Do not move or delete this comment (__DOC_END__)

--- a/src/rez/utils/colorize.py
+++ b/src/rez/utils/colorize.py
@@ -193,12 +193,7 @@ def _color(str_, fore_color=None, back_color=None, styles=None):
     .. _Colorama:
         https://pypi.python.org/pypi/colorama
     """
-    # TODO: Colorama is documented to work on Windows and trivial test case
-    # proves this to be the case, but it doesn't work in Rez.  If the initialise
-    # is called in sec/rez/__init__.py then it does work, however as discussed
-    # in the following comment this is not always desirable.  So until we can
-    # work out why we forcibly turn it off.
-    if not config.get("color_enabled", False) or platform_.name == "windows":
+    if not config.get("color_enabled", False):
         return str_
 
     # lazily init colorama. This is important - we don't want to init at startup,


### PR DESCRIPTION
Closes #819 

As outlined in the issue this pr removes the windows exceptions from colorize.py and instead only relies on the default in rezconfig.py to disable color on windows. In turn it can be turned on if desired (e.g. when using Windows Terminal or Powershell).