### PR TITLE
[Feature] Add rez-pip extra args passthrough

### DIFF
--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -2,6 +2,7 @@
 Install a pip-compatible python package, and its dependencies, as rez packages.
 """
 from __future__ import print_function
+from argparse import REMAINDER
 
 
 def setup_parser(parser, completions=False):
@@ -30,7 +31,10 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "PACKAGE",
         help="package to install or archive/url to install from")
-
+    parser.add_argument(
+        "-e", "--extra", nargs=REMAINDER,
+        help="extra args passthrough to pip install"
+    )
 
 def command(opts, parser, extra_arg_groups=None):
     from rez.pip import pip_install_package, run_pip_command
@@ -59,7 +63,8 @@ def command(opts, parser, extra_arg_groups=None):
         pip_version=opts.pip_ver,
         python_version=opts.py_ver,
         release=opts.release,
-        prefix=opts.prefix)
+        prefix=opts.prefix,
+        extra_args=opts.extra)
 
     # print summary
     #

--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -33,7 +33,7 @@ def setup_parser(parser, completions=False):
         help="package to install or archive/url to install from")
     parser.add_argument(
         "-e", "--extra", nargs=REMAINDER,
-        help="extra args passthrough to pip install"
+        help="extra args passthrough to pip install (overrides pre-configured args if specified)"
     )
 
 def command(opts, parser, extra_arg_groups=None):

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -308,6 +308,7 @@ config_schema = Schema({
     "implicit_styles":                              OptionalStrList,
     "alias_styles":                                 OptionalStrList,
     "memcached_uri":                                OptionalStrList,
+    "pip_extra_args":                               OptionalStrList,
     "local_packages_path":                          Str,
     "release_packages_path":                        Str,
     "dot_image_format":                             Str,

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -251,17 +251,29 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
         context.print_info(buf)
         _log(buf.getvalue())
 
+    # preconfigured options
+    pre_configured = ["--use-pep517", "--target=%s" % destpath]
+
     # gather additional pip install options
     pip_extra_opts = extra_args if extra_args else config.pip_extra_args
 
+    # make sure that the target option is overridden if supplied
+    if any("--target=" in opt for opt in pip_extra_opts):
+        # extra args redefines the target option so ignore pre-configured one
+        pre_configured = pre_configured[0:1]
+    # disable pep517 if forced
+    if "--no-use-pep517" in pip_extra_opts:
+        pre_configured = []
+
+    # keep unique opts
+    opts = list(set(pre_configured + pip_extra_opts))
+
     # Build pip commandline
     cmd = [
-        py_exe, "-m", "pip", "install",
-        "--use-pep517",
-        "--target=%s" % destpath
+        py_exe, "-m", "pip", "install"
     ]
 
-    cmd.extend(pip_extra_opts)
+    cmd.extend(opts)
 
     if mode == InstallMode.no_deps:
         cmd.append("--no-deps")

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -198,7 +198,8 @@ def find_pip_from_context(python_version, pip_version=None):
 
 
 def pip_install_package(source_name, pip_version=None, python_version=None,
-                        mode=InstallMode.min_deps, release=False, prefix=None):
+                        mode=InstallMode.min_deps, release=False, prefix=None,
+                        extra_args=None):
     """Install a pip-compatible python package as a rez package.
     Args:
         source_name (str): Name of package or archive/url containing the pip
@@ -212,6 +213,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
             managed.
         release (bool): If True, install as a released package; otherwise, it
             will be installed as a local package.
+        extra_args (List[str]): Additional options to the pip install command.
 
     Returns:
         2-tuple:
@@ -249,12 +251,17 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
         context.print_info(buf)
         _log(buf.getvalue())
 
+    # gather additional pip install options
+    pip_extra_opts = extra_args if extra_args else config.pip_extra_args
+
     # Build pip commandline
     cmd = [
         py_exe, "-m", "pip", "install",
         "--use-pep517",
         "--target=%s" % destpath
     ]
+
+    cmd.extend(pip_extra_opts)
 
     if mode == InstallMode.no_deps:
         cmd.append("--no-deps")

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -695,6 +695,11 @@ max_package_changelog_revisions = 0
 create_executable_script_mode = "single"
 
 # Configurable pip extra arguments passed to the rez-pip install command.
+# Since the rez-pip install command already includes some pre-configured
+# arguments (target, use-pep517) this setting can potentially override the
+# default configuration in a way which can cause package installation issues.
+# It is recommended to refrain from overriding the default arguments and only
+# use this setting for additional arguments that might be needed.
 # https://pip.pypa.io/en/stable/reference/pip_install/#options
 pip_extra_args = []
 

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -694,6 +694,10 @@ max_package_changelog_revisions = 0
 #       launched without extension from windows and other systems.
 create_executable_script_mode = "single"
 
+# Configurable pip extra arguments passed to the rez-pip install command.
+# https://pip.pypa.io/en/stable/reference/pip_install/#options
+pip_extra_args = []
+
 
 ###############################################################################
 # Rez-1 Compatibility


### PR DESCRIPTION
# Description

closes #816 

Enable users to customize the `pip install` command by explicitly defining additional settings to be passed to *rez-pip* in the form of [extra options](https://pip.pypa.io/en/stable/reference/pip_install/#options). Extra arguments can be defined either by using the new *rez-pip* cli argument `[-e/--extra..]` or by adding items to the new *rezconfig* entry `pip_extra_args` in the form of:

```
pip_extra_args: ["--no-compile", "--prefer-binary"]
```

Implementation is based on the ticket above and the discussion between JC, Thorsten and Allan up on slack.

## Breakdown

* Add new rez-pip argument -e/--extra to pass additional options to pip install command
* Additional options can be defined in a rezconfig file entry pip_extra_args to ensure they are always applied
* The command line argument -e/--extra overrides the configuration file options (if any)
* Repeating options automatically override previous one by pip (without extra processing) only last one counts
* Invalid options are handled by pip (no extra care was taken to prevent them)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Possible issues

As discussed [below](https://github.com/nerdvegas/rez/pull/827#discussion_r363997813) regarding repeating options since through extra args the user can override the target and use pep517 options which are prerequisites for correct package install we will need to handle that scenario somehow.

The way I see it there are two methods:

~a. Always ignore the target option and anything that can affect use pep517 such as no-binary etc~
~b. Have a list of allowed options that can be handled by extra args (filter out invalid ones)~

**Edit:**

It has been agreed to assume user responsibility for overriding the wrong options. It needs to be made clear that extra args adds to or overrides the pre-configured args.

# How Has This Been Tested?

* Tried defining multiple option combinations between CLI and rezconfig
* I will look into the test-suite and see if I can add tests if they already exist for other commands

**Test Configuration**:
* Python version: 2.7.17, 3.8
* OS: Linux, Windows 10
* Toolchain: rez 2.50.0, pip 19.3.1

## Demo

* rez-pip cli -e --extra argument

![pip_cli_extra_args_demo](https://user-images.githubusercontent.com/47409392/71046761-a1a7a000-217c-11ea-9273-cc5132eac523.gif)


* rez-pip cli extra args via rezconfig

![pip_cli_extra_args_conf_demo](https://user-images.githubusercontent.com/47409392/71046799-c734a980-217c-11ea-83d9-c493ea06f006.gif)

## Changelog

## Point release
[Source](https://github.com/nerdvegas/rez/tree/2.50.0) | [Diff](https://github.com/nerdvegas/rez/compare/master...lambdaclan:feature/rez-pip-extra-args-passthrough?expand=1)

**Notes**

Add rez-pip extra args passthrough

**Merged pull requests:**

- [Feature] Add rez-pip extra args passthrough [\#827](https://github.com/nerdvegas/rez/pull/827) ([lambdaclan](https://github.com/lambdaclan))

**Closed issues:**

- rez-pip creates .pyc files by default [\#816](https://github.com/nerdvegas/rez/issues/816)