### PR TITLE
Fall back to nerdvegas Windows Docker Image

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -26,8 +26,11 @@ on:
 jobs:
   main:
     runs-on: windows-2019
+    env:
+      IMAGE_NAME_FILE: ImageNameFile.txt
 
     strategy:
+
       matrix:
         # Needs to match python version of images (see windows-docker-image.yaml)
         python-version:
@@ -37,6 +40,7 @@ jobs:
       fail-fast: false
 
     steps:
+
       - name: Checkout
         uses: actions/checkout@v1
 
@@ -44,11 +48,25 @@ jobs:
         run: |
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          echo "Pulling rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}"
-          docker pull ${gh_user}/rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}
+          ${docker_image} = "${gh_user}/rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}"
+          Write-Output "Pulling ${docker_image}"
+          
+          $ErrorActionPreference = "Continue"
+          docker pull ${docker_image}
+          
+          $ErrorActionPreference = "Stop"
+          if ($LastExitCode -ne 0) {
+            Write-Output "Trying with nerdvegas instead of ${gh_user}."
+            ${docker_image} = ${docker_image}.Replace(${gh_user}, "nerdvegas")
+            
+            Write-Output "Pulling ${docker_image}"
+            docker pull ${docker_image}
+          }
+          
+          ${docker_image} > '${{ env.IMAGE_NAME_FILE }}'
 
       - name: Run Docker image (installs and tests rez)
         run: |
-          ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${gh_user}/rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}
+          ${docker_image} = Get-Content '${{ env.IMAGE_NAME_FILE }}'
+          Write-Output "Running ${docker_image}..."
+          docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -27,7 +27,9 @@ jobs:
   main:
     runs-on: windows-2019
     env:
-      IMAGE_NAME_FILE: ImageNameFile.txt
+      # DockerHub base image name. May switch to GitHub Docker Packages
+      # in the future. See GitHub Issue #789 and PR #830
+      BASE_IMAGE_NAME: "nerdvegas/rez-win-py:${{ matrix.python-version }}"
 
     strategy:
 
@@ -44,29 +46,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Pull docker image
-        run: |
-          ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          ${docker_image} = "${gh_user}/rez-win-py:${{ matrix.python-version }}-${Env:LAST_DOCKER_REVISION}"
-          Write-Output "Pulling ${docker_image}"
-          
-          $ErrorActionPreference = "Continue"
-          docker pull ${docker_image}
-          
-          $ErrorActionPreference = "Stop"
-          if ($LastExitCode -ne 0) {
-            Write-Output "Trying with nerdvegas instead of ${gh_user}."
-            ${docker_image} = ${docker_image}.Replace(${gh_user}, "nerdvegas")
-            
-            Write-Output "Pulling ${docker_image}"
-            docker pull ${docker_image}
-          }
-          
-          ${docker_image} > '${{ env.IMAGE_NAME_FILE }}'
-
       - name: Run Docker image (installs and tests rez)
         run: |
-          ${docker_image} = Get-Content '${{ env.IMAGE_NAME_FILE }}'
-          Write-Output "Running ${docker_image}..."
+          ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+          ${docker_image} = "${{ Env.BASE_IMAGE_NAME }}-${Env:LAST_DOCKER_REVISION}"
+
+          Write-Output "Running DockerHub ${docker_image}..."
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}


### PR DESCRIPTION
Fixes Windows CI tests failing on forked repositories where `${gh_user}`, e.g. `wwfxuk`, does not have a DockerHub image available.

For example, from #749 for commit cee7216

- [![][nerdvegas-badge]][nerdvegas-actions] nerdvegas  runs https://github.com/nerdvegas/rez/runs/379212610
- [![][wwfxuk-badge]][wwfxuk-actions] wwfxuk's run https://github.com/wwfxuk/rez/runs/379212678

[wwfxuk-badge]: https://github.com/wwfxuk/rez/workflows/Windows/badge.svg?branch=docs%2Fpip-install
[wwfxuk-actions]: https://github.com/wwfxuk/rez/actions?query=workflow%3AWindows+branch%3Adocs%2Fpip-install


[nerdvegas-badge]: https://github.com/nerdvegas/rez/workflows/Windows/badge.svg?branch=docs%2Fpip-install
[nerdvegas-actions]: https://github.com/nerdvegas/rez/actions?query=workflow%3AWindows+branch%3Adocs%2Fpip-install

Here is this branch's Windows CI on:

- [![][nerdvegas-this-badge]][nerdvegas-this-actions] nerdvegas  runs https://github.com/nerdvegas/rez/runs/379578231
- [![][wwfxuk-this-badge]][wwfxuk-this-actions] wwfxuk runs https://github.com/wwfxuk/rez/runs/379552284

[wwfxuk-this-badge]: https://github.com/wwfxuk/rez/workflows/Windows/badge.svg?branch=testing-windows-ci-docker
[wwfxuk-this-actions]: https://github.com/wwfxuk/rez/actions?query=workflow%3AWindows+branch%3Atesting-windows-ci-docker
[nerdvegas-this-badge]: https://github.com/nerdvegas/rez/workflows/Windows/badge.svg?branch=testing-windows-ci-docker
[nerdvegas-this-actions]: https://github.com/nerdvegas/rez/actions?query=workflow%3AWindows+branch%3Atesting-windows-ci-docker


