### PR TITLE
PR: Fix "StringIO" imports and accesses.

### DIFF
--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -161,7 +161,7 @@ class RezPluginType(object):
                     self.failed_plugins[nameish] = str(e)
                     if config.debug("plugins"):
                         import traceback
-                        from StringIO import StringIO
+                        from rez.vendor.six.six import StringIO
                         out = StringIO()
                         traceback.print_exc(file=out)
                         print_debug(out.getvalue())

--- a/src/rezgui/dialogs/ResolveDialog.py
+++ b/src/rezgui/dialogs/ResolveDialog.py
@@ -274,7 +274,7 @@ class ResolveDialog(QtWidgets.QDialog, StoreSizeMixin):
 
         if self.resolver.success():
             if self.advanced:
-                sbuf = StringIO.StringIO()
+                sbuf = StringIO()
                 self.resolver.context.print_info(buf=sbuf)
                 msg = "\nTHE RESOLVE SUCCEEDED:\n\n"
                 msg += sbuf.getvalue()

--- a/src/rezgui/dialogs/ResolveDialog.py
+++ b/src/rezgui/dialogs/ResolveDialog.py
@@ -6,9 +6,9 @@ from rezgui.widgets.TimestampWidget import TimestampWidget
 from rezgui.dialogs.WriteGraphDialog import view_graph
 from rezgui.objects.ResolveThread import ResolveThread
 from rezgui.objects.App import app
+from rez.vendor.six.six import StringIO
 from rez.vendor.version.requirement import Requirement
 from rez.config import config
-import StringIO
 
 
 class ResolveDialog(QtWidgets.QDialog, StoreSizeMixin):


### PR DESCRIPTION
This fixes the `ImportError` exception raised when trying to launch `rez-gui` under Python 3: https://github.com/nerdvegas/rez/issues/848 and an incorrect access.

Cheers,

Thomas