### PR TITLE
PR: Use "QtCompat" to handle "QHeaderView" incompatibilities and fix broken "resolve" button in "rez-gui".

### DIFF
--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -161,7 +161,7 @@ class RezPluginType(object):
                     self.failed_plugins[nameish] = str(e)
                     if config.debug("plugins"):
                         import traceback
-                        from StringIO import StringIO
+                        from rez.vendor.six.six import StringIO
                         out = StringIO()
                         traceback.print_exc(file=out)
                         print_debug(out.getvalue())

--- a/src/rezgui/dialogs/ResolveDialog.py
+++ b/src/rezgui/dialogs/ResolveDialog.py
@@ -274,7 +274,7 @@ class ResolveDialog(QtWidgets.QDialog, StoreSizeMixin):
 
         if self.resolver.success():
             if self.advanced:
-                sbuf = StringIO.StringIO()
+                sbuf = StringIO()
                 self.resolver.context.print_info(buf=sbuf)
                 msg = "\nTHE RESOLVE SUCCEEDED:\n\n"
                 msg += sbuf.getvalue()

--- a/src/rezgui/dialogs/ResolveDialog.py
+++ b/src/rezgui/dialogs/ResolveDialog.py
@@ -6,9 +6,9 @@ from rezgui.widgets.TimestampWidget import TimestampWidget
 from rezgui.dialogs.WriteGraphDialog import view_graph
 from rezgui.objects.ResolveThread import ResolveThread
 from rezgui.objects.App import app
+from rez.vendor.six.six import StringIO
 from rez.vendor.version.requirement import Requirement
 from rez.config import config
-import StringIO
 
 
 class ResolveDialog(QtWidgets.QDialog, StoreSizeMixin):

--- a/src/rezgui/widgets/ContextEnvironTable.py
+++ b/src/rezgui/widgets/ContextEnvironTable.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtWidgets
+from Qt import QtCompat, QtCore, QtWidgets
 
 
 class ContextEnvironTable(QtWidgets.QTableWidget):
@@ -19,7 +19,8 @@ class ContextEnvironTable(QtWidgets.QTableWidget):
         hh.setVisible(False)
         vh = self.verticalHeader()
         vh.setVisible(False)
-        vh.setResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        QtCompat.QHeaderView.setSectionResizeMode(
+            vh, QtWidgets.QHeaderView.ResizeToContents)
         self.setEnabled(False)
 
     def clear(self):

--- a/src/rezgui/widgets/ContextManagerWidget.py
+++ b/src/rezgui/widgets/ContextManagerWidget.py
@@ -100,14 +100,14 @@ class ContextManagerWidget(QtWidgets.QWidget, ContextViewMixin):
             self._revert_to_disk, "revert_to_disk")
         self.revert_tbtn.setMenu(self.revert_menu)
 
-        resolve_tbtn = QtWidgets.QToolButton()
-        resolve_tbtn.setPopupMode(QtWidgets.QToolButton.MenuButtonPopup)
-        menu = QtWidgets.QMenu()
+        self.resolve_tbtn = QtWidgets.QToolButton()
+        self.resolve_tbtn.setPopupMode(QtWidgets.QToolButton.MenuButtonPopup)
+        menu = QtWidgets.QMenu(self.resolve_tbtn)
         default_resolve_action = add_menu_action(menu, "Resolve", self._resolve, "resolve")
         add_menu_action(menu, "Advanced Resolve...",
                         partial(self._resolve, advanced=True), "advanced_resolve")
-        resolve_tbtn.setDefaultAction(default_resolve_action)
-        resolve_tbtn.setMenu(menu)
+        self.resolve_tbtn.setDefaultAction(default_resolve_action)
+        self.resolve_tbtn.setMenu(menu)
 
         toolbar = QtWidgets.QToolBar()
         toolbar.addWidget(resolve_time_label)
@@ -119,7 +119,7 @@ class ContextManagerWidget(QtWidgets.QWidget, ContextViewMixin):
         self.undiff_tbtn_action = toolbar.addWidget(self.undiff_tbtn)
         toolbar.addWidget(self.lock_tbtn)
         toolbar.addWidget(self.revert_tbtn)
-        toolbar.addWidget(resolve_tbtn)
+        toolbar.addWidget(self.resolve_tbtn)
         self.time_lock_tbtn_action.setVisible(False)
         self.undiff_tbtn_action.setVisible(False)
 
@@ -129,7 +129,7 @@ class ContextManagerWidget(QtWidgets.QWidget, ContextViewMixin):
         self.diff_tbtn.setCursor(QtCore.Qt.PointingHandCursor)
         self.lock_tbtn.setCursor(QtCore.Qt.PointingHandCursor)
         self.revert_tbtn.setCursor(QtCore.Qt.PointingHandCursor)
-        resolve_tbtn.setCursor(QtCore.Qt.PointingHandCursor)
+        self.resolve_tbtn.setCursor(QtCore.Qt.PointingHandCursor)
 
         btn_pane = create_pane([self.show_effective_request_checkbox,
                                 None, toolbar],

--- a/src/rezgui/widgets/ContextTableWidget.py
+++ b/src/rezgui/widgets/ContextTableWidget.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtWidgets, QtGui
+from Qt import QtCompat, QtCore, QtWidgets, QtGui
 from rezgui.util import update_font, create_pane, interp_color
 from rezgui.widgets.EffectivePackageCellWidget import EffectivePackageCellWidget
 from rezgui.widgets.PackageSelectWidget import PackageSelectWidget
@@ -306,7 +306,8 @@ class ContextTableWidget(QtWidgets.QTableWidget, ContextViewMixin):
         hh.setDefaultSectionSize(12 * self.fontMetrics().height())
 
         vh = self.verticalHeader()
-        vh.setResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        QtCompat.QHeaderView.setSectionResizeMode(
+            vh, QtWidgets.QHeaderView.ResizeToContents)
         vh.setVisible(False)
 
         self.delegate = CellDelegate(self)
@@ -432,7 +433,8 @@ class ContextTableWidget(QtWidgets.QTableWidget, ContextViewMixin):
 
             if self.diff_mode:
                 hh = self.horizontalHeader()
-                hh.setResizeMode(2, QtWidgets.QHeaderView.Fixed)
+                QtCompat.QHeaderView.setSectionResizeMode(
+                    hh, 2, QtWidgets.QHeaderView.Fixed)
                 self.setColumnWidth(2, 50)
 
             if self.context():

--- a/src/rezgui/widgets/ContextToolsWidget.py
+++ b/src/rezgui/widgets/ContextToolsWidget.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtWidgets
+from Qt import QtCompat, QtCore, QtWidgets
 from rezgui.widgets.ToolWidget import ToolWidget
 from rezgui.models.ContextModel import ContextModel
 from rezgui.mixins.ContextViewMixin import ContextViewMixin
@@ -35,7 +35,8 @@ class ContextToolsWidget(QtWidgets.QTreeWidget, ContextViewMixin):
 
         h = self.header()
         h.stretchLastSection()
-        h.setResizeMode(QtWidgets.QHeaderView.Fixed)
+        QtCompat.QHeaderView.setSectionResizeMode(
+            h, QtWidgets.QHeaderView.Fixed)
         h.setVisible(False)
 
         self.setColumnCount(2)

--- a/src/rezgui/widgets/PackageVersionsTable.py
+++ b/src/rezgui/widgets/PackageVersionsTable.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtWidgets, QtGui
+from Qt import QtCompat, QtCore, QtWidgets, QtGui
 from rezgui.mixins.ContextViewMixin import ContextViewMixin
 from rezgui.models.ContextModel import ContextModel
 from rezgui.util import get_timestamp_str
@@ -29,7 +29,8 @@ class PackageVersionsTable(QtWidgets.QTableWidget, ContextViewMixin):
         hh = self.horizontalHeader()
         hh.setStretchLastSection(True)
         vh = self.verticalHeader()
-        vh.setResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        QtCompat.QHeaderView.setSectionResizeMode(
+            vh, QtWidgets.QHeaderView.ResizeToContents)
         self.clear()
 
     def clear(self):

--- a/src/rezgui/widgets/VariantSummaryWidget.py
+++ b/src/rezgui/widgets/VariantSummaryWidget.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtWidgets
+from Qt import QtCompat, QtCore, QtWidgets
 from rezgui.util import create_pane, get_timestamp_str
 from rez.packages import Package, Variant
 from rez.util import find_last_sublist
@@ -21,7 +21,8 @@ class VariantSummaryWidget(QtWidgets.QWidget):
         hh.setStretchLastSection(True)
         hh.setVisible(False)
         vh = self.table.verticalHeader()
-        vh.setResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        QtCompat.QHeaderView.setSectionResizeMode(
+            vh, QtWidgets.QHeaderView.ResizeToContents)
 
         create_pane([self.label, self.table], False, compact=True,
                     parent_widget=self)

--- a/src/rezgui/widgets/VariantVersionsTable.py
+++ b/src/rezgui/widgets/VariantVersionsTable.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtWidgets, QtGui
+from Qt import QtCompat, QtCore, QtWidgets, QtGui
 from rezgui.mixins.ContextViewMixin import ContextViewMixin
 from rez.package_filter import PackageFilterList
 from rezgui.util import get_timestamp_str, update_font, get_icon_widget, create_pane
@@ -28,7 +28,8 @@ class VariantVersionsTable(QtWidgets.QTableWidget, ContextViewMixin):
         hh = self.horizontalHeader()
         hh.setVisible(False)
         vh = self.verticalHeader()
-        vh.setResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        QtCompat.QHeaderView.setSectionResizeMode(
+            vh, QtWidgets.QHeaderView.ResizeToContents)
 
         self.clear()
 
@@ -64,7 +65,8 @@ class VariantVersionsTable(QtWidgets.QTableWidget, ContextViewMixin):
 
         hh = self.horizontalHeader()
         self.setHorizontalHeaderLabels(["path", "released"])
-        hh.setResizeMode(0, QtWidgets.QHeaderView.Interactive)
+        QtCompat.QHeaderView.setSectionResizeMode(
+            hh, 0, QtWidgets.QHeaderView.Interactive)
         hh.setStretchLastSection(True)
         hh.setVisible(True)
 

--- a/src/rezgui/widgets/VariantsList.py
+++ b/src/rezgui/widgets/VariantsList.py
@@ -1,4 +1,4 @@
-from Qt import QtCore, QtWidgets
+from Qt import QtCompat, QtCore, QtWidgets
 from rez.packages import Package
 
 
@@ -20,7 +20,8 @@ class VariantsList(QtWidgets.QTableWidget):
         hh.setStretchLastSection(True)
         hh.setVisible(False)
         vh = self.verticalHeader()
-        vh.setResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        QtCompat.QHeaderView.setSectionResizeMode(
+            vh, QtWidgets.QHeaderView.ResizeToContents)
         vh.setVisible(False)
 
     def set_package(self, package):


### PR DESCRIPTION
This PR addresses #849 by leveraging the vendored `Qt.QtCompat` module.

The branch is based on the https://github.com/KelSolaar/rez/tree/feature/python3 branch that is waiting to be merged in #850 (and should be merged first).