### PR TITLE
Allow absolute path for build directory

### DIFF
--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -104,8 +104,11 @@ class BuildProcess(object):
             raise BuildProcessError(
                 "Build process was instantiated with a mismatched VCS instance")
 
-        self.build_path = os.path.join(self.working_dir,
-                                       self.package.config.build_directory)
+        if os.path.isabs(self.package.config.build_directory):
+            self.build_path = self.package.config.build_directory
+        else:
+            self.build_path = os.path.join(self.working_dir,
+                                           self.package.config.build_directory)
 
     @property
     def package(self):

--- a/src/rez/build_system.py
+++ b/src/rez/build_system.py
@@ -177,8 +177,8 @@ class BuildSystem(object):
             context: A ResolvedContext object that the build process must be
                 executed within.
             variant (`Variant`): The variant being built.
-            build_path: Where to write temporary build files. May be relative
-                to working_dir.
+            build_path: Where to write temporary build files. May be absolute
+                or relative to working_dir.
             install_path (str): The package repository path to install the
                 package to, if installing. If None, defaults to
                 `config.local_packages_path`.

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -563,8 +563,9 @@ shell_error_truncate_cap = 750
 # the 'relocatable' attribute in its package definition file.
 default_relocatable = True
 
-# The default working directory for a package build, relative to the package
-# source directory (this is typically where temporary build files are written).
+# The default working directory for a package build, either absolute path or
+# relative to the package source directory (this is typically where temporary
+# build files are written).
 build_directory = "build"
 
 # The number of threads a build system should use, eg the make '-j' option.


### PR DESCRIPTION
Wondering if others might find it useful to specify build_directory using an absolute path. I find it handy to redirect large builds to a local ssd.