### PR TITLE
Fixed unformatted error message

### DIFF
--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -433,9 +433,10 @@ def _get_distribution_files_mapping(distribution, targetdir):
 
         # A case we don't know how to deal with yet
         if topdir == os.pardir:
-            raise RuntimeError(
-                "Don't know what to do with source file %r, please file a ticket",
-                rel_src
+            raise IOError(
+                89,  # errno.EDESTADDRREQ : Destination address required
+                "Don't know what to do with source file, please file a ticket",
+                rel_src,
             )
 
         # At this point the file should be <pkg-name>/..., so we put


### PR DESCRIPTION
Also changed to [IOError](https://docs.python.org/2/library/exceptions.html?highlight=attribute#exceptions.EnvironmentError) in case we need to take advantage
of `IOError.filename` and `IOError.errno` in the future.

See also #861 and #855

Before (rez 2.54.0):

    RuntimeError: ("Don't know what to do with source file %r, please file a ticket", u'../../share/applications/ranger.desktop')

After
  
    IOError: [Errno 89] Don't know what to do with source file, please file a ticket: '../../share/applications/ranger.desktop'