### PR TITLE
pip install path remap

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -125,23 +125,19 @@ class StrList(Setting):
 class PipInstallRemaps(Setting):
     """Ordered, pip install remappings."""
     PARDIR, SEP = map(re.escape, (os.pardir, os.sep))
-    TOKENS = {'sep': SEP, 's': SEP, 'pardir': PARDIR, 'p': PARDIR}
+    RE_TOKENS = {'sep': SEP, 's': SEP, 'pardir': PARDIR, 'p': PARDIR}
+    TOKENS = {'sep': os.sep, 's': os.sep, 'pardir': os.pardir, 'p': os.pardir}
+    KEYS = ["record_path", "pip_install", "rez_install"]
 
-    schema = Schema(
-        [
-            {
-                "record_path": And(str, len),
-                "pip_install": And(str, len),
-                "rez_install": And(str, len),
-            }
-        ]
-    )
+    schema = Schema([{key: And(str, len) for key in KEYS}])
 
     def validate(self, data):
         """Extended to substitute regex-escaped path tokens."""
         return [
             {
-                key: expression.format(**self.TOKENS)
+                key: expression.format(
+                    **(self.RE_TOKENS if key == "record_path" else self.TOKENS)
+                )
                 for key, expression in remap.items()
             }
             for remap in super(PipInstallRemaps, self).validate(data)

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -141,7 +141,7 @@ class PipInstallRemaps(Setting):
         """Extended to substitute regex-escaped path tokens."""
         return [
             {
-                key: expression.format(**tokens)
+                key: expression.format(**self.TOKENS)
                 for key, expression in remap.items()
             }
             for remap in super(PipInstallRemaps, self).validate(data)

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -309,6 +309,7 @@ config_schema = Schema({
     "alias_styles":                                 OptionalStrList,
     "memcached_uri":                                OptionalStrList,
     "pip_extra_args":                               OptionalStrList,
+    "pip_src_remaps":                               OptionalDict,
     "local_packages_path":                          Str,
     "release_packages_path":                        Str,
     "dot_image_format":                             Str,

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -19,14 +19,14 @@ from rez.package_maker import make_package
 from rez.config import config
 from rez.utils.platform_ import platform_
 
-from tempfile import mkdtemp
+import os
 from pipes import quote
 from pprint import pformat
-import subprocess
-import os.path
+import re
 import shutil
+import subprocess
 import sys
-import os
+from tempfile import mkdtemp
 
 
 class InstallMode(Enum):
@@ -403,9 +403,6 @@ def _get_distribution_files_mapping(distribution, targetdir):
         * key: Path of pip installed file, relative to `targetdir`;
         * value: Relative path to install into rez package.
     """
-    bin_prefix = os.path.join(os.pardir, os.pardir, 'bin') + os.sep
-    lib_py_prefix = os.path.join(os.pardir, os.pardir, 'lib', 'python') + os.sep
-
     def get_mapping(rel_src):
         topdir = rel_src.split(os.sep)[0]
 
@@ -415,27 +412,19 @@ def _get_distribution_files_mapping(distribution, targetdir):
         if topdir.endswith(".dist-info"):
             return (rel_src, rel_src)
 
-        # RECORD lists bin files as being in ../../bin/, when in fact they are
-        # in ./bin. This also happens to match rez package structure, so here
-        # src and dest are same rel path.
-        #
-        if rel_src.startswith(bin_prefix):
-            adjusted_rel_src = os.path.join("bin", rel_src[len(bin_prefix):])
-            return (adjusted_rel_src, adjusted_rel_src)
-
-        # Rarely, some distributions report an installed file as being in
-        # ../../lib/python/<pkg-name>/...
-        #
-        if rel_src.startswith(lib_py_prefix):
-            adjusted_rel_src = rel_src[len(lib_py_prefix):]
-            rel_dest = os.path.join("python", adjusted_rel_src)
-            return (adjusted_rel_src, rel_dest)
-
-        # A case we don't know how to deal with yet
+        # Remapping of other installed files according to manifest
         if topdir == os.pardir:
+            for remap in config.pip_install_remaps:
+                path = remap['record_path']
+                if re.search(path, rel_src):
+                    pip_subpath = re.sub(path, remap['pip_install'], rel_src)
+                    rez_subpath = re.sub(path, remap['rez_install'], rel_src)
+                    return (pip_subpath, rez_subpath)
+
             raise IOError(
                 89,  # errno.EDESTADDRREQ : Destination address required
-                "Don't know what to do with source file, please file a ticket",
+                "Don't know what to do with source file, please add a custom "
+                "rule to 'pip_install_remaps' configuration for record_path",
                 rel_src,
             )
 

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -433,9 +433,10 @@ def _get_distribution_files_mapping(distribution, targetdir):
 
         # A case we don't know how to deal with yet
         if topdir == os.pardir:
-            raise RuntimeError(
-                "Don't know what to do with source file %r, please file a ticket",
-                rel_src
+            raise IOError(
+                89,  # errno.EDESTADDRREQ : Destination address required
+                "Don't know what to do with source file, please file a ticket",
+                rel_src,
             )
 
         # At this point the file should be <pkg-name>/..., so we put

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -440,9 +440,9 @@ def _get_distribution_files_mapping(distribution, targetdir):
             3. Create a new rule to 'pip_install_remaps' configuration like:
 
                 {{
-                    "record_path": "{2}",
-                    "pip_install": "<RELATIVE path pip installed to in 2.>",
-                    "rez_install": "<DESTINATION sub-path in rez package>",
+                    "record_path": r"{2}",
+                    "pip_install": r"<RELATIVE path pip installed to in 2.>",
+                    "rez_install": r"<DESTINATION sub-path in rez package>",
                 }}
 
             4. Try rez-pip install again.

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -423,35 +423,39 @@ def _get_distribution_files_mapping(distribution, targetdir):
                     rez_subpath = re.sub(path, remap['rez_install'], rel_src)
                     return (pip_subpath, rez_subpath)
 
-            tokenised_path = rel_src.replace(os.sep, '{pardir}')
-            tokenised_path = tokenised_path.replace(os.pardir, '{sep}')
-            info_dir = '{0.name}-{0.version}.dist-info{1}'.format(distribution)
+            tokenised_path = rel_src.replace(os.pardir, '{pardir}')
+            tokenised_path = tokenised_path.replace(os.sep, '{sep}')
+            dist_record = '{dist.name}-{dist.version}.dist-info{os.sep}RECORD'
+            dist_record = dist_record.format(dist=distribution, os=os)
+
             try_this_message = r"""
-            Unknown source file in {0}RECORD! '{1}'
+            Unknown source file in {0}! '{1}'
+
             To resolve, try:
+
             1. Manually install the pip package using 'pip install --target'
                to a temporary location.
             2. See where '{1}'
                actually got installed to by pip, RELATIVE to --target location
             3. Create a new rule to 'pip_install_remaps' configuration like:
 
-                {
+                {{
                     "record_path": "{2}",
                     "pip_install": "<RELATIVE path pip installed to in 2.>",
                     "rez_install": "<DESTINATION sub-path in rez package>",
-                }
+                }}
 
             4. Try rez-pip install again.
 
             If path remapping is not enough, consider submitting a new issue
             via https://github.com/nerdvegas/rez/issues/new
-            """.format(info_dir, rel_src, tokenised_path)
+            """.format(dist_record, rel_src, tokenised_path)
 
             map(print_error, dedent(try_this_message).splitlines())
             raise IOError(
                 89,  # errno.EDESTADDRREQ : Destination address required
-                "Don't know what to do with source file in {0}RECORD, see "
-                "above error message for path".format(info_dir),
+                "Don't know what to do with source file in {0}, see "
+                "above error message for path".format(dist_record),
                 rel_src,
             )
 

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -450,12 +450,12 @@ def _get_distribution_files_mapping(distribution, targetdir):
             If path remapping is not enough, consider submitting a new issue
             via https://github.com/nerdvegas/rez/issues/new
             """.format(dist_record, rel_src, tokenised_path)
+            print_error(dedent(try_this_message).lstrip())
 
-            map(print_error, dedent(try_this_message).splitlines())
             raise IOError(
                 89,  # errno.EDESTADDRREQ : Destination address required
-                "Don't know what to do with source file in {0}, see "
-                "above error message for path".format(dist_record),
+                "Don't know what to do with relative path in {0}, see "
+                "above error message for".format(dist_record),
                 rel_src,
             )
 

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -704,26 +704,48 @@ create_executable_script_mode = "single"
 # https://pip.pypa.io/en/stable/reference/pip_install/#options
 pip_extra_args = []
 
-# Substitutions for rez.sub when relative/unknown paths are encountered for a
-# pip package distribution manifest.
-pip_src_remaps = {
-    # In manifest:       ../../bin/*
-    # pip installed to:  ./bin/*
-    # rez destination:   ./bin/*
-    r'^{pardir}{sep}{pardir}{sep}bin{sep}(.*)': [
-        r'bin\1',  # Copy from pip installed target...
-        r'bin\1',  # ...to destination in rez package
-    ],
+# Substitutions for re.sub when unknown parent paths are encountered in the
+# pip package distribution record: *.dist-info/RECORD
+#
+# Rez reads the distribution record to figure out where pip installed files
+# to, then copies them to their final sub-path in the rez package,
+# i.e. Python source files are hard coded to be moved under the "python"
+# sub-folder inside the rez package, which then gets added to PYTHONPATH
+# upon rez-env.
+#
+# When it can't find the file listed in the record AND the path starts
+# with a reference to the parent directory "..", the following remaps are
+# used to:
+# 1. Match a path listed in the record to perform the re-mapping, then both
+# 2. re.sub expression from step 1 to make a relative path of where pip
+#    actually installed the file path in the.
+# 3. re.sub expression from step 1 to make a relative path to the rez package
+#    to install the file path.
+#
+# Use these tokens to avoid regex issues:
+# - "{pardir}" or "{p}" for parent directory: os.pardir, i.e. ".." on Linux/Mac
+# - "{sep}" or "{s}" for folder separators: os.sep, i.e. "/" on Linux/Mac
+pip_install_remaps = [
+    # # Typical bin copy behaviour
+    # Path in record          | pip installed to    | copy to rez destination
+    # ------------------------|---------------------|--------------------------
+    # ../../bin/*             | bin/*               | bin/*
+    {
+        "record_path": "^{pardir}{sep}{pardir}{sep}(bin{sep}.*)",
+        "pip_install": "\1",
+        "rez_install": "\1",
+    },
 
-    # In manifest:       ../../lib/python/*
-    # pip installed to:  ./*
-    # rez destination:   ./python/*
-    r'^{pardir}{sep}{pardir}{sep}lib{sep}python{sep}(.*)': [
-        r'\1',             # Copy from pip installed target...
-        r'python{sep}\1',  # ...to destination in rez package
-    ],
-}
-
+    # # Fix for https://github.com/nerdvegas/rez/issues/821
+    # Path in record          | pip installed to    | copy to rez destination
+    # ------------------------|---------------------|--------------------------
+    # ../../lib/python/*      | *                   | python/*
+    {
+        "record_path": "^{p}{s}{p}{s}lib{s}python{s}(.*)",
+        "pip_install": "\1",
+        "rez_install": "python{s}\1",
+    },
+]
 
 ###############################################################################
 # Rez-1 Compatibility

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -722,7 +722,7 @@ pip_extra_args = []
 # 3. re.sub expression from step 1 to make a relative path to the rez package
 #    to install the file path.
 #
-# Use these tokens to avoid regex issues:
+# Use these tokens to avoid regular expression and OS specific path issues:
 # - "{pardir}" or "{p}" for parent directory: os.pardir, i.e. ".." on Linux/Mac
 # - "{sep}" or "{s}" for folder separators: os.sep, i.e. "/" on Linux/Mac
 pip_install_remaps = [
@@ -731,9 +731,9 @@ pip_install_remaps = [
     # ------------------------|---------------------|--------------------------
     # ../../bin/*             | bin/*               | bin/*
     {
-        "record_path": "^{pardir}{sep}{pardir}{sep}(bin{sep}.*)",
-        "pip_install": "\1",
-        "rez_install": "\1",
+        "record_path": r"^{pardir}{sep}{pardir}{sep}(bin{sep}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
     },
 
     # # Fix for https://github.com/nerdvegas/rez/issues/821
@@ -741,9 +741,9 @@ pip_install_remaps = [
     # ------------------------|---------------------|--------------------------
     # ../../lib/python/*      | *                   | python/*
     {
-        "record_path": "^{p}{s}{p}{s}lib{s}python{s}(.*)",
-        "pip_install": "\1",
-        "rez_install": "python{s}\1",
+        "record_path": r"^{p}{s}{p}{s}lib{s}python{s}(.*)",
+        "pip_install": r"\1",
+        "rez_install": r"python{s}\1",
     },
 ]
 

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -704,6 +704,26 @@ create_executable_script_mode = "single"
 # https://pip.pypa.io/en/stable/reference/pip_install/#options
 pip_extra_args = []
 
+# Substitutions for rez.sub when relative/unknown paths are encountered for a
+# pip package distribution manifest.
+pip_src_remaps = {
+    # In manifest:       ../../bin/*
+    # pip installed to:  ./bin/*
+    # rez destination:   ./bin/*
+    r'^{pardir}{sep}{pardir}{sep}bin{sep}(.*)': [
+        r'bin\1',  # Copy from pip installed target...
+        r'bin\1',  # ...to destination in rez package
+    ],
+
+    # In manifest:       ../../lib/python/*
+    # pip installed to:  ./*
+    # rez destination:   ./python/*
+    r'^{pardir}{sep}{pardir}{sep}lib{sep}python{sep}(.*)': [
+        r'\1',             # Copy from pip installed target...
+        r'python{sep}\1',  # ...to destination in rez package
+    ],
+}
+
 
 ###############################################################################
 # Rez-1 Compatibility


### PR DESCRIPTION
Closes #861 
Closes #863

New configuration setting to allow people to map and configure `rez-pip --install` of unknown `RECORD` paths.

For example, for #861, a new entry like so can be added to capture and re-map and move all `../../*` paths that are unknown/not handled by `rez-pip` to just live under the root rez package installation like so:

```python
# Inside rezconfig.py...
pip_install_remaps = [

    # ...add these before the end

    # # Fix for greenlet in https://github.com/nerdvegas/rez/issues/861
    # Path in record          | pip installed to    | copy to rez destination
    # ------------------------|---------------------|--------------------------
    # usr/local/*             | *                   | python/*
    {
        "record_path": r"(.*){sep}usr{sep}local{sep}(.*)",
        "pip_install": r"\1{sep}usr{sep}local{sep}\2",
        "rez_install": r"\2",
    },

    # # Fix for Qt.py in https://github.com/nerdvegas/rez/issues/861
    # Path in record          | pip installed to    | copy to rez destination
    # ------------------------|---------------------|--------------------------
    # ../../NOT PARDIR        | *                   | *
    {
        "record_path": r"^{p}{s}{p}{s}(?!{p})(.*)",
        "pip_install": r"\1",
        "rez_install": r"\1",
    },
]
```

@smaragden, want to give these a test?

----

### Added

- `rez.config.PipInstallRemaps` setting to extend `validate` to perform token substitutions for...
- ...new `rez.rezconfig.pip_install_remaps` setting

### Changed

- More detailed error message for unknown source file
- Tidied imports in `rez.pip`