### PR TITLE
Fix for git rev-parse error out before checking for allow_no_upstream

### DIFF
--- a/src/rezplugins/release_vcs/git.py
+++ b/src/rezplugins/release_vcs/git.py
@@ -83,7 +83,8 @@ class GitReleaseVCS(ReleaseVCS):
             # and 2.12 - used to be "No upstream", now "no upstream"..
             errmsg = str(e).lower()
             if ("no upstream branch" not in errmsg
-                    and "no upstream configured" not in errmsg):
+                    and "no upstream configured" not in errmsg
+                    and "does not point to a branch" not in errmsg):
                 raise e
         return (None, None)
 


### PR DESCRIPTION
Fixed an issue where git rev-parse would error out before checking the config.allow_no_upstream.

I built locally and was able to release without issues