### PR TITLE
Added distribution author and help information

### DIFF
--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -405,8 +405,8 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
             if "home_page" in distribution_metadata:
                 help_.append(["Home Page", distribution_metadata["home_page"]])
 
-            if distribution.source_url:
-                help_.append(["Source Code", distribution.source_url])
+            if "download_url" in distribution_metadata:
+                help_.append(["Source Code", distribution_metadata["download_url"]])
 
             pkg.help = help_
 

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -398,6 +398,28 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
             pkg.from_pip = True
             pkg.is_pure_python = metadata["is_pure_python"]
 
+            distribution_metadata = distribution.metadata.todict()
+
+            help_ = []
+
+            if "home_page" in distribution_metadata:
+                help_.append(["Home Page", distribution_metadata["home_page"]])
+
+            if distribution.source_url:
+                help_.append(["Source Code", distribution.source_url])
+
+            pkg.help = help_
+
+            if "author" in distribution_metadata:
+                author = distribution_metadata["author"]
+
+                if "author_email" in distribution_metadata:
+                    author += " ({distribution_metadata[author_email]})".format(
+                        distribution_metadata=distribution_metadata
+                    )
+
+                pkg.authors = [author]
+
         log_append_pkg_variants(pkg)
 
     # cleanup

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.56.1"
+_rez_version = "2.57.0"
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
Resolves #838

This PR extends rez-pip to add author and URL information.

Before
```python
name = u'shiboken2'

version = '5.14.2'

description = u'Python / C++ bindings helper module'

variants = [['platform-linux', 'arch-x86_64', 'python-3.6']]

def commands():
    env.PYTHONPATH.append('{root}/python')
```

After
```python
name = u'shiboken2'

version = '5.14.2'

description = u'Python / C++ bindings helper module'

authors = [u'Qt for Python Team (pyside@qt-project.org)']

variants = [['platform-linux', 'arch-x86_64', 'python-3.6']]

def commands():
    env.PYTHONPATH.append('{root}/python')

help = [
    ['Home Page', u'https://www.pyside.org'],
    ['Source Code', u'https://download.qt.io/official_releases/QtForPython']
]
```

## Known Caveat
This setup doesn't deal with unicode too well. e.g. for black, this is the author data

```python
authors = [u'\u0141ukasz Langa (lukasz@langa.pl)']
```
(instead of `Łukasz Langa (lukasz@langa.pl)`)

Suggestions welcome!