### PR TITLE
Fix issue 826 - correct python and pip fallback

### DIFF
--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         ${{ matrix.method }}
         find /opt/rez/ -maxdepth 2
-    
+
     - name: rez status
       run: |
         export ${{ matrix.exports }}
@@ -44,14 +44,14 @@ jobs:
         export ${{ matrix.exports }}
         rez-pip --install .
         rez view rez
-    
+
     - name: Import rez package in Python
       run: |
         export ${{ matrix.exports }}
 
         # Still needed as there's no fallback to use system's python
-        rez bind python  
-        
+        rez bind python
+
         echo "Checking rez as python package: ==========================================="
         rez env rez -- python -c 'import rez;print(rez.__file__)'
 
@@ -87,7 +87,7 @@ jobs:
       run: |
         ${{ matrix.method }}
         find /opt/rez/ -maxdepth 2
-    
+
     - name: rez status
       run: |
         export ${{ matrix.exports }}
@@ -98,13 +98,13 @@ jobs:
         export ${{ matrix.exports }}
         rez-pip --install .
         rez view rez
-    
+
     - name: Import rez package in Python
       run: |
         export ${{ matrix.exports }}
 
         # Still needed as there's no fallback to use system's python
-        rez bind python  
-        
+        rez bind python
+
         echo "Checking rez as python package: ==========================================="
         rez env rez -- python -c 'import rez;print(rez.__file__)'

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -1,0 +1,110 @@
+name: Installation
+on: [push]
+
+jobs:
+  linux-vm:
+    name: ${{ matrix.python-version }} - ${{ matrix.method }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '2.7'
+          - '3.6'
+          - '3.7'
+        method:
+          - 'python ./install.py'
+          - 'pip install --target /opt/rez .'
+        include:
+          - method: 'python ./install.py'
+            exports: 'PATH=${PATH}:/opt/rez/bin/rez'
+          - method: 'pip install --target /opt/rez .'
+            exports: 'PATH=${PATH}:/opt/rez/bin PYTHONPATH=${PYTHONPATH}:/opt/rez'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install
+      run: |
+        ${{ matrix.method }}
+        find /opt/rez/ -maxdepth 2
+    
+    - name: rez status
+      run: |
+        export ${{ matrix.exports }}
+        rez status
+
+    - name: rez-pip --install .
+      run: |
+        export ${{ matrix.exports }}
+        rez-pip --install .
+        rez view rez
+    
+    - name: Import rez package in Python
+      run: |
+        export ${{ matrix.exports }}
+
+        # Still needed as there's no fallback to use system's python
+        rez bind python  
+        
+        echo "Checking rez as python package: ==========================================="
+        rez env rez -- python -c 'import rez;print(rez.__file__)'
+
+  linux-containers:
+    name: python:${{ matrix.python-version }} - ${{ matrix.method }}
+    runs-on: ubuntu-latest
+    container: python:${{ matrix.python-version }}
+    strategy:
+      matrix:
+        python-version:
+          - '2.7'
+          - '3.6'
+          - '3.7'
+        method:
+          - 'python ./install.py'
+          - 'pip install --target /opt/rez .'
+        include:
+          - method: 'python ./install.py'
+            exports: 'PATH=${PATH}:/opt/rez/bin/rez'
+          - method: 'pip install --target /opt/rez .'
+            exports: 'PATH=${PATH}:/opt/rez/bin PYTHONPATH=${PYTHONPATH}:/opt/rez'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install
+      run: |
+        ${{ matrix.method }}
+        find /opt/rez/ -maxdepth 2
+    
+    - name: rez status
+      run: |
+        export ${{ matrix.exports }}
+        rez status
+
+    - name: rez-pip --install .
+      run: |
+        export ${{ matrix.exports }}
+        rez-pip --install .
+        rez view rez
+    
+    - name: Import rez package in Python
+      run: |
+        export ${{ matrix.exports }}
+
+        # Still needed as there's no fallback to use system's python
+        rez bind python  
+        
+        echo "Checking rez as python package: ==========================================="
+        rez env rez -- python -c 'import rez;print(rez.__file__)'

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -9,8 +9,8 @@ jobs:
       matrix:
         python-version:
           - '2.7'
-          - '3.6'
-          - '3.7'
+          # - '3.6'
+          # - '3.7'
         os:
           - windows
           - macos
@@ -19,7 +19,7 @@ jobs:
             method: 'python .\install.py "C:\Program Files\rez"'
             check-parent: 'dir "C:\Program Files"'
           - os: macos
-            method: 'python ./install.py /Applications/Utilities/rez'
+            method: 'sudo python ./install.py /Applications/Utilities/rez'
             check-parent: 'ls -lah /Applications/Utilities'
 
     steps:
@@ -33,6 +33,7 @@ jobs:
   linux-vm:
     name: ${{ matrix.python-version }} - ${{ matrix.method }}
     runs-on: ubuntu-latest
+    if: false == true  # Disable while we test above
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -14,13 +14,21 @@ jobs:
         os:
           - windows
           - macos
+        include:
+          - os: windows
+            method: 'python .\install.py "C:\Program Files\rez"'
+            check-parent: 'dir "C:\Program Files"'
+          - os: macos
+            method: 'python ./install.py /Applications/Utilities/rez'
+            check-parent: 'ls -lah /Applications/Utilities'
 
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python ./install.py
+      - run: ${{ matrix.check-parent }}
+      - run: ${{ matrix.method }}
 
   linux-vm:
     name: ${{ matrix.python-version }} - ${{ matrix.method }}
@@ -41,64 +49,10 @@ jobs:
             exports: 'PATH=${PATH}:/opt/rez/bin PYTHONPATH=${PYTHONPATH}:/opt/rez'
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@master
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Install
-      run: |
-        ${{ matrix.method }}
-        find /opt/rez/ -maxdepth 2
-
-    - name: rez status
-      run: |
-        export ${{ matrix.exports }}
-        rez status
-
-    - name: rez-pip --install .
-      run: |
-        export ${{ matrix.exports }}
-        rez-pip --install .
-        rez view rez
-
-    - name: Import rez package in Python
-      run: |
-        export ${{ matrix.exports }}
-
-        # Still needed as there's no fallback to use system's python
-        rez bind python
-
-        echo "Checking rez as python package: ==========================================="
-        rez env rez -- python -c 'import rez;print(rez.__file__)'
-
-  linux-containers:
-    # Quick check with systems that already has Python and Pip setup
-    # rather than through GitHub CI actions/setup-python
-    name: python:${{ matrix.python-version }} - ${{ matrix.method }}
-    runs-on: ubuntu-latest
-    container: python:${{ matrix.python-version }}
-    strategy:
-      matrix:
-        python-version:
-          - '2.7'
-          - '3.6'
-          - '3.7'
-        method:
-          - 'python ./install.py'
-          - 'pip install --target /opt/rez .'
-        include:
-          - method: 'python ./install.py'
-            exports: 'PATH=${PATH}:/opt/rez/bin/rez'
-          - method: 'pip install --target /opt/rez .'
-            exports: 'PATH=${PATH}:/opt/rez/bin PYTHONPATH=${PYTHONPATH}:/opt/rez'
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
 
     - name: Install
       run: |

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -2,6 +2,26 @@ name: Installation
 on: [push]
 
 jobs:
+  os-vm: 
+    name: ${{ matrix.python-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy: 
+      matrix:
+        python-version:
+          - '2.7'
+          - '3.6'
+          - '3.7'
+        os:
+          - windows
+          - macos
+
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python ./install.py
+
   linux-vm:
     name: ${{ matrix.python-version }} - ${{ matrix.method }}
     runs-on: ubuntu-latest
@@ -56,6 +76,8 @@ jobs:
         rez env rez -- python -c 'import rez;print(rez.__file__)'
 
   linux-containers:
+    # Quick check with systems that already has Python and Pip setup
+    # rather than through GitHub CI actions/setup-python
     name: python:${{ matrix.python-version }} - ${{ matrix.method }}
     runs-on: ubuntu-latest
     container: python:${{ matrix.python-version }}
@@ -77,11 +99,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Install
       run: |

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -2,38 +2,9 @@ name: Installation
 on: [push]
 
 jobs:
-  os-vm: 
-    name: ${{ matrix.python-version }} - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-latest
-    strategy: 
-      matrix:
-        python-version:
-          - '2.7'
-          # - '3.6'
-          # - '3.7'
-        os:
-          - windows
-          - macos
-        include:
-          - os: windows
-            method: 'python .\install.py "C:\Program Files\rez"'
-            check-parent: 'dir "C:\Program Files"'
-          - os: macos
-            method: 'sudo python ./install.py /Applications/Utilities/rez'
-            check-parent: 'ls -lah /Applications/Utilities'
-
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: ${{ matrix.check-parent }}
-      - run: ${{ matrix.method }}
-
   linux-vm:
     name: ${{ matrix.python-version }} - ${{ matrix.method }}
     runs-on: ubuntu-latest
-    if: false == true  # Disable while we test above
     strategy:
       matrix:
         python-version:

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -88,7 +88,7 @@ def find_pip(pip_version=None, python_version=None):
     context = None
     found_pip_version = None
 
-    for version in [pip_version, pip_version or "latest"]:
+    for version in [pip_version, "latest"]:
         try:
             py_exe, found_pip_version, context = find_pip_from_context(
                 python_version, pip_version=version

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -87,18 +87,20 @@ def find_pip(pip_version=None, python_version=None):
     py_exe = None
     context = None
     found_pip_version = None
+    valid_found = False
 
     for version in [pip_version, "latest"]:
         try:
             py_exe, found_pip_version, context = find_pip_from_context(
                 python_version, pip_version=version
             )
-            if _check_found(py_exe, found_pip_version):
+            valid_found = _check_found(py_exe, found_pip_version)
+            if valid_found:
                 break
         except BuildError as error:
             print_warning(str(error))
 
-    else:  # No break from: for version in [pip_version,...]
+    if not valid_found:
         import pip
 
         found_pip_version = pip.__version__

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -134,7 +134,7 @@ def find_python_from_package(context, name="python", default=None):
     """
     py_exe_path = default
     context = context.copy()
-    context.append_sys_path = False  # GitHub nerdvegas/rez/pull/826
+    context.append_sys_path = False  # GitHub nerdvegas/rez/issue/826
 
     py_packages = (v for v in context.resolved_packages if v.name == name)
     python_package = next(py_packages)

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -188,6 +188,7 @@ class ResolvedContext(object):
                 effect if `verbosity` > 2.
             print_stats (bool): If true, print advanced solver stats at the end.
         """
+        self.append_sys_path = True
         self.load_path = None
 
         # resolving settings
@@ -1715,7 +1716,8 @@ class ResolvedContext(object):
         self._append_suite_paths(executor)
 
         # append system paths
-        executor.append_system_paths()
+        if self.append_sys_path:
+            executor.append_system_paths()
 
         # add rez path so that rez commandline tools are still available within
         # the resolved environment


### PR DESCRIPTION
[![Installation](https://github.com/j0yu/bleeding-rez/workflows/Installation/badge.svg?branch=fix-826-pip-fallback)](https://github.com/j0yu/bleeding-rez/actions?query=workflow%3AInstallation+branch%3Afix-826-pip-fallback) Closes #826

Ran across #826 while trying to refactoring pip wiki fix PR #749. The CI for #749 is also added here since it requires the pip fallback fix

1. [x] Use `python2` or `python3` rather than `python`

   [Currently with disgusting hack][hack] and thinking about either (need feedback!):

      - a new `add_sys_path` kwargs for [`ResolvedContext.get_environ`][get_environ] and [`ResovledContext._execute`][exe], or 
      - a new `ResolvedContext.append_sys_path` attribute which [`ResovledContext._execute`][exe] and any other methods can use

2. [x] Fallback to more compatible `pip` version if possible

[hack]: https://github.com/nerdvegas/rez/blob/ce3c9da8fda027e5182b06650df21e7b7cbd2bdc/src/rez/pip.py#L122-L186
[get_environ]: https://github.com/nerdvegas/rez/blob/ce3c9da8fda027e5182b06650df21e7b7cbd2bdc/src/rez/resolved_context.py#L932
[exe]: https://github.com/nerdvegas/rez/blob/ce3c9da8fda027e5182b06650df21e7b7cbd2bdc/src/rez/resolved_context.py#L1599