### PR TITLE
Fix ISSUE-879: AttributeError: 'Namespace' object has no attribute 'func'

### DIFF
--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -141,7 +141,15 @@ def run(command=None):
         exc_type = RezError
 
     def run_cmd():
-        return opts.func(opts, opts.parser, extra_arg_groups)
+        try:
+            # python3 will not automatically handle cases where no sub parser
+            # has been selected. In these cases func will not exist, and an
+            # AttributeError will be raised.
+            func = opts.func
+        except AttributeError:
+            parser.error("too few arguments.")
+        else:
+            return func(opts, opts.parser, extra_arg_groups)
 
     if opts.profile:
         import cProfile


### PR DESCRIPTION
This merge handles the attribute error raised when trying to get `func` when no sub parser has been selected.