### PR TITLE
added get_variant_from_uri functionality

### DIFF
--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -170,6 +170,18 @@ class PackageRepository(object):
         """
         raise NotImplementedError
 
+    def get_variant_from_uri(self, uri):
+        """Get a variant given its URI.
+
+        Args:
+            uri (str): Variant URI
+
+        Returns:
+            `VariantResource`, or None if the variant is not present in this
+            package repository.
+        """
+        return None
+
     def pre_variant_install(self, variant_resource):
         """Called before a variant is installed.
 

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -637,11 +637,37 @@ def get_variant(variant_handle, context=None):
     return variant
 
 
+def get_variant_from_uri(uri, paths=None):
+    """Get a variant given its URI.
+
+    Args:
+        uri (str): Variant URI
+        paths (list of str): paths to search for variants, defaults to
+            `config.packages_path`.
+
+    Returns:
+        `VariantResource`, or None if the variant is not present in this
+        package repository.
+    """
+    for path in (paths or config.packages_path):
+        repo = package_repository_manager.get_repository(path)
+        variant_resource = repo.get_variant_from_uri(uri)
+        if variant_resource is not None:
+            return Variant(variant_resource)
+
+    return None
+
+
 def get_last_release_time(name, paths=None):
     """Returns the most recent time this package was released.
 
     Note that releasing a variant into an already-released package is also
     considered a package release.
+
+    Args:
+        name (str): Package family name.
+        paths (list of str): paths to search for packages, defaults to
+            `config.packages_path`.
 
     Returns:
         int: Epoch time of last package release, or zero if this cannot be

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -2,7 +2,7 @@
 test package iteration, serialization etc
 """
 from rez.packages import iter_package_families, iter_packages, get_package, \
-    create_package, get_developer_package
+    create_package, get_developer_package, get_variant_from_uri
 from rez.package_py_utils import expand_requirement
 from rez.package_resources import package_release_keys
 from rez.tests.util import TestBase, TempdirMixin
@@ -421,6 +421,13 @@ class TestPackages(TestBase, TempdirMixin):
 
         for req in bad_tests:
             self.assertRaises(VersionError, expand_requirement, req)
+
+    def test_variant_from_uri(self):
+        """Test getting a variant from its uri."""
+        package = get_package("variants_py", "2.0")
+        for variant in package.iter_variants():
+            variant2 = get_variant_from_uri(variant.uri)
+            self.assertEqual(variant, variant2)
 
 
 class TestMemoryPackages(TestBase):

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.59.0"
+_rez_version = "2.60.0"
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
This is a first step towards https://github.com/nerdvegas/rez/issues/680, which I'm starting to work on now (yay!). The intent here is that you should be able to munge commands together to do useful things fairly easily.

For example, to warm the package cache, you might do this:

```
> ]$ rez-context --resolve --show-uris | xargs rez-package-cache --add-variant
```

In a similar vein, perhaps you want to create a local package repo for a context, so you can create a new context using only these variants, and then copy the whole thing to a server (more work is required to make this fully standalone, but I'm keen to see this feature, as is our engineering department, who hate nfs mounts :) ):

```
> ]$ rez-context --resolve --show-uris | xargs -i rez-cp --variant-uris {} --dest-path /mylocalrepo
```
