### PR TITLE
Cli variant uri

### DIFF
--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -127,6 +127,19 @@ def _env_var_true(name):
     return (os.getenv(name, "").lower() in ("1", "true", "on", "yes"))
 
 
+def print_items(items, stream=sys.stdout):
+    try:
+        item_per_line = (not stream.isatty())
+    except:
+        item_per_line = True
+
+    if item_per_line:
+        for item in items:
+            print(item)
+    else:
+        print(' '.join(map(str, items)))
+
+
 def sigbase_handler(signum, frame):
     # show cursor - progress lib may have hidden it
     SHOW_CURSOR = '\x1b[?25h'

--- a/src/rez/cli/context.py
+++ b/src/rez/cli/context.py
@@ -34,7 +34,7 @@ def setup_parser(parser, completions=False):
     parser.add_argument(
         "--res", "--print-resolve", dest="print_resolve",
         action="store_true",
-        help="print only the resolve list")
+        help="print only the resolve list. Use with --su to print package URIs")
     parser.add_argument(
         "--so", "--source-order", dest="source_order", action="store_true",
         help="print resolved packages in order they are sorted, rather than "
@@ -96,6 +96,7 @@ def setup_parser(parser, completions=False):
 
 
 def command(opts, parser, extra_arg_groups=None):
+    from rez.cli._util import print_items
     from rez.status import status
     from rez.utils.formatting import columnise, PackageRequest
     from rez.resolved_context import ResolvedContext
@@ -123,9 +124,12 @@ def command(opts, parser, extra_arg_groups=None):
 
     if not opts.interpret:
         if opts.print_request:
-            print(" ".join(str(x) for x in rc.requested_packages(False)))
+            print_items(rc.requested_packages(False))
         elif opts.print_resolve:
-            print(' '.join(x.qualified_package_name for x in rc.resolved_packages))
+            if opts.show_uris:
+                print_items(x.uri for x in rc.resolved_packages)
+            else:
+                print_items(x.qualified_package_name for x in rc.resolved_packages)
         elif opts.tools:
             rc.print_tools()
         elif opts.diff:

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -170,6 +170,18 @@ class PackageRepository(object):
         """
         raise NotImplementedError
 
+    def get_variant_from_uri(self, uri):
+        """Get a variant given its URI.
+
+        Args:
+            uri (str): Variant URI
+
+        Returns:
+            `VariantResource`, or None if the variant is not present in this
+            package repository.
+        """
+        return None
+
     def pre_variant_install(self, variant_resource):
         """Called before a variant is installed.
 

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -637,11 +637,37 @@ def get_variant(variant_handle, context=None):
     return variant
 
 
+def get_variant_from_uri(uri, paths=None):
+    """Get a variant given its URI.
+
+    Args:
+        uri (str): Variant URI
+        paths (list of str): paths to search for variants, defaults to
+            `config.packages_path`.
+
+    Returns:
+        `VariantResource`, or None if the variant is not present in this
+        package repository.
+    """
+    for path in (paths or config.packages_path):
+        repo = package_repository_manager.get_repository(path)
+        variant_resource = repo.get_variant_from_uri(uri)
+        if variant_resource is not None:
+            return Variant(variant_resource)
+
+    return None
+
+
 def get_last_release_time(name, paths=None):
     """Returns the most recent time this package was released.
 
     Note that releasing a variant into an already-released package is also
     considered a package release.
+
+    Args:
+        name (str): Package family name.
+        paths (list of str): paths to search for packages, defaults to
+            `config.packages_path`.
 
     Returns:
         int: Epoch time of last package release, or zero if this cannot be

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -2,7 +2,7 @@
 test package iteration, serialization etc
 """
 from rez.packages import iter_package_families, iter_packages, get_package, \
-    create_package, get_developer_package
+    create_package, get_developer_package, get_variant_from_uri
 from rez.package_py_utils import expand_requirement
 from rez.package_resources import package_release_keys
 from rez.tests.util import TestBase, TempdirMixin
@@ -421,6 +421,13 @@ class TestPackages(TestBase, TempdirMixin):
 
         for req in bad_tests:
             self.assertRaises(VersionError, expand_requirement, req)
+
+    def test_variant_from_uri(self):
+        """Test getting a variant from its uri."""
+        package = get_package("variants_py", "2.0")
+        for variant in package.iter_variants():
+            variant2 = get_variant_from_uri(variant.uri)
+            self.assertEqual(variant, variant2)
 
 
 class TestMemoryPackages(TestBase):

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.59.0"
+_rez_version = "2.60.0"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -577,11 +577,14 @@ class FileSystemPackageRepository(PackageRepository):
             return None
 
         # find variant in package
-        try:
-            variant_index = int(part2)
-        except:
-            # future proof - we may move to hash-based indices for hashed variants
-            variant_index = part2
+        if part2 == '':
+            variant_index = None
+        else:
+            try:
+                variant_index = int(part2)
+            except:
+                # future proof - we may move to hash-based indices for hashed variants
+                variant_index = part2
 
         for variant in pkg.iter_variants():
             if variant.index == variant_index:


### PR DESCRIPTION
The rez-cp tool now has a --variant-uri option, so you can do things like this:

```
> ]$ rez-context --resolve --su | xargs -i rez-cp --variant-uri {} --dest-path ...
```

Ie, copy all the variants in a context, into their own package repo.

PR to merge first: https://github.com/nerdvegas/rez/pull/886
