### PR TITLE
fix bug in py3 (hash of unicode)

### DIFF
--- a/src/rez/cli/release.py
+++ b/src/rez/cli/release.py
@@ -82,7 +82,7 @@ def command(opts, parser, extra_arg_groups=None):
     if config.prompt_release_message and not release_msg and not opts.no_message:
         from hashlib import sha1
 
-        h = sha1(working_dir).hexdigest()
+        h = sha1(working_dir.encode("utf8")).hexdigest()
         filename = "rez-release-message-%s.txt" % h
         filepath = os.path.join(config.tmpdir, filename)
 

--- a/src/rez/resolver.py
+++ b/src/rez/resolver.py
@@ -69,7 +69,7 @@ class Resolver(object):
         # store hash of package orderers. This is used in the memcached key
         if package_orderers:
             sha1s = ''.join(x.sha1 for x in package_orderers)
-            self.package_orderers_hash = sha1(sha1s).hexdigest()
+            self.package_orderers_hash = sha1(sha1s.encode("utf8")).hexdigest()
         else:
             self.package_orderers_hash = ''
 

--- a/src/rez/utils/sourcecode.py
+++ b/src/rez/utils/sourcecode.py
@@ -312,10 +312,10 @@ class IncludeModuleManager(object):
             if not os.path.exists(filepath):
                 return None
 
-            with open(filepath) as f:
+            with open(filepath, "rb") as f:
                 txt = f.read().strip()
 
-            hash_str = sha1(txt.encode("utf8")).hexdigest()
+            hash_str = sha1(txt).hexdigest()
         else:
             # load sourcefile that's been copied into package install payload
             path = os.path.join(package.base, self.include_modules_subpath)

--- a/src/rez/utils/sourcecode.py
+++ b/src/rez/utils/sourcecode.py
@@ -315,7 +315,7 @@ class IncludeModuleManager(object):
             with open(filepath) as f:
                 txt = f.read().strip()
 
-            hash_str = sha1(txt).hexdigest()
+            hash_str = sha1(txt.encode("utf8")).hexdigest()
         else:
             # load sourcefile that's been copied into package install payload
             path = os.path.join(package.base, self.include_modules_subpath)

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -298,7 +298,7 @@ class LocalBuildProcess(BuildProcessHelper):
             with open(filepath, "rb") as f:
                 txt = f.read().strip()
 
-            uuid = sha1(txt).hexdigest()
+            uuid = sha1(txt.encode("utf8")).hexdigest()
             dest_filepath = os.path.join(path, "%s-%s.py" % (name, uuid))
 
             if not os.path.exists(dest_filepath):

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -298,7 +298,7 @@ class LocalBuildProcess(BuildProcessHelper):
             with open(filepath, "rb") as f:
                 txt = f.read().strip()
 
-            uuid = sha1(txt.encode("utf8")).hexdigest()
+            uuid = sha1(txt).hexdigest()
             dest_filepath = os.path.join(path, "%s-%s.py" % (name, uuid))
 
             if not os.path.exists(dest_filepath):


### PR DESCRIPTION
Fixed various places not hit in py3 testing yet, where hash of non-encoded string would result in:

```
TypeError: Unicode-objects must be encoded before hashing
```
