### PR TITLE
Allow configuration of filesystem lock mechanism

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -450,6 +450,7 @@ class FileSystemPackageRepository(PackageRepository):
     """
     schema_dict = {"file_lock_timeout": int,
                    "file_lock_dir": Or(None, str),
+                   "file_lock_type": Or("default", "link", "mkdir"),
                    "package_filenames": [basestring]}
 
     building_prefix = ".building"
@@ -724,7 +725,14 @@ class FileSystemPackageRepository(PackageRepository):
 
     @contextmanager
     def _lock_package(self, package_name, package_version=None):
-        from rez.vendor.lockfile import LockFile, NotLocked
+        from rez.vendor.lockfile import NotLocked
+
+        if _settings.file_lock_type == 'default':
+            from rez.vendor.lockfile import LockFile
+        elif _settings.file_lock_type == 'mkdir':
+            from rez.vendor.lockfile.mkdirlockfile import MkdirLockFile as LockFile
+        elif _settings.file_lock_type == 'link':
+            from rez.vendor.lockfile.linklockfile import LinkLockFile as LockFile
 
         path = self.location
 

--- a/src/rezplugins/package_repository/rezconfig
+++ b/src/rezplugins/package_repository/rezconfig
@@ -1,4 +1,10 @@
 filesystem:
+    # The mechanism used to create the lockfile. If set to 'default', this will
+    # use hardlinks if the 'os.link' method is present, otherwise mkdir is used.
+    # It can also be explicitly set to use only 'hardlink', or only 'mkdir'.
+    # Valid options are 'default', 'mkdir', or 'hardlink'
+    file_lock_type: default
+
     # The timeout to use when creating file locks. This is done when a variant is
     # installed into an existing package, to prevent multiple file writes at
     # once (which could result in a variant install getting lost). The timeout


### PR DESCRIPTION
Even in the presence of os.link, the filesystem used for `release_packages_path` might not support hardlinks

In our case the lock during `rez release` would error like so:

```
  File "\\example\rez\lib\site-packages\rez\vendor\lockfile\linklockfile.py", line 30, in acquire
    os.link(self.unique_name, self.lock_file)
OSError: [WinError 50] The request is not supported: '\\\\example\\rez\\packages\\ExampleHost-2588.10520-7026682643879910208' -> '\\\\example\\rez\\packages\\.lock.deploytest-0.1.0.lock'
```

With the supplied patch, this can be configured like so:

```python
plugins = {
    "package_repository": {
        "filesystem": {
            "file_lock_type": "mkdir",
        },
    },
}
```
to force the lockfile module to use the mkdir based lock. I also added option in to force it to `hardlink`, and the `default` option preserves the existing behaviour of using `hardlink` if `hasattr(os, 'link')` (also briefly considered adding a `none` option but that didn't seem like a good idea!)