### PR TITLE
make context tracking tolerant of errors

### DIFF
--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.61.1"
+_rez_version = "2.61.2"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/vendor/amqp/transport.py
+++ b/src/rez/vendor/amqp/transport.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 import errno
 import re
 import socket
-import ssl
 
 # Jython does not have this attribute
 try:
@@ -200,6 +199,11 @@ class SSLTransport(_AbstractTransport):
 
     def _setup_transport(self):
         """Wrap the socket in an SSL object."""
+
+        # note: moved here in rez in order to avoid ssl import unless necessary
+        # https://github.com/nerdvegas/rez/issues/910
+        import ssl
+
         if hasattr(self, 'sslopts'):
             self.sock = ssl.wrap_socket(self.sock, **self.sslopts)
         else:


### PR DESCRIPTION
Fixes #910 (kindof)

-moved ssl import in amqp vendor lib so only imported if necessary
-made tolerant of exceptions in context tracking, just print error
