### PR TITLE
Respect sys path order when spawning shell on Windows

### DIFF
--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -120,7 +120,7 @@ class PowerShellBase(Shell):
             if match:
                 paths.extend(match.group(2).split(os.pathsep))
 
-        cls.syspaths = list(set([x for x in paths if x]))
+        cls.syspaths = [x for x in paths if x]
 
         return cls.syspaths
 

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -132,7 +132,7 @@ class CMD(Shell):
             if match:
                 paths.extend(match.group(2).split(os.pathsep))
 
-        cls.syspaths = set([x for x in paths if x])
+        cls.syspaths = [x for x in paths if x]
         return cls.syspaths
 
     def _bind_interactive_rez(self):


### PR DESCRIPTION
This is a quick fix for issue #925, which only consider to keep the ordering of paths but ignores the duplicates.