### PR TITLE
Fix #927, add encoding=utf-8 on file write

### DIFF
--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -22,6 +22,7 @@ from rez.config import config
 from rez.vendor.atomicwrites import atomic_write
 from rez.vendor.enum import Enum
 from rez.vendor.six.six.moves import StringIO
+from rez.vendor.six.six import PY3
 from rez.vendor import yaml
 
 
@@ -63,12 +64,13 @@ def open_file_for_write(filepath, mode=None):
     filepath = os.path.realpath(filepath)
     tmpdir = tmpdir_manager.mkdtemp()
     cache_filepath = os.path.join(tmpdir, os.path.basename(filepath))
+    encoding = {"encoding": "utf-8"} if PY3 else {}
 
     debug_print("Writing to %s (local cache of %s)", cache_filepath, filepath)
 
     for attempt in range(2):
         try:
-            with atomic_write(filepath, overwrite=True) as f:
+            with atomic_write(filepath, overwrite=True, **encoding) as f:
                 f.write(content)
 
         except WindowsError as e:
@@ -85,7 +87,7 @@ def open_file_for_write(filepath, mode=None):
     if mode is not None:
         os.chmod(filepath, mode)
 
-    with open(cache_filepath, 'w') as f:
+    with open(cache_filepath, 'w', **encoding) as f:
         f.write(content)
 
     file_cache[filepath] = cache_filepath


### PR DESCRIPTION
This PR will allow installing/releasing packages which has Unicode character in `package.py`.

For example, this relaxing package "☺️" would failed before this PR
```python

name = "_releaxed"

version = "0.1.0"

authors = ["☺️"]

build_command = False


def commands():
    print("Releax ! ☺️")

```

But after this PR, you get
```
C:\Users\david\dev\test\unicode-content>rez-build --install

================================================================================
Building _releaxed-a.b.c...
================================================================================
Resolving build environment:
resolved by david@DESKTOP-EABK8SP, on Mon Aug 10 02:34:17 2020, using Rez v2.63.0

requested packages:
~platform==windows           (implicit)
~arch==AMD64                 (implicit)
~os==windows-10.0.19041.SP0  (implicit)

resolved packages:

Invoking custom build system...

================================================================================
Build Summary
================================================================================

All 1 build(s) were successful.


C:\Users\david\dev\test\unicode-content>rez-env _releaxed
Releax ! ☺️

You are now in a rez-configured environment.

```

