### PR TITLE
Fix #934, no hash string in include script file name

### DIFF
--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -16,7 +16,6 @@ from rez.utils.sourcecode import IncludeModuleManager
 from rez.utils.filesystem import TempDirs
 from rez.package_test import PackageTestRunner, PackageTestResults
 
-from hashlib import sha1
 import json
 import shutil
 import os
@@ -298,11 +297,8 @@ class LocalBuildProcess(BuildProcessHelper):
             with open(filepath, "rb") as f:
                 txt = f.read().strip()
 
-            uuid = sha1(txt).hexdigest()
-            dest_filepath = os.path.join(path, "%s-%s.py" % (name, uuid))
-
-            if not os.path.exists(dest_filepath):
-                shutil.copy(filepath, dest_filepath)
+            dest_filepath = os.path.join(path, "%s.py" % name)
+            shutil.copy(filepath, dest_filepath)  # overwrite if exists
 
     def _rmtree(self, path):
         try:

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -16,6 +16,7 @@ from rez.utils.sourcecode import IncludeModuleManager
 from rez.utils.filesystem import TempDirs
 from rez.package_test import PackageTestRunner, PackageTestResults
 
+from hashlib import sha1
 import json
 import shutil
 import os
@@ -296,9 +297,14 @@ class LocalBuildProcess(BuildProcessHelper):
 
             with open(filepath, "rb") as f:
                 txt = f.read().strip()
+            uuid = sha1(txt).hexdigest()
 
             dest_filepath = os.path.join(path, "%s.py" % name)
             shutil.copy(filepath, dest_filepath)  # overwrite if exists
+
+            sha1_filepath = os.path.join(path, "%s.sha1" % name)
+            with open(sha1_filepath, "w") as f:  # overwrite if exists
+                f.write(uuid)
 
     def _rmtree(self, path):
         try:


### PR DESCRIPTION
This PR fix #934. Installed package will be able to pick up updated included module.

### What's changed

* Python module that being included in `package.py` with `@include`, will be copied without hash string.
* When an installed package try to load the includes, will firstly find the module that is not named with hash string, if NOT found, fallback to previous behavior. And if found, the module file will be hashed again for finding previous imported one.