### PR TITLE
Raise unversioned error when config not allowed

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1184,7 +1184,8 @@ class FileSystemPackageRepository(PackageRepository):
         # Stop if package is unversioned and config does not allow that
         if (not package_data["version"]
                 and not config.allow_unversioned_packages):
-            raise PackageMetadataError("Unversioned package is not allowed.")
+            raise PackageMetadataError("Unversioned package is not allowed "
+                                       "in current configuration.")
 
         # write out new package definition file
         package_file = ".".join([package_filename, package_extension])

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1181,6 +1181,11 @@ class FileSystemPackageRepository(PackageRepository):
         # format version is always set
         package_data["format_version"] = format_version
 
+        # Stop if package is unversioned and config does not allow that
+        if (not package_data["version"]
+                and not config.allow_unversioned_packages):
+            raise PackageMetadataError("Unversioned package is not allowed.")
+
         # write out new package definition file
         package_file = ".".join([package_filename, package_extension])
         filepath = os.path.join(pkg_base_path, package_file)


### PR DESCRIPTION
### Problem

When building unversioned package with `config.allow_unversioned_packages = False`, the error raised and says :
```
  ...
  File "..\rezplugins\package_repository\filesystem.py", line 715, in _create_variant
    overrides=overrides
  File "..\rezplugins\package_repository\filesystem.py", line 1228, in _create_variant
    raise RezSystemError("Internal failure - expected installed variant")
rez.exceptions.RezSystemError: Internal failure - expected installed variant
```
Which isn't clear enough to know that the failure was due to building a package which is unversioned while Rez has been configured to not allow it.

### Propose

Check package data and config settings between data override applying and data dumping.
And the output would be :
```
Invoking custom build system...
20:48:55 ERROR    PackageMetadataError: Unversioned package is not allowed in current configuration.
```
