### PR TITLE
Support rez-env -c <alias> or -- <alias> (Windows CMD shell)

### DIFF
--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1308,7 +1308,7 @@ class ResolvedContext(object):
         if post_actions_callback:
             post_actions_callback(executor)
 
-        if command:
+        if command and self.platform == "windows":
             command = self._reveal_alias(executor, command)
 
         executor.env.REZ_SHELL_INIT_TIMESTAMP = str(int(time.time()))

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -16,7 +16,7 @@ from rez.utils.filesystem import TempDirs
 from rez.utils.memcached import pool_memcached_connections
 from rez.utils.logging_ import print_error, print_warning
 from rez.backport.shutilwhich import which
-from rez.rex import RexExecutor, Python, OutputStyle
+from rez.rex import RexExecutor, Python, OutputStyle, Alias
 from rez.rex_bindings import VersionBinding, VariantBinding, \
     VariantsBinding, RequirementsBinding
 from rez import package_order
@@ -1307,6 +1307,14 @@ class ResolvedContext(object):
 
         if post_actions_callback:
             post_actions_callback(executor)
+
+        if command:
+            # Swap into actual command if it's alias
+            for action in executor.manager.actions:
+                if isinstance(action, Alias):
+                    if command == action.args[0]:
+                        command = action.args[1]
+                        break
 
         executor.env.REZ_SHELL_INIT_TIMESTAMP = str(int(time.time()))
         executor.env.REZ_SHELL_INTERACTIVE = "1" if command is None else "0"

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1309,12 +1309,7 @@ class ResolvedContext(object):
             post_actions_callback(executor)
 
         if command:
-            # Swap into actual command if it's alias
-            for action in executor.manager.actions:
-                if isinstance(action, Alias):
-                    if command == action.args[0]:
-                        command = action.args[1]
-                        break
+            command = self._reveal_alias(executor, command)
 
         executor.env.REZ_SHELL_INIT_TIMESTAMP = str(int(time.time()))
         executor.env.REZ_SHELL_INTERACTIVE = "1" if command is None else "0"
@@ -1886,6 +1881,12 @@ class ResolvedContext(object):
         for path in suite_paths:
             tools_path = os.path.join(path, "bin")
             executor.env.PATH.append(tools_path)
+
+    def _reveal_alias(self, executor, command):
+        for action in executor.actions:
+            if isinstance(action, Alias) and command == action.args[0]:
+                return action.args[1]
+        return command
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -16,7 +16,7 @@ from rez.utils.filesystem import TempDirs
 from rez.utils.memcached import pool_memcached_connections
 from rez.utils.logging_ import print_error, print_warning
 from rez.backport.shutilwhich import which
-from rez.rex import RexExecutor, Python, OutputStyle, Alias
+from rez.rex import RexExecutor, Python, OutputStyle
 from rez.rex_bindings import VersionBinding, VariantBinding, \
     VariantsBinding, RequirementsBinding
 from rez import package_order
@@ -1308,9 +1308,6 @@ class ResolvedContext(object):
         if post_actions_callback:
             post_actions_callback(executor)
 
-        if command and self.platform == "windows":
-            command = self._reveal_alias(executor, command)
-
         executor.env.REZ_SHELL_INIT_TIMESTAMP = str(int(time.time()))
         executor.env.REZ_SHELL_INTERACTIVE = "1" if command is None else "0"
 
@@ -1881,12 +1878,6 @@ class ResolvedContext(object):
         for path in suite_paths:
             tools_path = os.path.join(path, "bin")
             executor.env.PATH.append(tools_path)
-
-    def _reveal_alias(self, executor, command):
-        for action in executor.actions:
-            if isinstance(action, Alias) and command == action.args[0]:
-                return action.args[1]
-        return command
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -416,6 +416,31 @@ class TestShells(TestBase, TempdirMixin):
 
         _execute_code(_make_alias)
 
+    @per_available_shell()
+    def test_alias_command_with_args(self):
+        """Testing alias can be passed in as command with args
+
+        This is important for Windows CMD shell because the doskey.exe isn't
+        executed yet when the alias is being passed.
+
+        """
+
+        def _execute_code(func):
+            loc = inspect.getsourcelines(func)[0][1:]
+            code = textwrap.dedent('\n'.join(loc))
+            r = self._create_context([])
+            p = r.execute_shell(command='tell "hello"',
+                                actions_callback=lambda e: e.execute_code(code),
+                                stdout=subprocess.PIPE)
+
+            out, _ = p.communicate()
+            self.assertEqual(0, p.returncode)
+
+        def _make_alias():
+            alias('tell', 'echo')
+
+        _execute_code(_make_alias)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -396,8 +396,8 @@ class TestShells(TestBase, TempdirMixin):
     def test_alias_command(self):
         """Testing alias can be passed in as command
 
-        This is important for Windows because the doskey.exe isn't executed
-        yet when the alias is being passed.
+        This is important for Windows CMD shell because the doskey.exe isn't
+        executed yet when the alias is being passed.
 
         """
         def _execute_code(func):

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -392,6 +392,30 @@ class TestShells(TestBase, TempdirMixin):
         # code 0.
         _execute_code(_alias_after_path_manipulation)
 
+    @per_available_shell()
+    def test_alias_command(self):
+        """Testing alias can be passed in as command
+
+        This is important for Windows because the doskey.exe isn't executed
+        yet when the alias is being passed.
+
+        """
+        def _execute_code(func):
+            loc = inspect.getsourcelines(func)[0][1:]
+            code = textwrap.dedent('\n'.join(loc))
+            r = self._create_context([])
+            p = r.execute_shell(command='hi',
+                                actions_callback=lambda e: e.execute_code(code),
+                                stdout=subprocess.PIPE)
+
+            out, _ = p.communicate()
+            self.assertEqual(0, p.returncode)
+
+        def _make_alias():
+            alias('hi', 'echo "hi"')
+
+        _execute_code(_make_alias)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -216,7 +216,7 @@ def per_available_shell():
                     if hasattr(e, "args") and e.args:
                         try:
                             args = list(e.args)
-                            args[0] += " (in shell '{}')".format(shell)
+                            args[0] = str(args[0]) + " (in shell '{}')".format(shell)
                             e.args = tuple(args)
                         except:
                             raise e

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -23,6 +23,7 @@ class CMD(Shell):
     # http://ss64.com/nt/cmd.html
     syspaths = None
     _doskey = None
+    _doskey_alias = None
     expand_env_vars = True
 
     _env_var_regex = re.compile("%([A-Za-z0-9_]+)%")    # %ENVVAR%
@@ -152,6 +153,7 @@ class CMD(Shell):
                     stdin=False, command=None, env=None, quiet=False,
                     pre_command=None, add_rez=True, **Popen_args):
 
+        command = self._reveal_alias(command)
         startup_sequence = self.get_startup_sequence(rcfile, norc, bool(stdin), command)
         shell_command = None
 
@@ -312,6 +314,7 @@ class CMD(Shell):
                 self._doskey = "doskey"
 
         self._addline("%s %s=%s $*" % (self._doskey, key, value))
+        self._alias_map(key, value)
 
     def comment(self, value):
         for line in value.split('\n'):
@@ -351,6 +354,16 @@ class CMD(Shell):
     @classmethod
     def line_terminator(cls):
         return "\r\n"
+
+    def _alias_map(self, key, value):
+        if self._doskey_alias is None:
+            self._doskey_alias = dict()
+        self._doskey_alias[key] = value
+
+    def _reveal_alias(self, command):
+        if self._doskey_alias is None:
+            return command
+        return self._doskey_alias.get(command, command)
 
 
 def register_plugin():

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -373,11 +373,13 @@ class CMD(Shell):
         it with full command if matched.
 
         """
-        command_map = self._doskey_alias or dict()
+        if command:
+            command_map = self._doskey_alias or dict()
 
-        for alias in command_map:
-            if command == alias or command.startswith(alias + " "):
-                return command_map[alias] + command[len(alias):]
+            for alias in command_map:
+                if command == alias or command.startswith(alias + " "):
+                    command = command_map[alias] + command[len(alias):]
+                    break
 
         return command
 

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -153,7 +153,7 @@ class CMD(Shell):
                     stdin=False, command=None, env=None, quiet=False,
                     pre_command=None, add_rez=True, **Popen_args):
 
-        command = self._reveal_alias(command)
+        command = self._expand_alias(command)
         startup_sequence = self.get_startup_sequence(rcfile, norc, bool(stdin), command)
         shell_command = None
 
@@ -360,7 +360,7 @@ class CMD(Shell):
             self._doskey_alias = dict()
         self._doskey_alias[key] = value
 
-    def _reveal_alias(self, command):
+    def _expand_alias(self, command):
         command_map = self._doskey_alias or dict()
 
         for alias in command_map:

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -361,6 +361,18 @@ class CMD(Shell):
         self._doskey_alias[key] = value
 
     def _expand_alias(self, command):
+        """Expand `command` if alias is being presented
+
+        This is important for Windows CMD shell because the doskey.exe isn't
+        executed yet when the alias is being passed in `command`.
+
+        Which means we could not rely on doskey.exe to execute alias in first
+        run.
+
+        So here we lookup alias that were just parsed from package, replace
+        it with full command if matched.
+
+        """
         command_map = self._doskey_alias or dict()
 
         for alias in command_map:

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -361,9 +361,13 @@ class CMD(Shell):
         self._doskey_alias[key] = value
 
     def _reveal_alias(self, command):
-        if self._doskey_alias is None:
-            return command
-        return self._doskey_alias.get(command, command)
+        command_map = self._doskey_alias or dict()
+
+        for alias in command_map:
+            if command == alias or command.startswith(alias + " "):
+                return command_map[alias] + command[len(alias):]
+
+        return command
 
 
 def register_plugin():


### PR DESCRIPTION
### Problem

As #708 stated, `rez-env pkg -c alias-cmd` or `rez-env pkg -- alias-cmd` currently not supported (on Windows).

### Solution

Since the `Alias` object will be saved in `ActionManager` if any alias setup been found in package's commands by `RexExecutor`, look into that list and matching them with input `command`, swap it back to actual command if matched, would be the simplest solution.
