### PR TITLE
Fixes package cache stall on osx.

### DIFF
--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -294,7 +294,7 @@ class PackageCache(object):
                 cmd = 'copy'
             else:
                 cmd = 'cp'
-            p = Popen([cmd, '-r', variant_root, rootpath], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+            p = subprocess.Popen([cmd, '-r', variant_root, rootpath], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             output, err = p.communicate()
         finally:
             still_copying = False

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -290,7 +290,12 @@ class PackageCache(object):
         th.start()
 
         try:
-            shutil.copytree(variant_root, rootpath)
+            if sys.platform == 'win32':
+                cmd = 'copy'
+            else:
+                cmd = 'cp'
+            p = Popen([cmd, '-r', variant_root, rootpath], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+            output, err = p.communicate()
         finally:
             still_copying = False
 


### PR DESCRIPTION
Using shutil on osx causes the package cache to stall. (unable to delete the .copying file maybe? )
Replacing shutil with cp appears to fix the issue.
"copy" command added to retain windows compatibility.

Resolves nerdvegas/rez/#950