### PR TITLE
Fix unicode vcs changelog encode err

### DIFF
--- a/src/rez/release_vcs.py
+++ b/src/rez/release_vcs.py
@@ -208,7 +208,7 @@ class ReleaseVCS(object):
             print_debug("Running command: %s" % cmd_str)
 
         p = Popen(nargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                  cwd=self.pkg_root, text=True)
+                  cwd=self.pkg_root, text=True, encoding="utf-8")
         out, err = p.communicate()
 
         if p.returncode:

--- a/src/rez/utils/execution.py
+++ b/src/rez/utils/execution.py
@@ -73,8 +73,8 @@ class Popen(_PopenBase):
         #
         # NOTE: currently no solution for `python3+<3.6`
         #
-        if sys.version_info[:2] >= (3, 6) and "encoding" in kwargs:
-            kwargs['encoding'] = 'utf-8'
+        if sys.version_info[:2] < (3, 6) and "encoding" in kwargs:
+            kwargs.pop("encoding")
 
         super(Popen, self).__init__(args, **kwargs)
 

--- a/src/rez/utils/formatting.py
+++ b/src/rez/utils/formatting.py
@@ -492,7 +492,7 @@ def as_block_string(txt):
 
     lines = []
     for line in txt.split('\n'):
-        line_ = json.dumps(line)
+        line_ = json.dumps(line, ensure_ascii=False)
         line_ = line_[1:-1].rstrip()  # drop double quotes
         lines.append(line_)
 


### PR DESCRIPTION
### Problem

`rez-release` raise `UnicodeDecodeError` when releasing package with non-ascii characters in change log.

### Solution

* Explicitly set `encoding="utf-8"` when fetching results from vsc with subprocess. (but not if `python<3.6`)
* Allow non-ascii character when formatting with `json`.


