### PR TITLE
Fix repo location false mismatch

### DIFF
--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -337,14 +337,14 @@ class PackageRepository(object):
             # always be made from repo.make_resource_handle... for now,
             # at least, error to catch any "incorrect" construction of
             # handles...
-            if resource_handle.variables.get("repository_type") != self.name():
+            repository_type = resource_handle.variables.get("repository_type")
+            if repository_type != self.name():
                 raise ResourceError("repository_type mismatch - requested %r, "
                                     "repository_type is %r"
-                                    % (resource_handle.variables["repository_type"],
-                                       self.name()))
+                                    % (repository_type, self.name()))
 
             location = resource_handle.variables.get("location")
-            if self.name() == "filesystem":
+            if repository_type == "filesystem":
                 location = canonical_path(location)
 
             if location != self.location:

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -1,5 +1,6 @@
 from rez.utils.resources import ResourcePool, ResourceHandle
 from rez.utils.data_utils import cached_property
+from rez.utils.filesystem import canonical_path
 from rez.plugin_managers import plugin_manager
 from rez.config import config
 from rez.exceptions import ResourceError
@@ -342,11 +343,14 @@ class PackageRepository(object):
                                     % (resource_handle.variables["repository_type"],
                                        self.name()))
 
-            if resource_handle.variables.get("location") != self.location:
+            location = resource_handle.variables.get("location")
+            if self.name() == "filesystem":
+                location = canonical_path(location)
+
+            if location != self.location:
                 raise ResourceError("location mismatch - requested %r, "
                                     "repository location is %r "
-                                    % (resource_handle.variables["location"],
-                                       self.location))
+                                    % (location, self.location))
 
         resource = self.pool.get_resource_from_handle(resource_handle)
         resource._repository = self


### PR DESCRIPTION
### Problem

I have my `release_packages_path` set to a mounted network drive e.g. `'x:/rez-studio/release'`, and when I run the following script to get current resolved context, I got `ResourceError` that saying my repository location mismatched.

```
>>> from rez.status import status
>>> status.context
Traceback (most recent call last):
...
rez.exceptions.ResourceError: location mismatch - requested 'x:\\rez-studio\\release',
    repository location is '\\\\server\\technical\\rez-studio\\release'
```

<details><summary>Full error</summary>

```shell
>>> from rez.status import status
>>> status.context
Traceback (most recent call last):
  File "c:\users\davidlatwe.lai\rez\packages\install\rez\2.67.0\platform-windows\payload\rez\resolved_context.py", line 615, in read_from_buffer
    return cls._read_from_buffer(buf, identifier_str)
  File "c:\users\davidlatwe.lai\rez\packages\install\rez\2.67.0\platform-windows\payload\rez\resolved_context.py", line 1666, in _read_from_buffer
    context = cls.from_dict(doc, identifier_str)
  File "c:\users\davidlatwe.lai\rez\packages\install\rez\2.67.0\platform-windows\payload\rez\resolved_context.py", line 1511, in from_dict
    variant = get_variant(variant_handle)
  File "c:\users\davidlatwe.lai\rez\packages\install\rez\2.67.0\platform-windows\payload\rez\packages.py", line 671, in get_variant
    variant_resource = package_repository_manager.get_resource_from_handle(variant_handle)
  File "c:\users\davidlatwe.lai\rez\packages\install\rez\2.67.0\platform-windows\payload\rez\package_repository.py", line 499, in get_resource_from_handle
    resource = repo.get_resource_from_handle(resource_handle)
  File "c:\users\davidlatwe.lai\rez\packages\install\rez\2.67.0\platform-windows\payload\rez\package_repository.py", line 346, in get_resource_from_handle
    raise ResourceError("location mismatch - requested %r, "
rez.exceptions.ResourceError: location mismatch - requested 'x:\\rez-studio\\release', repository location is '\\\\server\\technical\\rez-studio\\release'
```
</details>

Those two paths were actually pointing to the same location, one is a mounted path, another is an Windows UNC path.

The UNC path was coming from the filesystem plugin, which convert the path with `rez.utils.filesystem.canonical_path`,
at here 👇🏼 
https://github.com/nerdvegas/rez/blob/77ada5b1a9a1793fd14a2403ebc8c5f6385599ba/src/rezplugins/package_repository/filesystem.py#L478-L480


But the other path (from `ResourceHandle`) that put to varified with, does not made it canonical.
https://github.com/nerdvegas/rez/blob/77ada5b1a9a1793fd14a2403ebc8c5f6385599ba/src/rez/package_repository.py#L345-L349

Hence the false alarm.

### Solution

Is this PR.


