### PR TITLE
Handling build/install directory remove error in build process

### DIFF
--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -11,7 +11,7 @@ from rez.utils.logging_ import print_warning
 from rez.utils.base26 import create_unique_base26_symlink
 from rez.utils.colorize import Printer, warning
 from rez.utils.filesystem import safe_makedirs, copy_or_replace, \
-    make_path_writable, get_existing_path
+    make_path_writable, get_existing_path, forceful_rmtree
 from rez.utils.sourcecode import IncludeModuleManager
 from rez.utils.filesystem import TempDirs
 from rez.package_test import PackageTestRunner, PackageTestResults
@@ -308,7 +308,7 @@ class LocalBuildProcess(BuildProcessHelper):
 
     def _rmtree(self, path):
         try:
-            shutil.rmtree(path)
+            forceful_rmtree(path)
         except Exception as e:
             print_warning("Failed to delete %s - %s", path, e)
 

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -142,7 +142,7 @@ class LocalBuildProcess(BuildProcessHelper):
 
         # create directories (build, install)
         if clean and os.path.exists(variant_build_path):
-            shutil.rmtree(variant_build_path)
+            self._rmtree(variant_build_path)
 
         safe_makedirs(variant_build_path)
 


### PR DESCRIPTION
### Problem

In the following cases, plain `shutil.rmtree` may have trouble removing a directory :
* Path length is over 259 characters (on Windows)
* Path contains Unicode character (using Python 2)
* File is read-only (e.g. some git internal files in `.git` folder, if build dir contains one)

This PR aims to overcome those issues and to ensure build/install directory can be removed entirely by Rez when we need it to. 