### PR TITLE
fix regression wrt unicode, subprocess

### DIFF
--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.68.2"
+_rez_version = "2.68.3"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/utils/execution.py
+++ b/src/rez/utils/execution.py
@@ -64,17 +64,18 @@ class Popen(_PopenBase):
         #
         text = kwargs.pop("text", None)
         universal_newlines = kwargs.pop("universal_newlines", None)
+
         if text or universal_newlines:
             kwargs["universal_newlines"] = True
 
-        # fixes py3/cmd.exe UnicodeDecodeError() with some characters.
-        #    UnicodeDecodeError: 'charmap' codec can't decode byte
-        #    0x8d in position 1023172: character maps to <undefined>
-        #
-        # NOTE: currently no solution for `python3+<3.6`
-        #
-        if sys.version_info[:2] >= (3, 6) and "encoding" not in kwargs:
-            kwargs["encoding"] = "utf-8"
+            # fixes py3/cmd.exe UnicodeDecodeError() with some characters.
+            #    UnicodeDecodeError: 'charmap' codec can't decode byte
+            #    0x8d in position 1023172: character maps to <undefined>
+            #
+            # NOTE: currently no solution for `python3+<3.6`
+            #
+            if sys.version_info[:2] >= (3, 6) and "encoding" not in kwargs:
+                kwargs["encoding"] = "utf-8"
 
         super(Popen, self).__init__(args, **kwargs)
 


### PR DESCRIPTION
This PR fixes a regression introduced when merging https://github.com/nerdvegas/rez/pull/956

Original PR related to this: https://github.com/nerdvegas/rez/pull/779/files

A mistake was made when merging 779, resulting in "encoding" not being set to "utf-8" when it should (ie, when py >= 3.6 AND "text"/"universal_newlines" arg present).
