### PR TITLE
handling QFileDialog.getSaveFileName return type

### DIFF
--- a/src/rezgui/dialogs/ResolveDialog.py
+++ b/src/rezgui/dialogs/ResolveDialog.py
@@ -307,7 +307,7 @@ class ResolveDialog(QtWidgets.QDialog, StoreSizeMixin):
         return i
 
     def _save_context(self):
-        filepath = QtWidgets.QFileDialog.getSaveFileName(
+        filepath, _ = QtWidgets.QFileDialog.getSaveFileName(
             self, "Save Context", filter="Context files (*.rxt)")
         if filepath:
             self.resolver.context.save(filepath)

--- a/src/rezgui/widgets/ContextManagerWidget.py
+++ b/src/rezgui/widgets/ContextManagerWidget.py
@@ -244,7 +244,7 @@ class ContextManagerWidget(QtWidgets.QWidget, ContextViewMixin):
         self._diff_with_file(filepath)
 
     def _diff_with_other(self):
-        filepath = QtWidgets.QFileDialog.getOpenFileName(
+        filepath, _ = QtWidgets.QFileDialog.getOpenFileName(
             self, "Open Context", filter="Context files (*.rxt)")
         if filepath:
             self._diff_with_file(str(filepath))

--- a/src/rezgui/windows/ContextSubWindow.py
+++ b/src/rezgui/windows/ContextSubWindow.py
@@ -125,7 +125,7 @@ class ContextSubWindow(QtWidgets.QMdiSubWindow, ContextViewMixin, StoreSizeMixin
 
     def _save_context_as(self):
         dir_ = os.path.dirname(self.filepath()) if self.filepath() else ""
-        filepath = QtWidgets.QFileDialog.getSaveFileName(
+        filepath, _ = QtWidgets.QFileDialog.getSaveFileName(
             self, "Save Context", dir_, "Context files (*.rxt)")
 
         if filepath:

--- a/src/rezgui/windows/MainWindow.py
+++ b/src/rezgui/windows/MainWindow.py
@@ -107,7 +107,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 bar.showMessage(txt, min_display_time - milisecs)
 
     def _open_context(self):
-        filepath = QtWidgets.QFileDialog.getOpenFileName(
+        filepath, _ = QtWidgets.QFileDialog.getOpenFileName(
             self, "Open Context", filter="Context files (*.rxt)")
         if filepath:
             self.open_context(str(filepath))


### PR DESCRIPTION
Closes #962 

getSaveFileName and getOpenFileName always returns a tuple with Qt.py: (fileName, selectedFilter).
