### PR TITLE
Update vendored pydot (1.4.2.dev0)

### DIFF
--- a/src/rez/vendor/README.md
+++ b/src/rez/vendor/README.md
@@ -159,12 +159,15 @@ Note that the latest versions column is just to give us an idea of how far back 
 <tr><td>
     pydot
 </td><td>
-    1.4.1 (Dec 12, 2018)
+    1.4.2.dev0 (Oct 28, 2020)
 </td><td>
-    1.4.1 (Dec 12, 2018)
+    1.4.2.dev0 (Oct 28, 2020)
 </td><td>
-    Updated (July 2019) in order to update pyparsing lib which in turn is
-    required by the packaging library. Updated (Aug 2019) for py3.
+    
+* Updated (July 2019) in order to update pyparsing lib which in turn is
+required by the packaging library. Updated (Aug 2019) for py3.
+
+* Updated (Nov 2020) for finding right dot executable on Windows + Anaconda, see [pydot/pydot#205](https://github.com/pydot/pydot/issues/205) for detail. Also, pydot has not bumping version for a long time, log down commit change here: a10ced4 -> 03533f3
 </td></tr>
 
 <!-- ######################################################### -->

--- a/src/rez/vendor/pydot/dot_parser.py
+++ b/src/rez/vendor/pydot/dot_parser.py
@@ -548,8 +548,7 @@ def parse_dot_data(s):
         tokens = graphparser.parseString(s)
         return list(tokens)
     except ParseException as err:
-        print(
-            err.line +
-            " "*(err.column-1) + "^" +
-            err)
+        print(err.line)
+        print(" " * (err.column - 1) + "^")
+        print(err)
         return None


### PR DESCRIPTION
### Problem

On Windows, when the Python is running from a Conda envirnoment, and Graphviz is NOT installed by Conda, `dot` executable will not be found. Because `pydot` changed to look for `dot.bat` if Conda environment is detected.

### Solution

This is a rare case, and maybe even won't happen in production. But I was doing some tests with my IDE that has set to use Conda as virtual environment provider, so.. to avoid all those confusion in the future, I propose to update `pydot` which they already have a fix for this problem.

The problem cause: [pydot/pydot-ng#52 L413-L417](https://github.com/pydot/pydot-ng/pull/52/files#diff-a895743b12bc04c6bd6536a9715ecdc8dce8fb3abbddaa801deccec6415c4e40R413-R417)
The issue in pydot : https://github.com/pydot/pydot/issues/205
The fix they made: https://github.com/pydot/pydot/pull/237

Other changes they have made should not be a problem for Rez to accept. Only [4 commits](https://github.com/pydot/pydot/compare/a7639607c2a050b856bce70a6336feb637ab615e...03533f36f226a19de316061832f3e33ef8e6555c) after last update.
