### PR TITLE
Fix pip.py get purelib error.

### DIFF
--- a/src/rez/utils/pip.py
+++ b/src/rez/utils/pip.py
@@ -327,7 +327,7 @@ def is_pure_python_package(installed_dist):
     wheel_data = Parser().parsestr(wheel_data)
 
     # see https://www.python.org/dev/peps/pep-0427/#what-s-the-deal-with-purelib-vs-platlib
-    return (wheel_data["Root-Is-Purelib"].lower() == "true")
+    return (wheel_data.get("Root-Is-Purelib", "").lower() == "true")
 
 
 def get_rez_requirements(installed_dist, python_version, name_casings=None):


### PR DESCRIPTION
If package not have purelib, it will occour a error... ( Exp: rez-pip -i pyqt5 )