### PR TITLE
Try telling who is/are requesting missing package

### DIFF
--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -1290,21 +1290,22 @@ class _ResolvePhase(_Common):
                         try:
                             scope = _PackageScope(req, solver=self.solver)
                         except PackageFamilyNotFoundError as e:
-                            # Look up which is requesting the missing one
+                            # Look up which are requesting the missing one
+                            requesters = []
                             for k, extracted_request in extractions.items():
                                 if extracted_request.name == req.name:
-                                    requested, required = k
-                                    break
-                            else:
-                                # Must have a match.
-                                # But if not, raise origin error
+                                    requesters.append(k[0])
+                            if not requesters:
+                                # Must have a match. Raise origin error if not
                                 raise e
-                            # Raise with more info when match found
-                            searched = "; ".join(self.solver.package_paths)
-                            raise PackageFamilyNotFoundError(
-                                "package family not found: %s, was required "
-                                "by: %s (searched: %s)"
-                                % (required, requested, searched))
+                            else:
+                                # Raise with more info when match found
+                                searched = "; ".join(self.solver.package_paths)
+                                requested = ", ".join(requesters)
+                                raise PackageFamilyNotFoundError(
+                                    "package family not found: %s, "
+                                    "was required by: %s (searched: %s)"
+                                    % (req.name, requested, searched))
 
                         scopes.append(scope)
                         if self.pr:


### PR DESCRIPTION
So this is anothre shot after #971, which only focusing on missing package info this time.

Here is my [test cases](https://gist.github.com/davidlatwe/043b4c6216ebb94c325305d9f7a23343), and the output would be as follows:

```
Required package not found
====================
package family not found: oops, was required by: dummy (searched: memory@any)

Required package not found (deeper)
====================
package family not found: oops, was required by: dummy (searched: memory@any)

Required package not found (multiple)
====================
package family not found: oops, was required by: dummy, jojo (searched: memory@any)
```