### PR TITLE
fix: exit file write retry loop after successfull write

### DIFF
--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -72,6 +72,7 @@ def open_file_for_write(filepath, mode=None):
         try:
             with atomic_write(filepath, overwrite=True, **encoding) as f:
                 f.write(content)
+            break
 
         except WindowsError as e:
             if attempt == 0:


### PR DESCRIPTION
This prevents the `open_file_for_write` function from attempting to
always write the file twice, even when the first write is successful.
It also solves a bug where if the first write was successful,
but the second raises a permission error, the loop will fail to catch
the error it was designed to catch and raise an exception.