### PR TITLE
Fix no CLI args passed into forward script on Windows

### DIFF
--- a/src/rez/utils/execution.py
+++ b/src/rez/utils/execution.py
@@ -167,7 +167,7 @@ def create_executable_script(filepath, body, program=None, py_script_mode=None):
                 # following lines of batch script will be stripped
                 # before yaml.load
                 f.write("@echo off\n")
-                f.write("%s.exe %%~dpnx0\n" % program)
+                f.write("%s.exe %%~dpnx0 %%*\n" % program)
                 f.write("goto :eof\n")  # skip YAML body
                 f.write(":: YAML\n")    # comment for human
             else:


### PR DESCRIPTION
In #968 , the implementaion didn't catch CLI args which makes suite control arguments being ignored, e.g.
```
> maya ++about
# launching Maya instead of showing suite tool info..
```
This PR fixes the problem.