### PR TITLE
Handle non atomic write method when writing on network fs with linux

### DIFF
--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.69.6"
+_rez_version = "2.69.7"
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
Linux doesn't provide a sync method for network mounted fs, which cause atomicwrites to fail.
I added a failsafe to write with a basic (non atomic) method for that edge case

Fix issue #858