### PR TITLE
Issue 994 wiki workflow fixes

### DIFF
--- a/.github/workflows/wiki.yaml
+++ b/.github/workflows/wiki.yaml
@@ -1,8 +1,8 @@
 name: Wiki
 on:
   push:
-    #branches:
-    #  - master
+    branches:
+      - master
     paths:
       - '.github/workflows/wiki.yaml'
       - 'wiki/**'

--- a/.github/workflows/wiki.yaml
+++ b/.github/workflows/wiki.yaml
@@ -1,10 +1,8 @@
 name: Wiki
 on:
   push:
-    paths:
-      - 'wiki/**'
-      - src/rez/rezconfig.py
-  pull_request:
+    #branches:
+    #  - master
     paths:
       - 'wiki/**'
       - src/rez/rezconfig.py
@@ -24,22 +22,20 @@ jobs:
         with:
           python-version: 3.7
 
+      - name: Get Rez Version
+        run: |
+          rezver=$(cat ./src/rez/utils/_version.py | grep -w _rez_version | tr '"' ' ' | awk '{print $NF}')
+          echo "rezver=${rezver}" >> $GITHUB_ENV
+
       - name: Build Wiki
         working-directory: wiki  # Start in correct dir, else inspect fails
         run: |
-          git config --global color.ui always
-          if [ "${{ github.event_name == 'pull_request' }}" == "true" ]
-          then
-            BRANCH="${{ github.head_ref }}"
-          else
-            BRANCH="${{ github.ref }}"
-          fi
+          #git config --global color.ui always
 
           python update-wiki.py \
             --keep-temp \
             --no-push \
-            --github-release="$BRANCH" \
-            --github-branch="${BRANCH##refs*/}" \
+            --github-release=${rezver} \
             --wiki-dir="${{ github.workspace }}"/"${{ env.TEMP_WIKI_DIR }}" \
             --wiki-url="${{ env.CLONE_URL }}"
 

--- a/.github/workflows/wiki.yaml
+++ b/.github/workflows/wiki.yaml
@@ -4,6 +4,7 @@ on:
     #branches:
     #  - master
     paths:
+      - '.github/workflows/wiki.yaml'
       - 'wiki/**'
       - src/rez/rezconfig.py
 env:


### PR DESCRIPTION
This PR limits the workflow to master merges only. It would be possible to have it work for any branch, but would involve tracking a matching remote branch in the rez.wiki project. However, that is hard (or not possible?) to see in the github UI anyway and therefore of very limited value.
