### PR TITLE
Bugfix/issue 1003

### DIFF
--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -225,7 +225,8 @@ class BuildProcessHelper(BuildProcess):
     def create_build_context(self, variant, build_type, build_path):
         """Create a context to build the variant within."""
         request = variant.get_requires(build_requires=True,
-                                       private_build_requires=True)
+                                       private_build_requires=True,
+                                       requires=False)
 
         req_strs = map(str, request)
         quoted_req_strs = map(quote, req_strs)

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -403,7 +403,8 @@ class Variant(PackageBaseResourceWrapper):
             (self.parent.requires or []) + self.variant_requires
         )
 
-    def get_requires(self, build_requires=False, private_build_requires=False):
+    def get_requires(self, build_requires=False, private_build_requires=False,
+                     requires=True):
         """Get the requirements of the variant.
 
         Args:
@@ -414,14 +415,16 @@ class Variant(PackageBaseResourceWrapper):
         Returns:
             List of `Requirement` objects.
         """
-        requires = self.requires or []
+        result = []
+        if requires:
+            result += self.requires or []
 
         if build_requires:
-            requires = requires + (self.build_requires or [])
+            result += self.build_requires or []
         if private_build_requires:
-            requires = requires + (self.private_build_requires or [])
+            result += self.private_build_requires or []
 
-        return requires
+        return result
 
     def install(self, path, dry_run=False, overrides=None):
         """Install this variant into another package repository.

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -224,10 +224,7 @@ class ResolvedContext(object):
         self.package_filter = (PackageFilterList.singleton if package_filter is None
                                else package_filter)
 
-        self.package_orderers = (
-            PackageOrderList.singleton if package_orderers is None
-            else package_orders
-        )
+        self.package_orderers = package_orderers or PackageOrderList.singleton
 
         # settings that affect context execution
         self.append_sys_path = True

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.71.0"
+_rez_version = "2.71.1"
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
- fix the issue that build environment is affected by `requires` (which is supposed to only affect runtime environment). For instance this issue will block you from building a python-3 oriented package using python-2 or vice versa, which seems unintentional. See more in [here](https://github.com/nerdvegas/rez/issues/1003).
- fix a typo in `src/rez/resolved_context.py` : `package_orders` -> `package_orderers`