### PR TITLE
Improve get_variant_from_uri on Windows

### DIFF
--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -343,6 +343,7 @@ def is_subdirectory(path_a, path_b):
     try:
         relative = os.path.relpath(path_a, path_b)
     except ValueError:
+        # paths are on different mount drives
         return False
     else:
         return not relative.startswith(os.pardir + os.sep)

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -340,8 +340,12 @@ def is_subdirectory(path_a, path_b):
     """Returns True if `path_a` is a subdirectory of `path_b`."""
     path_a = os.path.realpath(path_a)
     path_b = os.path.realpath(path_b)
-    relative = os.path.relpath(path_a, path_b)
-    return (not relative.startswith(os.pardir + os.sep))
+    try:
+        relative = os.path.relpath(path_a, path_b)
+    except ValueError:
+        return False
+    else:
+        return not relative.startswith(os.pardir + os.sep)
 
 
 def find_matching_symlink(path, source):

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -21,7 +21,8 @@ from rez.utils.formatting import is_valid_package_name
 from rez.utils.resources import cached_property
 from rez.utils.logging_ import print_warning
 from rez.utils.memcached import memcached, pool_memcached_connections
-from rez.utils.filesystem import make_path_writable, canonical_path
+from rez.utils.filesystem import make_path_writable, \
+    canonical_path, is_subdirectory
 from rez.utils.platform_ import platform_
 from rez.serialise import load_from_file, FileFormat
 from rez.config import config
@@ -543,12 +544,14 @@ class FileSystemPackageRepository(PackageRepository):
         - /svr/packages/mypkg/package.py[1]  (unversioned package - rare)
         - /svr/packages/mypkg/package.py<1.0.0>[1]  ("combined" package type - rare)
         """
+        uri = os.path.normcase(uri)
+
         i = uri.rfind('[')
         if i == -1:
             return None
 
         prefix = self.location + os.path.sep
-        if not uri.startswith(prefix):
+        if not is_subdirectory(uri, prefix):
             return None
 
         part1 = uri[len(prefix):i]  # 'mypkg/1.0.0/package.py'


### PR DESCRIPTION
When using Rez bin tool like `rez-pkg-cache` on Windows, the package path of variant URI must be in same letter case and same path sep with the path in `rezconfig` when manually adding variant for cache. Or it won't be able to find the variant.

This PR improves that.
