### PR TITLE
Fix dir/file remove error handling

### DIFF
--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -227,11 +227,11 @@ def forceful_rmtree(path):
                 path = windows_long_path(path)
 
             parent_path = os.path.dirname(path)
-
             if not os.access(parent_path, os.W_OK):
                 st = os.stat(parent_path)
                 os.chmod(parent_path, st.st_mode | stat.S_IWUSR)
-            else:
+
+            if not os.access(path, os.W_OK):
                 st = os.stat(path)
                 os.chmod(path, st.st_mode | stat.S_IWUSR)
 

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -231,6 +231,9 @@ def forceful_rmtree(path):
             if not os.access(parent_path, os.W_OK):
                 st = os.stat(parent_path)
                 os.chmod(parent_path, st.st_mode | stat.S_IWUSR)
+            else:
+                st = os.stat(path)
+                os.chmod(path, st.st_mode | stat.S_IWUSR)
 
         except:
             # avoid confusion by ensuring original exception is reraised


### PR DESCRIPTION
`rez-build` process may fail when removing dir like `.git` that has read-only files, and it was fixed in PR #959, but broken after commit adb03579.

This PR should resolved it.
