### PR TITLE
Adds more variables to the custom build system.

### DIFF
--- a/src/rezplugins/build_system/custom.py
+++ b/src/rezplugins/build_system/custom.py
@@ -23,7 +23,6 @@ from rez.utils.logging_ import print_warning
 from rez.vendor.six import six
 from rez.config import config
 
-
 basestring = six.string_types[0]
 
 
@@ -38,12 +37,24 @@ class CustomBuildSystem(BuildSystem):
     located somewhere under the 'build' dir under the root dir containing the
     package.py.
 
+    The '{build_path}' string will expand to the default build path.
+
+    The '{install}' string will expand to 'install' if an install is occurring,
+    or the empty string ('') otherwise.
+
+    The '{install_path}' will expand to the full path where the install should go.
+
+    The '{name}' string will expand to the package name.
+
     The '{root}' string will expand to the source directory (the one containing
     the package.py).
 
-    The '{install}' string will expand to 'install' if an install is occuring,
-    and the empty string ('') otherwise.
+    The '{variant_index}' will expand to the index of the current variant to be build,
+    or an empty string ('') if no variants are present.
+
+    The '{version}' string will expand to the package version currently build.
     """
+
     @classmethod
     def name(cls):
         return "custom"
@@ -84,7 +95,7 @@ class CustomBuildSystem(BuildSystem):
         before_args = set(x.dest for x in parser._actions)
 
         try:
-            exec(source, {"parser": group})
+            exec (source, {"parser": group})
         except Exception as e:
             print_warning("Error in ./parse_build_args.py: %s" % str(e))
 
@@ -129,9 +140,13 @@ class CustomBuildSystem(BuildSystem):
             return ret
 
         def expand(txt):
-            root = self.package.root
-            install_ = "install" if install else ''
-            return txt.format(root=root, install=install_).strip()
+            return txt.format(build_path=build_path,
+                              install="install" if install else '',
+                              install_path=install_path,
+                              name=self.package.name,
+                              root=self.package.root,
+                              variant_index=variant.index if variant.index is not None else '',
+                              version=self.package.version).strip()
 
         if isinstance(command, basestring):
             if self.build_args:


### PR DESCRIPTION
This patch adds more commands to the custom build system.

The reason is that we might be able to define more commands directly without intermediate bash or python scripts
if certain data is available in the build_command. Most prominently `install_path` so that we can for example satisfy build systems like:
```
build_command = "python setup.py --install-dir {build_path}"
``` 
This also eliminates the need to grab the environment should you prefer to handle build scripts via arguments only, which is a little more verbose to understand the action from the package.py

The full list of supported variables to the build_command are now:
- build_path
- install (retained)
- install_path
- name
- root (retained)
- variant_index (or empty string if non is given)
- version

Also adressed minor spelling/formatting issue and removed unnecessary temporary variables.

This will not break compatibility but due the the simplicity I did not add unit-tests. Let me know if you would prefer any.