### PR TITLE
Fix install-as-rez-package script for Windows

### DIFF
--- a/install.py
+++ b/install.py
@@ -219,13 +219,14 @@ def install_as_rez_package(repo_path):
     # do a temp production (virtualenv-based) rez install
     tmpdir = mkdtemp(prefix="rez-install-")
     install(tmpdir)
+    _, py_executable = get_virtualenv_py_executable(tmpdir)
 
     try:
         # This extracts a rez package from the installation. See
         # rez.utils.installer.install_as_rez_package for more details.
         #
         args = (
-            os.path.join(tmpdir, "bin", "python"), "-E", "-c",
+            py_executable, "-E", "-c",
             r"from rez.utils.installer import install_as_rez_package;"
             r"install_as_rez_package('%s')" % repo_path
         )

--- a/install.py
+++ b/install.py
@@ -228,7 +228,7 @@ def install_as_rez_package(repo_path):
         args = (
             py_executable, "-E", "-c",
             r"from rez.utils.installer import install_as_rez_package;"
-            r"install_as_rez_package('%s')" % repo_path
+            r"install_as_rez_package(%r)" % repo_path
         )
         print(subprocess.check_output(args))
 


### PR DESCRIPTION
### Problem

1. Python executable path was assembled by `os.path.join(tmpdir, "bin", "python")`, which will not work on Windows. (dir name is `scripts` instead of `bin`).

2. `repo_path` that has `\\` in it will not be properly escaped.

### Solution

1. Replace hardcoded bin dir path with virtual env helper function.
2. Format `repo_path` with `repr()`