### PR TITLE
Fix rez.vendor.distlib for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setup(
             ['utils/logging.conf'] +
             ['README*'] +
             find_files('*', 'completion') +
-            find_files('*', 'tests/data'),
+            find_files('*', 'tests/data') +
+            find_files('*.exe', 'vendor/distlib'),
         'rezplugins':
             find_files('rezconfig', root='rezplugins') +
             find_files('*.cmake', 'build_system', root='rezplugins') +


### PR DESCRIPTION
### Problem

`rez.vendor.distlib` is not working properly on Windows, a few `.exe` files were not collected in `setup.py`.

### Fix

Include them in `package_data`