### PR TITLE
Fix sorting of rules with and without family (closes #1037)

### DIFF
--- a/src/rez/package_filter.py
+++ b/src/rez/package_filter.py
@@ -200,8 +200,15 @@ class PackageFilter(PackageFilterBase):
         cached_property.uncache(self, "cost")
 
     def __str__(self):
-        return str((sorted(self._excludes.items()),
-                    sorted(self._includes.items())))
+        def sortkey(rule_items):
+            family, rules = rule_items
+            if family is None:
+                family = ""
+                return (family, rules)
+            return rule_items
+
+        return str((sorted(self._excludes.items(), key=sortkey),
+                    sorted(self._includes.items(), key=sortkey)))
 
 
 class PackageFilterList(PackageFilterBase):


### PR DESCRIPTION
Rules are grouped by family. When sorting rules that have a family and rules that have no family (`None`) an exception is raised, because a strings and `None` can't be sorted. This fixes this by converting `None` families to an empty string for sorting.