### PR TITLE
Fix rez-python arg disordered

### DIFF
--- a/src/rez/cli/python.py
+++ b/src/rez/cli/python.py
@@ -20,13 +20,7 @@ def command(opts, parser, extra_arg_groups=None):
     from rez.utils.execution import Popen
     import sys
 
-    cmd = [sys.executable, "-E"]
-
-    for arg_group in (extra_arg_groups or []):
-        cmd.extend(arg_group)
-
-    if opts.FILE:
-        cmd.append(opts.FILE)
+    cmd = [sys.executable, "-E"] + sys.argv[1:]
 
     with Popen(cmd) as p:
         sys.exit(p.wait())


### PR DESCRIPTION
### Problem
When I run command
```
> rez-python -m pip list
```
It shows
```
Scripts\python.exe: No module named list
```
Which is weird since the module arg should be `pip`, so I print out the args that parsed into `python.exe` and it shows :
```
['scripts\python.exe', '-E', '-m', 'list', 'pip']
```
As you can see, `pip` has been parsed as `FILE` arg and then appended behind other args that are unrecognized by the `rez-python` arg-parser.

### Fix
Instead of rearranging arguments by what are recognized and what not, just pass them all directly into python executable. Since it looks like we only need parser to run script file auto-completion.
