### PR TITLE
Fix missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,9 @@
 include src/rez/rezconfig
+include src/rez/completion/*
+include src/rez/tests/data/*
+include src/rez/vendor/distlib/*.exe
+include src/rezgui/rezguiconfig
+include src/rezgui/icons/*
 include src/rezplugins/build_system/template_files/Doxyfile
 recursive-include src/rez README*
-recursive-include src/rezplugins *.cmake Doxyfile
-
+recursive-include src/rezplugins *.cmake Doxyfile rezconfig


### PR DESCRIPTION
### Problem
Rez is now up-to-date on PyPi since [2.75.0](https://github.com/nerdvegas/rez/releases/tag/2.75.0), but some package data files are missing in source distribution, e.g. `rezconfig` files in `rezplugins`.

### Fix
Update `MANIFEST.in` as `package_data` in `setup.py`.

### Note
* `MANIFEST.in` is for source distribution, and
* `package_data` in `setup.py` is for binary distribution.

So we have to maintain both in future releases.
