### PR TITLE
Let rez-selftest try using pytest

### DIFF
--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -44,6 +44,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install test dependencies
+        run: |
+          python -m pip install pytest
+
       - name: Install Rez
         run: |
           mkdir ./build

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Rez test dependencies
         run: |
-          ./build/bin/rez/rez-python -m pip install pytest
+          ./build/bin/rez/rez-python -m pip install pytest-cov
 
       # TODO: Add a --core rez-selftest option. Some test suites (eg test_context)
       # have some 'core' parts (eg not reliant on a shell). It would be good to just

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -44,14 +44,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install test dependencies
-        run: |
-          python -m pip install pytest
-
       - name: Install Rez
         run: |
           mkdir ./build
           python ./install.py ./build
+
+      - name: Install Rez test dependencies
+        run: |
+          ./build/bin/rez/rez-python -m pip install pytest
 
       # TODO: Add a --core rez-selftest option. Some test suites (eg test_context)
       # have some 'core' parts (eg not reliant on a shell). It would be good to just

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -49,14 +49,14 @@ jobs:
         run: |
           pwsh --version
 
-      - name: Install test dependencies
-        run: |
-          python -m pip install pytest
-
       - name: Install Rez
         run: |
           mkdir ./build
           python ./install.py ./build
+
+      - name: Install Rez test dependencies
+        run: |
+          ./build/bin/rez/rez-python -m pip install pytest
 
       - name: Run Rez Tests
         run: |

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -49,6 +49,10 @@ jobs:
         run: |
           pwsh --version
 
+      - name: Install test dependencies
+        run: |
+          python -m pip install pytest
+
       - name: Install Rez
         run: |
           mkdir ./build

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install Rez test dependencies
         run: |
-          ./build/bin/rez/rez-python -m pip install pytest
+          ./build/bin/rez/rez-python -m pip install pytest-cov
 
       - name: Run Rez Tests
         run: |

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -62,14 +62,14 @@ jobs:
         run: |
           sudo apt-get install -y zsh
 
-      - name: Install test dependencies
-        run: |
-          python -m pip install pytest
-
       - name: Install Rez
         run: |
           mkdir ./build
           python ./install.py ./build
+
+      - name: Install Rez test dependencies
+        run: |
+          ./build/bin/rez/rez-python -m pip install pytest
 
       - name: Run Rez Tests
         run: |

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -62,6 +62,10 @@ jobs:
         run: |
           sudo apt-get install -y zsh
 
+      - name: Install test dependencies
+        run: |
+          python -m pip install pytest
+
       - name: Install Rez
         run: |
           mkdir ./build

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install Rez test dependencies
         run: |
-          ./build/bin/rez/rez-python -m pip install pytest
+          ./build/bin/rez/rez-python -m pip install pytest-cov
 
       - name: Run Rez Tests
         run: |

--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -50,7 +50,9 @@ subcommands = {
         "arg_mode": "grouped"
     },
     "search": {},
-    "selftest": {},
+    "selftest": {
+        "arg_mode": "passthrough"
+    },
     "status": {},
     "suite": {},
     "test": {},

--- a/src/rez/cli/selftest.py
+++ b/src/rez/cli/selftest.py
@@ -74,7 +74,14 @@ def command(opts, parser, extra_arg_groups=None):
         module_tests = opts.module_tests
 
     if use_pytest:
-        run_pytest(module_tests, opts.tests, opts.verbose, extra_arg_groups)
+        cwd = os.getcwd()
+        os.chdir(tests_dir)
+        try:
+            run_pytest(module_tests, opts.tests, opts.verbose,
+                       extra_arg_groups)
+        finally:
+            os.chdir(cwd)
+
     else:
         run_unittest(module_tests, opts.tests, opts.verbose)
 
@@ -91,9 +98,6 @@ def run_unittest(module_tests, tests, verbosity):
 
 def run_pytest(module_tests, tests, verbosity, extra_arg_groups):
     from pytest import main
-
-    cwd = os.getcwd()
-    os.chdir(tests_dir)
 
     # parse test name, e.g.
     #   "rez.tests.test_solver.TestSolver.test_01"
@@ -122,7 +126,6 @@ def run_pytest(module_tests, tests, verbosity, extra_arg_groups):
         argv += extra_arg_groups[0]
 
     main(args=argv)
-    os.chdir(cwd)
 
 
 # Copyright 2013-2016 Allan Johns.


### PR DESCRIPTION
For better test log reviewing, I propose to opt-in `pytest` (still use `unittest` if `pytest` not installed in Rez venv).
See how tidy the test reports in github-actions are.

I have changed the `selftest` sub-command arg mode to `passthrough`, so it can accept additional `pytest` args. But the existing [`/pytest.ini`](https://github.com/nerdvegas/rez/blob/master/pytest.ini) contains `pytest-cov` options, so one might have to install `pytest-cov` for the arguments like `--cov` can be recognized.
