### PR TITLE
Implement REP-002.006: directive request syntax

### DIFF
--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -6,7 +6,7 @@ from rez.exceptions import BuildProcessError, BuildContextResolveError, \
     ReleaseVCSError, _NeverError
 from rez.utils.logging_ import print_warning
 from rez.utils.colorize import heading, Printer
-from rez.utils.request_directives import process_directives
+from rez.utils.request_directives import resolve_directives
 from rez.resolved_context import ResolvedContext
 from rez.release_hook import create_release_hooks
 from rez.resolver import ResolverStatus
@@ -266,7 +266,7 @@ class BuildProcessHelper(BuildProcess):
         if context.status != ResolverStatus.solved:
             raise BuildContextResolveError(context)
 
-        process_directives(variant, context)
+        resolve_directives(variant, context)
 
         return context, rxt_filepath
 

--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -6,6 +6,7 @@ from rez.exceptions import BuildProcessError, BuildContextResolveError, \
     ReleaseVCSError, _NeverError
 from rez.utils.logging_ import print_warning
 from rez.utils.colorize import heading, Printer
+from rez.utils.request_directives import process_directives
 from rez.resolved_context import ResolvedContext
 from rez.release_hook import create_release_hooks
 from rez.resolver import ResolverStatus
@@ -264,6 +265,9 @@ class BuildProcessHelper(BuildProcess):
 
         if context.status != ResolverStatus.solved:
             raise BuildContextResolveError(context)
+
+        process_directives(variant, context)
+
         return context, rxt_filepath
 
     def pre_release(self):

--- a/src/rez/data/tests/builds/packages/soft/package.py
+++ b/src/rez/data/tests/builds/packages/soft/package.py
@@ -1,0 +1,12 @@
+name = 'soft'
+version = '1'
+authors = ['davidlatwe']
+requires = [
+    'soft_dep-1.*',
+    'soft_dep<1.1.0',
+]
+variants = [
+    ['soft_var-2//harden(2)'],
+    ['soft_var-3.*'],
+]
+build_command = False

--- a/src/rez/data/tests/builds/packages/soft_dep/1.0.0/package.py
+++ b/src/rez/data/tests/builds/packages/soft_dep/1.0.0/package.py
@@ -1,0 +1,4 @@
+name = 'soft_dep'
+version = '1.0.0'
+authors = ['davidlatwe']
+build_command = False

--- a/src/rez/data/tests/builds/packages/soft_dep/1.1.0/package.py
+++ b/src/rez/data/tests/builds/packages/soft_dep/1.1.0/package.py
@@ -1,0 +1,4 @@
+name = 'soft_dep'
+version = '1.1.0'
+authors = ['davidlatwe']
+build_command = False

--- a/src/rez/data/tests/builds/packages/soft_var/2.1/package.py
+++ b/src/rez/data/tests/builds/packages/soft_var/2.1/package.py
@@ -1,0 +1,4 @@
+name = 'soft_var'
+version = '2.1'
+authors = ['davidlatwe']
+build_command = False

--- a/src/rez/data/tests/builds/packages/soft_var/3.0/package.py
+++ b/src/rez/data/tests/builds/packages/soft_var/3.0/package.py
@@ -1,0 +1,4 @@
+name = 'soft_var'
+version = '3.0'
+authors = ['davidlatwe']
+build_command = False

--- a/src/rez/package_maker.py
+++ b/src/rez/package_maker.py
@@ -4,12 +4,13 @@ from rez.utils.filesystem import retain_cwd
 from rez.utils.formatting import PackageRequest
 from rez.utils.data_utils import AttrDictWrapper
 from rez.utils.logging_ import print_warning
+from rez.utils.request_directives import bind_directives
 from rez.exceptions import PackageMetadataError
 from rez.package_resources import help_schema, _commands_schema, \
     _function_schema, late_bound
 from rez.package_repository import create_memory_package_repository
 from rez.packages import Package
-from rez.package_py_utils import expand_requirement
+from rez.package_py_utils import late_expand_requirement
 from rez.vendor.schema.schema import Schema, Optional, Or, Use, And
 from rez.vendor.six import six
 from rez.vendor.version.version import Version
@@ -23,7 +24,7 @@ basestring = six.string_types[0]
 # this schema will automatically harden request strings like 'python-*'; see
 # the 'expand_requires' function for more info.
 #
-package_request_schema = Or(And(basestring, Use(expand_requirement)),
+package_request_schema = Or(And(basestring, Use(late_expand_requirement)),
                             And(PackageRequest, Use(str)))
 
 tests_schema = Schema({
@@ -140,6 +141,10 @@ class PackageMaker(AttrDictWrapper):
 
         # revalidate the package for extra measure
         package.validate_data()
+
+        # bind schema validated directive requires with package
+        bind_directives(package)
+
         return package
 
     def _get_data(self):

--- a/src/rez/package_py_utils.py
+++ b/src/rez/package_py_utils.py
@@ -7,12 +7,21 @@ including:
 """
 
 # these imports just forward the symbols into this module's namespace
+from rez.utils.request_directives import parse_directive
 from rez.utils.execution import Popen
 from rez.exceptions import InvalidPackageError
 from rez.vendor.six import six
 
 
 basestring = six.string_types[0]
+
+
+def late_expand_requirement(request):
+    """Expands a requirement string after resolve, if possible
+    """
+    request_ = parse_directive(request)
+    # should we prompt warning when it ends up early expand ?
+    return expand_requirement(request_)
 
 
 def expand_requirement(request, paths=None):
@@ -54,87 +63,30 @@ def expand_requirement(request, paths=None):
 
     from rez.vendor.version.version import VersionRange
     from rez.vendor.version.requirement import Requirement
+    from rez.vendor.version.util import dewildcard
     from rez.packages import get_latest_package
-    from uuid import uuid4
 
-    wildcard_map = {}
-    expanded_versions = {}
-    request_ = request
+    with dewildcard(request) as deer:
+        req = deer.victim
 
-    # replace wildcards with valid version tokens that can be replaced again
-    # afterwards. This produces a horrendous, but both valid and temporary,
-    # version string.
-    #
-    while "**" in request_:
-        uid = "_%s_" % uuid4().hex
-        request_ = request_.replace("**", uid, 1)
-        wildcard_map[uid] = "**"
+        def expand(version, rank):
+            range_ = VersionRange(str(version))
+            package = get_latest_package(name=req.name,
+                                         range_=range_,
+                                         paths=paths)
+            if package is None:
+                return version
+            if rank:
+                return package.version.trim(rank)
+            else:
+                return package.version
 
-    while '*' in request_:
-        uid = "_%s_" % uuid4().hex
-        request_ = request_.replace('*', uid, 1)
-        wildcard_map[uid] = '*'
-
-    # create the requirement, then expand wildcards
-    #
-    req = Requirement(request_, invalid_bound_error=False)
-
-    def expand_version(version):
-        rank = len(version)
-        wildcard_found = False
-
-        while version and str(version[-1]) in wildcard_map:
-            token = wildcard_map[str(version[-1])]
-            version = version.trim(len(version) - 1)
-
-            if token == "**":
-                if wildcard_found:  # catches bad syntax '**.*'
-                    return None
-                else:
-                    wildcard_found = True
-                    rank = 0
-                    break
-
-            wildcard_found = True
-
-        if not wildcard_found:
-            return None
-
-        range_ = VersionRange(str(version))
-        package = get_latest_package(name=req.name, range_=range_, paths=paths)
-
-        if package is None:
-            return version
-
-        if rank:
-            return package.version.trim(rank)
-        else:
-            return package.version
-
-    def visit_version(version):
-        # requirements like 'foo-1' are actually represented internally as
-        # 'foo-1+<1_' - '1_' is the next possible version after '1'. So we have
-        # to detect this case and remap the uid-ified wildcard back here too.
-        #
-        for v, expanded_v in expanded_versions.items():
-            if version == next(v):
-                return next(expanded_v)
-
-        version_ = expand_version(version)
-        if version_ is None:
-            return None
-
-        expanded_versions[version] = version_
-        return version_
-
-    if req.range_ is not None:
-        req.range_.visit_versions(visit_version)
+        deer.on_wildcard(expand)
 
     result = str(req)
 
     # do some cleanup so that long uids aren't left in invalid wildcarded strings
-    for uid, token in wildcard_map.items():
-        result = result.replace(uid, token)
+    result = deer.restore(result)
 
     # cast back to a Requirement again, then back to a string. This will catch
     # bad verison ranges, but will also put OR'd version ranges into the correct

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -7,6 +7,7 @@ from rez.utils import reraise
 from rez.utils.sourcecode import SourceCode
 from rez.utils.data_utils import cached_property
 from rez.utils.formatting import StringFormatMixin, StringFormatType
+from rez.utils.request_directives import apply_directives
 from rez.utils.schema import schema_keys
 from rez.utils.resources import ResourceHandle, ResourceWrapper
 from rez.exceptions import PackageFamilyNotFoundError, ResourceError
@@ -444,6 +445,8 @@ class Variant(PackageBaseResourceWrapper):
             `Variant` object - the (existing or newly created) variant in the
             specified repository. If `dry_run` is True, None may be returned.
         """
+        apply_directives(self)
+
         repo = package_repository_manager.get_repository(path)
         resource = repo.install_variant(self.resource,
                                         dry_run=dry_run,

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -10,6 +10,7 @@ import unittest
 from rez.tests.util import TestBase, TempdirMixin, find_file_in_path, \
     per_available_shell, install_dependent, program_dependent
 from rez.utils.platform_ import platform_
+from rez.packages import get_package
 import shutil
 import os.path
 
@@ -175,6 +176,18 @@ class TestBuild(TestBase, TempdirMixin):
         proc = context.execute_command(['hai'], stdout=PIPE)
         stdout = proc.communicate()[0]
         self.assertEqual('Oh hai!', stdout.decode("utf-8").strip())
+
+    def test_build_soft(self):
+        self._test_build("soft_dep", "1.0.0")
+        self._test_build("soft_dep", "1.1.0")
+        self._test_build("soft_var", "2.1")
+        self._test_build("soft_var", "3.0")
+        self._test_build("soft")
+
+        soft = get_package("soft", "1", paths=[self.install_root])
+        self.assertEqual("soft_dep-1.0", str(soft.requires[0]))
+        self.assertEqual(["soft_var-2.1"], list(map(str, soft.variants[0])))
+        self.assertEqual(["soft_var-3.0"], list(map(str, soft.variants[1])))
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -223,7 +223,8 @@ class TestPackages(TestBase, TempdirMixin):
         package = get_developer_package(path)
 
         self.assertEqual(package.description, "This.")
-        self.assertEqual(package.requires, [PackageRequest('versioned-3')])
+        # expansion delayed
+        self.assertEqual(package.requires, [PackageRequest('versioned')])
         self.assertEqual(package.authors, ["tweedle-dee", "tweedle-dum"])
         self.assertFalse(hasattr(package, "added_by_global_preprocess"))
         self.assertEqual(package.added_by_local_preprocess, True)

--- a/src/rez/tests/test_requests.py
+++ b/src/rez/tests/test_requests.py
@@ -1,0 +1,45 @@
+"""
+Test requests
+"""
+import unittest
+from rez.tests.util import TestBase
+from rez.utils.request_directives import \
+    parse_directive, anonymous_directive_string
+
+
+class TestRequest(TestBase):
+
+    def test_wildcard_to_directive(self):
+        requests = [
+            ("foo-**", "foo//harden", None),
+            ("foo==**", "foo//harden", None),
+            ("foo-*", "foo//harden(1)", None),
+            ("foo-1.**", "foo-1//harden", None),
+            ("foo-1.0.*", "foo-1.0//harden(3)", None),
+            ("foo==*", "foo//harden(1)", None),
+            ("foo==1.*", "foo==1//harden(2)", None),
+            ("foo-1.*+", "foo-1+//harden(2)", None),
+            ("foo>1.*", "foo>1//harden(2)", None),
+            ("foo>=1.*", "foo-1+//harden(2)", None),
+            ("foo<**", "foo//harden", None),  # but meaningless
+            # unsupported
+            ("foo-2.*|1", None, "multi-rank hardening"),
+            ("foo<=4,>2.*", None, "multi-rank hardening"),
+            ("foo-1..2.*", None, "multi-rank hardening"),
+            ("foo-1|2.*", None, "multi-rank hardening"),
+            ("foo-1.*+<2.*.*", None, "multi-rank hardening"),
+            ("foo-1.*+<3|==5.*.*", None, "multi-rank hardening"),
+        ]
+
+        for case, expected, message in requests:
+            request = parse_directive(case)
+
+            if expected is None:
+                self.assertEqual(case, request, message)
+            else:
+                directive = anonymous_directive_string(request) or ""
+                self.assertEqual(expected, "//".join([request, directive]), case)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/rez/utils/request_directives.py
+++ b/src/rez/utils/request_directives.py
@@ -1,0 +1,280 @@
+
+from rez.vendor.schema.schema import Schema, Optional, Use, And
+from rez.vendor.version.version import VersionRange
+from rez.vendor.version.requirement import Requirement
+from rez.vendor.version.util import dewildcard
+from rez.utils.formatting import PackageRequest
+from copy import copy
+import inspect
+import sys
+
+
+# directives
+#
+
+class DirectiveBase(object):
+    """Base class of directive request handler"""
+    @classmethod
+    def name(cls):
+        """Return the name of the directive"""
+        raise NotImplementedError
+
+    def parse(self, arg_string):
+        """Parse arguments from directive syntax string"""
+        raise NotImplementedError
+
+    def to_string(self, args):
+        """Format arguments to directive syntax string"""
+        raise NotImplementedError
+
+    def process(self, range_, version, rank=None):
+        """Process requirement's version range"""
+        raise NotImplementedError
+
+
+class DirectiveHarden(DirectiveBase):
+    """Harden directive request version to specific rank"""
+    @classmethod
+    def name(cls):
+        return "harden"
+
+    def parse(self, arg_string):
+        if arg_string:
+            return [int(arg_string[1:-1].strip())]
+        return []
+
+    def to_string(self, args):
+        if args and args[0]:
+            return "%s(%d)" % (self.name(), args[0])
+        return self.name()
+
+    def process(self, range_, version, rank=None):
+        if rank:
+            version = version.trim(rank)
+        hardened = VersionRange.from_version(version)
+        new_range = range_.intersection(hardened)
+        return new_range
+
+
+# helpers
+#
+
+def parse_directive(request):
+    """Parsing directive requests when creating package
+    """
+    if "//" in request:
+        request_, directive = request.split("//", 1)
+    elif "*" in request:
+        request_, directive = _convert_wildcard_to_directive(request)
+        if not directive:
+            return request
+    else:
+        return request
+
+    # parse directive and save into anonymous inventory
+    _directive_args = directive_manager.parse(directive)
+    directive_manager.loaded.put(_directive_args,
+                                 key=request_,
+                                 anonymous=True)
+
+    return request_
+
+
+def _convert_wildcard_to_directive(request):
+    ranks = dict()
+
+    with dewildcard(request) as deer:
+        req = deer.victim
+
+        def ranking(version, rank_):
+            wild_ver = deer.restore(str(version))
+            ranks[wild_ver] = rank_
+        deer.on_version(ranking)
+
+    cleaned_request = str(req)
+    # do some cleanup
+    cleaned_request = deer.restore(cleaned_request)
+
+    if len(ranks) > 1:
+        # should we support this ?
+        return None, None
+    else:
+        rank = next(iter(ranks.values()))
+
+        if rank < 0:
+            directive = "harden"
+        else:
+            directive = "harden(%d)" % rank
+
+        return cleaned_request, directive
+
+
+def bind_directives(package):
+    """Bind previously parsed directives to each variants
+    """
+    anonymous = directive_manager.loaded.storage(anonymous=True)
+
+    for variant in package.iter_variants():
+        requires = copy(variant.variant_requires)
+        requires += variant.get_requires(build_requires=True,
+                                         private_build_requires=True)
+        requires_str = set(map(str, requires))
+
+        data = {r: v for r, v in anonymous.items() if r in requires_str}
+        directive_manager.loaded.put(data, key=variant)
+
+    directive_manager.loaded.clear(anonymous=True)
+
+
+def process_directives(variant, context):
+    """Evaluate directives with resolved context
+    """
+    package = variant.parent
+    package_data = package.validated_data()
+
+    directives = directive_manager.loaded.retrieve(key=variant) or dict()
+    resolved_packages = {p.name: p for p in context.resolved_packages}
+
+    processed = dict()
+    directed = list()
+
+    def visit_directive(request):
+        directive_name, args = directives.get(str(request)) or (None, None)
+        resolved = resolved_packages.get(request.name)
+
+        if directive_name and resolved:
+            request = PackageRequest(str(
+                Requirement.construct(
+                    name=resolved.name,
+                    range=directive_manager.process(
+                        request.range, resolved.version, directive_name, args,
+                    ))
+            ))
+            directed.append(request)
+
+        return request
+
+    visitor = And(PackageRequest, Use(visit_directive))
+    schemas = {
+        "requires": [visitor],
+        "build_requires": [visitor],
+        "private_build_requires": [visitor],
+        "variants": [[visitor]],
+    }
+
+    for key, value in schemas.items():
+        if key not in package_data:
+            continue
+        schema = Schema({Optional(key): value})
+        data = schema.validate({key: package_data[key]})
+        if directed:
+            processed[key] = copy(data[key])
+            directed.clear()
+
+    directive_manager.processed.put(processed, key=variant)
+
+
+def apply_directives(variant):
+    """Patch evaluated directives to variant on install
+    """
+    directed_requires = directive_manager.processed.retrieve(key=variant)
+
+    # Just like how `cached_property` caching attributes, override
+    # requirement attributes internally. These change will be picked
+    # up by `variant.parent.validated_data`.
+    for key, value in directed_requires.items():
+        setattr(variant.parent.resource, key, value)
+        if key == "variants":
+            setattr(variant.resource, "variant_requires", value[variant.index])
+
+
+class DirectiveManager(object):
+
+    def __init__(self):
+        self._loaded = VariantDataInventory()
+        self._processed = VariantDataInventory()
+        self._handlers = dict()
+
+    @property
+    def loaded(self):
+        return self._loaded
+
+    @property
+    def processed(self):
+        return self._processed
+
+    def register_handler(self, cls, name=None, *args, **kwargs):
+        name = name or cls.name()
+        self._handlers[name] = cls(*args, **kwargs)
+
+    def parse(self, string):
+        for name, handler in self._handlers.items():
+            if string == name or string.startswith(name + "("):
+                return name, handler.parse(string[len(name):])
+
+    def to_string(self, name, args):
+        handler = self._handlers[name]
+        return handler.to_string(args)
+
+    def process(self, range_, version, name, args):
+        handler = self._handlers[name]
+        return handler.process(range_, version, *args)
+
+
+class VariantDataInventory(object):
+
+    def __init__(self):
+        self._anonymous = dict()
+        self._identified = dict()
+
+    def _hash(self, key, anonymous):
+        if anonymous:
+            return key
+        else:
+            variant = key
+            return (
+                variant.name,
+                str(variant.version),
+                variant.uuid,
+                variant.index,
+            )
+
+    def storage(self, anonymous):
+        return self._anonymous if anonymous else self._identified
+
+    def put(self, data, key, anonymous=False):
+        key = self._hash(key, anonymous)
+        storage = self.storage(anonymous)
+        storage[key] = data
+
+    def retrieve(self, key, anonymous=False):
+        key = self._hash(key, anonymous)
+        storage = self.storage(anonymous)
+        if key in storage:
+            return copy(storage[key])
+
+    def drop(self, key, anonymous=False):
+        key = self._hash(key, anonymous)
+        storage = self.storage(anonymous)
+        if key in storage:
+            storage.pop(key)
+
+    def clear(self, anonymous=False):
+        storage = self.storage(anonymous)
+        storage.clear()
+
+
+def anonymous_directive_string(request):
+    """Test use"""
+    name, args = directive_manager.loaded.retrieve(request, anonymous=True)
+    return directive_manager.to_string(name, args)
+
+
+directive_manager = DirectiveManager()
+
+# Auto register all subclasses of DirectiveBase in this module
+for obj in list(sys.modules[__name__].__dict__.values()):
+    if not inspect.isclass(obj):
+        continue
+    if issubclass(obj, DirectiveBase) and obj is not DirectiveBase:
+        directive_manager.register_handler(obj)

--- a/src/rez/utils/request_directives.py
+++ b/src/rez/utils/request_directives.py
@@ -126,7 +126,7 @@ def bind_directives(package):
     directive_manager.loaded.clear(anonymous=True)
 
 
-def process_directives(variant, context):
+def resolve_directives(variant, context):
     """Evaluate directives with resolved context
     """
     package = variant.parent

--- a/src/rez/vendor/version/util.py
+++ b/src/rez/vendor/version/util.py
@@ -1,4 +1,7 @@
+
+from contextlib import contextmanager
 from itertools import groupby
+from uuid import uuid4
 
 
 class VersionError(Exception):
@@ -24,3 +27,117 @@ def dedup(iterable):
     """Removes duplicates from a sorted sequence."""
     for e in groupby(iterable):
         yield e[0]
+
+
+def is_valid_bound(bound):
+    lower_tokens = bound.lower.version.tokens
+    upper_tokens = bound.upper.version.tokens
+    return ((lower_tokens is None or lower_tokens)
+            and (upper_tokens is None or upper_tokens))
+
+
+@contextmanager
+def dewildcard(request):
+    deer = WildcardReplacer(request)
+    yield deer
+    deer.clean()
+
+
+class WildcardReplacer(object):
+
+    def __init__(self, request):
+        from .requirement import Requirement
+
+        self.wildcard_map = dict()
+        self._req = None
+        self._on_wildcard = None
+        self._on_version = None
+
+        # replace wildcards with valid version tokens that can be replaced again
+        # afterwards. This produces a horrendous, but both valid and temporary,
+        # version string.
+        #
+        while "**" in request:
+            uid = "_%s_" % uuid4().hex
+            request = request.replace("**", uid, 1)
+            self.wildcard_map[uid] = "**"
+
+        while "*" in request:
+            uid = "_%s_" % uuid4().hex
+            request = request.replace("*", uid, 1)
+            self.wildcard_map[uid] = "*"
+
+        self._req = Requirement(request, invalid_bound_error=False)
+
+    @property
+    def victim(self):
+        return self._req
+
+    def on_wildcard(self, func):
+        self._on_wildcard = func
+
+    def on_version(self, func):
+        self._on_version = func
+
+    def restore(self, string):
+        for uid, token in self.wildcard_map.items():
+            string = string.replace(uid, token)
+        return string
+
+    def clean(self, on_wildcard=None, on_version=None):
+        from .version import VersionRange
+
+        on_wildcard = on_wildcard or self._on_wildcard or (lambda v, r: v)
+        on_version = on_version or self._on_version or (lambda v, r: None)
+
+        req = self._req
+        wildcard_map = self.wildcard_map
+        cleaned_versions = dict()
+
+        def clean_version(version):
+            rank = len(version)
+            original = version
+            wildcard_found = False
+
+            while version and str(version[-1]) in wildcard_map:
+                token_ = wildcard_map[str(version[-1])]
+                version = version.trim(len(version) - 1)
+
+                if token_ == "**":
+                    if wildcard_found:  # catches bad syntax '**.*'
+                        return None
+                    else:
+                        wildcard_found = True
+                        rank = 0
+                        break
+
+                wildcard_found = True
+
+            on_version(original, rank)
+            if wildcard_found:
+                return on_wildcard(version, rank)
+
+        def visit_version(version):
+            # requirements like 'foo-1' are actually represented internally as
+            # 'foo-1+<1_' - '1_' is the next possible version after '1'. So we have
+            # to detect this case and remap the uid-ified wildcard back here too.
+            #
+            for v, expanded_v in cleaned_versions.items():
+                if version == next(v):
+                    return next(expanded_v)
+
+            version_ = clean_version(version)
+            if version_ is None:
+                return None
+
+            cleaned_versions[version] = version_
+            return version_
+
+        req.range_.visit_versions(visit_version)
+
+        for bound in list(req.range_.bounds):
+            if not is_valid_bound(bound):
+                req.range_.bounds.remove(bound)
+
+        if not req.range_.bounds:
+            req.range_ = VersionRange()


### PR DESCRIPTION
This PR implements `REP-002.006` in #673. Note this, the new syntax isn't meant to replace/deprecate the current requirements expansion feature as what `REP-002.006` and `REP-002.001` have said, but try to convert those wildcarded requests into new syntax internally while building package.

### Delaying Requirement Expansion

Current requirements expansion feature expands requirements on package load, by scanning currently installed packages. In contrast, this new feature expands requirements with resolved package build context.

### Storing Additional Information

Information that parsed from directive syntax on package-load time, e.g. directive function name and arguments, need to be stored somewhere during package build. One possible option would be to attach them to `PackageRequest` or other related classes, which means to store them in package itself like attributes' metadata.

But the `PackageRequest` and other related classes are low level stuff, which isn't a good fit for this high level feature. Plus, by the nature of how package attributes are loaded before build, how attributes will be processed afterward, and how package variants will be spawned multiple times in different places, those information is hard to guarantee to be retrieved or written correctly at any given point without fighting more details in low level.

So instead, I end up storing them outside of package, and retrieve or modify those data by a key that is hashed from variant.

### Caveats

Currently, for old style expansion syntax requests (those have wildcards), this new feature only ***try*** to convert them into new syntax, and fallback to early expansion route if the conversion result is not defined in new syntax.

For example, how request like `foo-1+<2` will be harden is not yet been defined in `REP-002.006`, so for request like `foo-1.*+<2.*` can not be converted.

Also for case like `foo<**`, although it doesn't make sense in package requires but still can be converted, however the conversion result is `foo//harden` which means differently than the old style syntax.
