### PR TITLE
rez config --json FIELD

### DIFF
--- a/src/rez/cli/config.py
+++ b/src/rez/cli/config.py
@@ -3,8 +3,14 @@ Print current rez settings.
 '''
 from __future__ import print_function
 
+import json
+
 
 def setup_parser(parser, completions=False):
+    parser.add_argument(
+        "--json", dest="json", action="store_true",
+        help="Output dict/list field values as JSON. Useful for setting "
+             "REZ_*_JSON environment variables. Ignored if FIELD not given")
     parser.add_argument(
         "--search-list", dest="search_list", action="store_true",
         help="list the config files searched")
@@ -46,8 +52,8 @@ def command(opts, parser, extra_arg_groups=None):
                 raise ValueError("no such setting: %r" % opts.FIELD)
 
     if isinstance(data, (dict, list)):
-        txt = dump_yaml(data).strip()
-        print(txt)
+        txt = json.dumps(data) if opts.json else dump_yaml(data)
+        print(txt.strip())
     else:
         print(data)
 

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -10,6 +10,7 @@ from rez.utils.data_utils import RO_AttrDictWrapper
 from rez.packages import get_developer_package
 import os
 import os.path
+import subprocess
 
 
 class TestConfig(TestBase):
@@ -237,8 +238,54 @@ class TestConfig(TestBase):
 
         self.assertEqual(c.packages_path, packages_path)
 
+    def test_8(self):
+        """Test CLI dict/list value JSON round trip."""
+        import json
+        import rez.cli._main
 
-if __name__ == '__main__':
+        cli_file = rez.cli._main.__file__
+
+        # python /path/to/rez/cli/_main.py config ...
+        config_args = [os.sys.executable, cli_file, "config"]
+
+        c = Config([self.root_config_file], locked=True)
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("REZ_")
+        }
+
+        test_configs = {
+            "packages_path": ["/foo bar/baz", "/foo bar/baz hey", "/home/foo bar/baz"],
+            "platform_map": {"foo": {"bar": "baz"}},
+        }
+        for config_key, test_value in test_configs.items():
+            try:
+                # Test fetching default value
+                stdout = subprocess.check_output(
+                    config_args + ["--json", config_key],
+                    env=env,
+                )
+                config_json_value = stdout.decode().strip()
+                self.assertEqual(
+                    config_json_value,
+                    json.dumps(getattr(c, config_key)).decode(),
+                )
+
+                # Test setting via env var and fetching custom value
+                test_json_value = json.dumps(test_value).decode()
+                env["REZ_%s_JSON" % config_key.upper()] = test_json_value
+                stdout = subprocess.check_output(
+                    config_args + ["--json", config_key],
+                    env=env,
+                )
+                self.assertEqual(stdout.decode().strip(), test_json_value)
+            except subprocess.CalledProcessError as error:
+                print(error.stdout)
+                raise
+
+
+if __name__ == "__main__":
     unittest.main()
 
 

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -8,6 +8,7 @@ from rez.config import Config, get_module_root_config, _replace_config
 from rez.system import system
 from rez.utils.data_utils import RO_AttrDictWrapper
 from rez.packages import get_developer_package
+from rez.vendor.six import six
 import os
 import os.path
 import subprocess
@@ -266,14 +267,13 @@ class TestConfig(TestBase):
                     config_args + ["--json", config_key],
                     env=env,
                 )
-                config_json_value = stdout.decode().strip()
                 self.assertEqual(
-                    config_json_value,
-                    json.dumps(getattr(c, config_key)).decode(),
+                    six.ensure_str(stdout).strip(),
+                    six.ensure_str(json.dumps(getattr(c, config_key))),
                 )
 
                 # Test setting via env var and fetching custom value
-                test_json_value = json.dumps(test_value).decode()
+                test_json_value = six.ensure_str(json.dumps(test_value))
                 env["REZ_%s_JSON" % config_key.upper()] = test_json_value
                 stdout = subprocess.check_output(
                     config_args + ["--json", config_key],


### PR DESCRIPTION
Simple addition to allow for


```bash
rez config --json platform_map
# {"os": {"CentOS-(\\d+)\\.(\\d+)(\\.(\\d+))?": "CentOS-\\1"}}

# Serialising for usage in another clean shell/environment e.g. docker
docker run --env REZ_PLATFORM_MAP_JSON="$(rez config --json platform_map)" centos:7
```

----

### Added

- `--json` flag to `rez-config` that will JSON format the output if the `FIELD` given is a dict/list