### PR TITLE
switch to cached root in variant binding

### DIFF
--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -4,7 +4,7 @@ test the rex command generator API
 from rez.rex import RexExecutor, Python, Setenv, Appendenv, Prependenv, Info, \
     Comment, Alias, Command, Source, Error, Shebang, Unsetenv, expandable, \
     literal
-from rez.rex_bindings import VersionBinding, VariantsBinding, \
+from rez.rex_bindings import VersionBinding, VariantBinding, VariantsBinding, \
     RequirementsBinding, EphemeralsBinding, intersects
 from rez.exceptions import RexError, RexUndefinedVariableError
 from rez.config import config
@@ -425,7 +425,13 @@ class TestRex(TestBase):
             for package in family.iter_packages()
             for variant in package.iter_variants()
         ]
-        resolve = VariantsBinding(resolved_packages)
+
+        variant_bindings = dict(
+            (variant.name, VariantBinding(variant))
+            for variant in resolved_packages
+        )
+        resolve = VariantsBinding(variant_bindings)
+
         self.assertTrue(intersects(resolve.foo, "1"))
         self.assertFalse(intersects(resolve.foo, "0"))
         self.assertTrue(intersects(resolve.maya, "2019+"))


### PR DESCRIPTION
-added test to verify that refs like resolve.mypkg.root are correct in commands
-changed ResolvedContext.execute_rex_code() to be post-actions callback

Fixes #1065 

This is an alternative fix to https://github.com/nerdvegas/rez/pull/1067 please see comment there.
