### PR TITLE
Avoid hidden folder/files as it introduces problems on certain fileystems

### DIFF
--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -323,7 +323,7 @@ def make_tmp_name(name):
     disk at context exit time, it is deleted.
     """
     path, base = os.path.split(name)
-    tmp_base = ".tmp-%s-%s" % (base, uuid4().hex)
+    tmp_base = "_tmp-%s-%s" % (base, uuid4().hex)
     tmp_name = os.path.join(path, tmp_base)
 
     try:


### PR DESCRIPTION
I am not sure what the right solution is. Config variable? Windows vs. Linux case? Either way here is
a fix to a very tricky issue that might affect others considering that . prefix is not a happy story in Windows
anyway:

Prefixing file/folders . on certain Linux file servers, that are mounted
via samba to Windows makes the folders hidden. But in edgecases the rename
retains the hidden attribute after the rename without the . prefix.
We observed this on rez-cp.

Some client applications (Autodesk Maya) refuses to work with hidden files.
As such avoid using hidden files for temporary artifacts for sanity sake.