### PR TITLE
Allow trailing comma in Legacy Metadata

### DIFF
--- a/src/rez/vendor/distlib/util.py
+++ b/src/rez/vendor/distlib/util.py
@@ -215,6 +215,9 @@ def parse_requirement(req):
                         if not ver_remaining or ver_remaining[0] != ',':
                             break
                         ver_remaining = ver_remaining[1:].lstrip()
+                        # Some packages have a trailing comma which would break the matching
+                        if not ver_remaining:
+                            break
                         m = COMPARE_OP.match(ver_remaining)
                         if not m:
                             raise SyntaxError('invalid constraint: %s' % ver_remaining)


### PR DESCRIPTION
This fixes rez-pip install for packages that have a trailing comma on
version requirements.

For example openpyxl will now install properly with this line:
```
Requires-Python: >=3.6,
                      ^ Parser will fail without the patch
```

Not sure if you rather want to wait for upstream.