### PR TITLE
Using tox to run flake8

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -33,19 +33,5 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Install Dependencies
-        run: |
-          pip install flake8
-
-      - name: Run flake8
-        run: >-
-          find -name '*.py'
-          -not -path './build_utils/*'
-          -not -path './rez/vendor/*'
-          -not -path './rez/data/*'
-          -not -path './support/*'
-          -not -path './rez/backport/*'
-          -not -path './rezgui/*'
-          | xargs flake8 --ignore
-          E241,E265,E266,E741,E742,E722,F821,W503
-        working-directory: src
+      - run: pip install tox
+      - run: tox -e py37-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,21 @@
+[tox]
+envlist = py37,flake8
+
+[testenv:py37-flake8]
+description = Lint inside src, mimics Rez 2.59.1 Flake8 CI
+changedir = {toxinidir}{/}src
+deps = flake8
+commands = flake8
+
 [flake8]
 max-line-length = 120
 # max-complexity = 12
 
-ignore = E265,E241
-exclude = tests,template,vendor,backport,build_utils
+ignore = E241,E265,E266,E741,E742,E722,F821,W503
+extend-exclude =
+    */build_utils/*
+    */rez/vendor/*
+    */rez/data/*
+    */support/*
+    */rez/backport/*
+    */rezgui/*


### PR DESCRIPTION
:eyes:  _Look, there's a tox.ini! Maybe we can use that!_

Just a side thing to implement and use `py37-flake8` routine as it's currently partially implemented and not actively used.

I've made sure to update the:
- Ignore rules as per the Flake8 CI
- Check that the file path exclusion is fully compatible with the previous `find ...` rules (hacked a local venv's `flake8` source code to inspect and compare the file paths found are the same)

Not even sure if this is a good idea, heck, do we even want to go down the `tox` route for test, docs building and linting when developing rez source code locally? Perhaps `tox.ini` wasn't supposed to be used anyways?
