### PR TITLE
fixed missing __ne__ op in resource handle

### DIFF
--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.90.1"
+_rez_version = "2.90.2"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rez/utils/resources.py
+++ b/src/rez/utils/resources.py
@@ -176,6 +176,9 @@ class ResourceHandle(object):
     def __eq__(self, other):
         return (self.key == other.key) and (self.variables == other.variables)
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash(self._hashable_repr())
 


### PR DESCRIPTION
This bug has been there a long time, undetected.

Manifested as rez-test not being able to find the correct variant to run a test in, because a (VariantHandle != VariantHandle) test was always returning True despite the handles being equivalent. This started happening because in v2.84.0, a change was made where the handle returned from installing a variant into a filesystem repo, was changed to return it from a _copy_ of the repo. See https://github.com/nerdvegas/rez/pull/1061/files#diff-0923f674fb98267b2cbc6111a14e4073edceab2b1b2661939dfef8bf7f112dbcR1341-R1346 for an explanation of why we do this.

Fixes #1095 
