### PR TITLE
Prevent alias (windows function) to store all arguments in one string instead of an array of strings

### DIFF
--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -273,7 +273,7 @@ class PowerShellBase(Shell):
         value = EscapedString.disallow(value)
         # TODO: Find a way to properly escape paths in alias() calls that also
         # contain args
-        cmd = "function {key}() {{ {value} $args }}"
+        cmd = "function {key}() {{ {value} @args }}"
         self._addline(cmd.format(key=key, value=value))
 
     def comment(self, value):


### PR DESCRIPTION
Hi,

We are facing an issue when defining alias in the `package.py` of a windows package.
Arguments passed to the python script defined in the alias receive all arguments in one string instead of an array of strings.

Here is a way to reproduce it:

1. the python script (test/ test_arg.py)
``` python
# coding: utf8

import sys
import argparse  # noqa: I100


if __name__ == "__main__":

    argv = sys.argv[1:]

    parser = argparse.ArgumentParser()
    parser.add_argument("foo", type=str)
    parser.add_argument("-b", "--bar", type=str, default="toto")
    args = parser.parse_args(argv)

    print(argv)
    print(args)
```


2. the alias defined test package (test/package.py)
``` python
    import os

    alias(
        "arg_test",
        "python {}".format(
            os.path.join("{root}", "test_arg.py")
        ),
    )
```

3. tests

When calling arg_test like this: `rez env test -- arg_test blah --bar titi`, we would expect:
`argv = ['blah', '--bar', 'titi']` and `args = Namespace(bar='titi', foo='blah')`

But unfortunately, we have
`argv = ['blah --bar titi']` and `args = Namespace(bar='toto', foo='blah --bar titi')`

because the sys.argv is not split
