### PR TITLE
Remove the -s flag to rez-pip because "pip search" is decommissioned

### DIFF
--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -44,7 +44,7 @@ def command(opts, parser, extra_arg_groups=None):
         # Prevent other rez.* loggers from printing debugs
         logging.getLogger('rez').setLevel(logging.INFO)
 
-    from rez.pip import pip_install_package, run_pip_command
+    from rez.pip import pip_install_package
     import warnings
 
     if not (opts.search or opts.install):

--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -20,9 +20,6 @@ def setup_parser(parser, completions=False):
         "-i", "--install", action="store_true",
         help="install the package")
     parser.add_argument(
-        "-s", "--search", action="store_true",
-        help="search for the package on PyPi")
-    parser.add_argument(
         "-r", "--release", action="store_true",
         help="install as released package; if not set, package is installed "
         "locally only")
@@ -52,11 +49,6 @@ def command(opts, parser, extra_arg_groups=None):
 
     if not (opts.search or opts.install):
         parser.error("Expected one of: --install, --search")
-
-    if opts.search:
-        with run_pip_command(["search", opts.PACKAGE]) as p:
-            p.wait()
-        return
 
     if opts.pip_ver:
         with warnings.catch_warnings():


### PR DESCRIPTION
Fixes #1104 .
As the title says, remove the `-s` flag to `rez-pip` because `pip search` functionality that was provided by PyPI has been decommissioned, see https://status.python.org/incidents/grk0k7sz6zkp.

Recent pip versions prints a nice error message, but studios using an older version just gets an unhandled error from pip.

So the safe thing to do is to remove the flag. I could keep the flag and simply print an error, but in my opinion, just getting rid of the flag should be enough... In any case, let me know and I can re-introduce the flag and print a user friendly error message.