### PR TITLE
Ensure command string is escaped correctly when executing in windows cmd shell

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -197,6 +197,21 @@ class TestShells(TestBase, TempdirMixin):
 
     @per_available_shell()
     @install_dependent()
+    def test_rez_env_output_special_chars(self):
+        # here we are making sure that running a command with special chars
+        # via rez-env prints exactly what we expect.
+
+        # Assumes that the shell has an echo command, build-in or alias
+        cmd = [os.path.join(system.rez_bin_path, "rez-env"), "--", "echo", "<hey>"]
+        process = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, universal_newlines=True
+        )
+        sh_out = process.communicate()
+        self.assertEqual(sh_out[0].strip(), "<hey>")
+
+    @per_available_shell()
+    @install_dependent()
     def test_rez_command(self):
         sh = create_shell()
         _, _, _, command = sh.startup_capabilities(command=True)

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -204,7 +204,7 @@ class CMD(Shell):
 
         if startup_sequence["command"] is not None:
             _record_shell(executor, files=startup_sequence["files"])
-            shell_command = startup_sequence["command"]
+            shell_command = self.escape_string(startup_sequence["command"])
         else:
             _record_shell(executor, files=startup_sequence["files"], print_msg=(not quiet))
 


### PR DESCRIPTION
### Problem:
The following does not execute correctly when run in a windows cmd prompt.
```
rez-env python -- echo "<hey>"
The system cannot find the file specified.
```

This is because the batch file that is written out is without the escaped chars.
```
set REZ_ENV_PROMPT=%REZ_ENV_PROMPT%$G
echo %PATHEXT%|C:\Windows\System32\findstr.exe /i /c:".PY">nul || set PATHEXT=%PATHEXT%;.PY
(call )
call C:\..\AppData\Local\Temp\rez_context_fiqpunrh\context.bat
set REZ_STORED_PROMPT_CMD=$P$G
set PROMPT=%REZ_ENV_PROMPT% $P$G
echo <Hey>
exit %errorlevel%
```

what we need is the batch file to contain.
`echo ^<Hey^>`

### Solution:
Ensure that the command run via rez-env is escaped correctly when executing in a windows cmd shell.