### PR TITLE
quoting fix (continue on #1115, tested on Windows)

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -195,6 +195,12 @@ class TestShells(TestBase, TempdirMixin):
             sh_out = process.communicate()
             self.assertEqual(sh_out[0].strip(), txt)
 
+        # please note - it's no coincidence that there are no substrings like
+        # '$you' here. These would expand to the equivalent env-var (as
+        # intended), which would be an empty string. We're not testing that
+        # here though.
+        #
+
         _test("hey")  # simple case
         _test("hey you")  # with a space
         _test("<hey>")  # special characters

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -183,17 +183,25 @@ class TestShells(TestBase, TempdirMixin):
     @per_available_shell()
     @install_dependent()
     def test_rez_env_output(self):
-        # here we are making sure that running a command via rez-env prints
-        # exactly what we expect.
+        def _test(txt):
+            # Assumes that the shell has an echo command, build-in or alias
+            binpath = os.path.join(system.rez_bin_path, "rez-env")
+            args = [binpath, "--", "echo", txt]
 
-        # Assumes that the shell has an echo command, build-in or alias
-        cmd = [os.path.join(system.rez_bin_path, "rez-env"), "--", "echo", "hey"]
-        process = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, universal_newlines=True
-        )
-        sh_out = process.communicate()
-        self.assertEqual(sh_out[0].strip(), "hey")
+            process = subprocess.Popen(
+                args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, universal_newlines=True
+            )
+            sh_out = process.communicate()
+            self.assertEqual(sh_out[0].strip(), txt)
+
+        _test("hey")  # simple case
+        _test("hey you")  # with a space
+        _test("<hey>")  # special characters
+        _test("!hey>$")  # more special characters
+        _test("'hey'")  # single quotes
+        _test('"hey"')  # double quotes
+        _test("hey ?yeah> 'you'..^!")  # throw lots of stuff at it
 
     @per_available_shell()
     @install_dependent()

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -10,6 +10,7 @@ from rez.rex import literal, expandable
 from rez.utils.execution import ExecutableScriptMode, _get_python_script_files
 from rez.tests.util import TestBase, TempdirMixin, per_available_shell, \
     install_dependent
+from rez.util import shlex_join
 from rez.bind import hello_world
 import unittest
 import subprocess
@@ -193,7 +194,7 @@ class TestShells(TestBase, TempdirMixin):
                 stderr=subprocess.PIPE, universal_newlines=True
             )
             sh_out = process.communicate()
-            self.assertEqual(sh_out[0].strip(), txt)
+            self.assertEqual(sh_out[0].strip(), shlex_join([txt]))
 
         # please note - it's no coincidence that there are no substrings like
         # '$you' here. These would expand to the equivalent env-var (as

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -6,6 +6,7 @@ import collections
 import atexit
 import os
 import os.path
+import re
 from rez.exceptions import RezError
 from rez.vendor.progress.bar import Bar
 from rez.vendor.six import six
@@ -40,14 +41,31 @@ def dedup(seq):
             yield item
 
 
+_find_unsafe = re.compile(r'[^\w@%+=:,./-]').search
+
+
+def double_quote(s):
+    """A backport of shlex.quote (py 3.8+) that double-quotes instead of single.
+
+    We need this in order to escape commands in resolved shells. For example,
+    the command `rez-env -- echo 'hey $YOU'` needs to execute the equivalent
+    command `echo "hey $YOU"` within the runtime. The single quotes in the
+    initial command are only used to stop early expansion of $YOU, but within
+    the rez env, we default to expansion.
+    """
+    if not s:
+        return "''"
+    if _find_unsafe(s) is None:
+        return s
+
+    # use double quotes, and put double quotes into single quotes
+    # the string $"b is then quoted as "$"'"'"b"
+    return '"' + s.replace('"', '"\'"\'"') + '"'
+
+
 def shlex_join(value):
-    import pipes
-
-    def quote(s):
-        return pipes.quote(s) if '$' not in s else s
-
     if is_non_string_iterable(value):
-        return ' '.join(quote(x) for x in value)
+        return ' '.join(double_quote(x) for x in value)
     else:
         return str(value)
 

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.93.2"
+_rez_version = "2.94.0"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -1,6 +1,6 @@
 import os
 import re
-from subprocess import PIPE, list2cmdline
+from subprocess import PIPE
 
 from rez.config import config
 from rez.rex import RexExecutor, OutputStyle, EscapedString

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -8,6 +8,7 @@ from rez.shells import Shell
 from rez.system import system
 from rez.utils.platform_ import platform_
 from rez.utils.execution import Popen
+from rez.util import shlex_join
 
 
 class PowerShellBase(Shell):
@@ -304,9 +305,7 @@ class PowerShellBase(Shell):
 
     @classmethod
     def join(cls, command):
-        # TODO: This may disappear in future [1]
-        # [1] https://bugs.python.org/issue10838
-        return list2cmdline(command)
+        return shlex_join(command)
 
     @classmethod
     def line_terminator(cls):

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -7,6 +7,7 @@ from rez.shells import Shell
 from rez.system import system
 from rez.utils.execution import Popen
 from rez.utils.platform_ import platform_
+from rez.util import shlex_join
 from rez.vendor.six import six
 from functools import partial
 import os
@@ -354,9 +355,7 @@ class CMD(Shell):
 
     @classmethod
     def join(cls, command):
-        # TODO: This may disappear in future [1]
-        # [1] https://bugs.python.org/issue10838
-        return subprocess.list2cmdline(command)
+        return shlex_join(command)
 
     @classmethod
     def line_terminator(cls):


### PR DESCRIPTION
As title, this should fix #1114 based on #1115, and tested on my Windows machine.

* Base on the finding in https://github.com/nerdvegas/rez/pull/1111#issuecomment-891506931, I replaced `subprocess.list2cmdline` with `rez.util.shlex_join` for Windows shells.

* In test `rez.tests.test_shells.TestShells.test_rez_env_output`, I also changed the assertion to compare process output with shlex joined input. Thought that input string is being shlex joined on the way into subprocess so we should compare the same thing. Here's the original (#1115) testing output on my Windows :
```
___________________________________________________ TestShells.test_rez_env_output ____________________________________________________

self = <rez.tests.test_shells.TestShells testMethod=test_rez_env_output>

    @per_available_shell()
    @install_dependent()
    def test_rez_env_output(self):
        def _test(txt):
            # Assumes that the shell has an echo command, build-in or alias
            binpath = os.path.join(system.rez_bin_path, "rez-env")
            args = [binpath, "--", "echo", txt]

            process = subprocess.Popen(
                args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                stderr=subprocess.PIPE, universal_newlines=True
            )
            sh_out = process.communicate()
            self.assertEqual(sh_out[0].strip(), txt)

        # please note - it's no coincidence that there are no substrings like
        # '$you' here. These would expand to the equivalent env-var (as
        # intended), which would be an empty string. We're not testing that
        # here though.
        #

        _test("hey")  # simple case
>       _test("hey you")  # with a space

test_shells.py:205:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_shells.py:196: in _test
    self.assertEqual(sh_out[0].strip(), txt)
E   AssertionError: '"hey you"' != 'hey you'
E   - "hey you"
E   ? -       -
E   + hey you
E    (in shell 'cmd')
-------------------------------------------------------- Captured stdout call ---------------------------------------------------------

testing in shell: cmd...
======================================================= short test summary info =======================================================
FAILED test_shells.py::TestShells::test_rez_env_output - AssertionError: '"hey you"' != 'hey you'
========================================================== 1 failed in 1.28s ==========================================================
```