### PR TITLE
Added a configuration option for rez-pip dist-info remapping

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -354,6 +354,7 @@ config_schema = Schema({
     "memcached_uri":                                OptionalStrList,
     "pip_extra_args":                               OptionalStrList,
     "pip_install_remaps":                           PipInstallRemaps,
+    "pip_install_override_dist_info_remap":         Bool,
     "local_packages_path":                          Str,
     "release_packages_path":                        Str,
     "dot_image_format":                             Str,

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -495,8 +495,8 @@ def _get_distribution_files_mapping(distribution, targetdir):
 
         # Special case - dist-info files. These are all in a '<pkgname>-<version>.dist-info'
         # dir. We keep this dir and place it in the root dir of the rez package.
-        #
-        if topdir.endswith(".dist-info"):
+        # This behavior can be disable with config `pip_override_dist_info_remap = False`
+        if config.get("pip_install_override_dist_info_remap", True) and topdir.endswith(".dist-info"):
             return (rel_src, rel_src)
 
         # Remapping of other installed files according to manifest

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -918,6 +918,10 @@ pip_install_remaps = [
     },
 ]
 
+# If this is False, *.dist-info/* files will be placed in {root}/python/*.dist-info/*.
+# If this is True, *.dist-info/* files will be placed in {root}/*.dist-info/*.
+pip_install_override_dist_info_remap = True
+
 # Optional variables. A dict type config for storing arbitrary data that can be
 # accessed by the [optionvars](Package-Commands#optionvars) function in packages
 # *commands*.


### PR DESCRIPTION
I created this PR to get some traction on #892 .

This PR keeps the current behavior, but lets us configure the current "special-case" in rez-pip that always copies dist-info files to the rez-package root.

By setting `pip_install_override_dist_info_remap = False`, dist-info files will end up alongside the python package as some tools expect.

In my opinion the better solution would be to just change the default behavior and copy the files to where they are expected.