### PR TITLE
Fix  fileno() error in Maya2022

### DIFF
--- a/src/rez/utils/execution.py
+++ b/src/rez/utils/execution.py
@@ -58,9 +58,12 @@ class Popen(_PopenBase):
                 AttributeError,
                 UnsupportedOperation  # https://github.com/nerdvegas/rez/pull/966
             ):
-                file_no = sys.__stdin__.fileno()
+                if sys.__stdin__ is None:
+                    file_no = None
+                else:
+                    file_no = sys.__stdin__.fileno()
 
-            if file_no not in (0, 1, 2):
+            if file_no is None or file_no not in (0, 1, 2):
                 kwargs["stdin"] = subprocess.PIPE
 
         # Add support for the new py3 "text" arg, which is equivalent to


### PR DESCRIPTION
Maya 2022 console don't have sys.__stdin__ is a None object. 
Although the comment said this is taken into account, but the code didn't implement this idea.

Using `resolved_context.save_resolved_context_file(file_path=rez_ctx_file)` in Maya 2022 will cause the following error
```
# Error: AttributeError: file ~~~~\rez\~~~\platform-windows\python-3.7\lib\site-packages\rez\utils\execution.py line 59: 'NoneType' object has no attribute 'fileno' # 
```