### PR TITLE
CLI: display detailed version info with --version

### DIFF
--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -9,7 +9,7 @@ from argparse import _StoreTrueAction, SUPPRESS
 from rez.cli._util import subcommands, LazyArgumentParser, _env_var_true
 from rez.utils.logging_ import print_error
 from rez.exceptions import RezError, RezSystemError, _NeverError
-from rez import __version__
+from rez import __version__, module_root_path
 
 
 # true if command was like 'rez-env' rather than 'rez env'
@@ -84,12 +84,15 @@ def setup_parser():
     Returns:
         LazyArgumentParser: Argument parser for rez command.
     """
+    py = sys.version_info
     parser = LazyArgumentParser("rez")
 
     parser.add_argument("-i", "--info", action=InfoAction,
                         help="print information about rez and exit")
     parser.add_argument("-V", "--version", action="version",
-                        version="Rez %s" % __version__)
+                        version="Rez %s from %s (python %d.%d)" % (
+                            __version__, module_root_path, py.major, py.minor
+                        ))
 
     # add args common to all subcommands... we add them both to the top parser,
     # AND to the subparsers, for two reasons:


### PR DESCRIPTION
Like what you get with `pip --version` in shell, thought this kind of info would also be helpful for Rez
```
>rez --version
Rez 2.95.0 from c:\users\david\dev\rez\src\rez (python 3.7)
```