### PR TITLE
Better shell specific testing

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -11,6 +11,7 @@ from rez.utils.execution import ExecutableScriptMode, _get_python_script_files
 from rez.tests.util import TestBase, TempdirMixin, per_available_shell, \
     install_dependent
 from rez.bind import hello_world
+from rez.config import config
 import unittest
 import subprocess
 import tempfile
@@ -183,16 +184,20 @@ class TestShells(TestBase, TempdirMixin):
     @per_available_shell()
     @install_dependent()
     def test_rez_env_output(self):
+        target_shell = config.default_shell  # overridden by test util
+
         def _test(txt):
             # Assumes that the shell has an echo command, build-in or alias
             binpath = os.path.join(system.rez_bin_path, "rez-env")
-            args = [binpath, "--", "echo", txt]
+            args = [binpath, "--shell", target_shell, "--", "echo", txt]
 
             process = subprocess.Popen(
                 args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE, universal_newlines=True
             )
             sh_out = process.communicate()
+            if sh_out[1]:
+                raise Exception("Command failed:\n%s" % sh_out[1])
             self.assertEqual(sh_out[0].strip(), txt)
 
         # please note - it's no coincidence that there are no substrings like

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -198,8 +198,10 @@ def program_dependent(program_name, *program_names):
     return decorator
 
 
-def per_available_shell():
+def per_available_shell(exclude=None):
     """Function decorator that runs the function over all available shell types."""
+    exclude = exclude or []
+
     def decorator(func):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
@@ -216,6 +218,10 @@ def per_available_shell():
             ]
 
             for shell in shells:
+                if not only_shell and shell in exclude:
+                    print("\nshell excluded from this test: %s..." % shell)
+                    continue
+
                 print("\ntesting in shell: %s..." % shell)
                 config.override("default_shell", shell)
 


### PR DESCRIPTION
* fix #1135,
* also, able to exclude specific shells from testing with `@per_available_shell()`. This is currently as a helper feature for working on `test_rez_env_output`.
    
    Example usage as follow:

    ```python
        @per_available_shell(exclude=["cmd", "powershell"])
        @install_dependent()
        def test_rez_env_output(self):
            ...
    ```