### PR TITLE
Typo or mistake in wiki anchor - package commands: variable-appending-and-prepending

### DIFF
--- a/wiki/pages/Package-Commands.md
+++ b/wiki/pages/Package-Commands.md
@@ -334,7 +334,7 @@ The *env* object also provides the following functions:
 
 Appends a value to an environment variable. By default this will use the *os.pathsep* delimiter
 between list items, but this can be overridden using the config setting *env_var_separators*. See
-[here](#variable-prepending-and-appending) for further information on the behavior of this function.
+[here](#variable-appending-and-prepending) for further information on the behavior of this function.
 
 #### env.prepend
 *Function*


### PR DESCRIPTION
The variable-prepending-and-appending does not exist but variable-appending-and-prepending does so I'm assuming this was a typo