### PR TITLE
Add editable mode in production install

### DIFF
--- a/install.py
+++ b/install.py
@@ -136,8 +136,9 @@ def install(dest_dir, edit=False, print_welcome=False):
 
     Args:
         dest_dir (str): Full path to the install directory.
-        edit (bool):
-        print_welcome (bool):
+        edit (bool): Install Rez in editable mode if True. Default False.
+        print_welcome (bool): Print welcome message at the end of installation.
+            Default False.
     """
     print("%sinstalling rez to %s..."
           % ("(edit mode) " if edit else "", dest_dir))


### PR DESCRIPTION
For Rez CLI development/testing convenience, I suggest we add `--edit` option in production installation script.
And to be more advance, Rez's production install check should also accepts editable mode installation.

## Implementation

The new `--edit` option is just [`pip install --edit`](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs), which is `setuptools` [development mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html). With this enabled, one could dev/testing Rez CLI in fast pace in production venv.

Now here's a problem, Rez's production check is using the relative path of Rez module location (`rez.__path__[0]`) to Rez binary tools, which only works if both end points are inside the venv directory layout. And if `--edit` is enabled, this won't work because the module location would be at the source code repository. Completely out side of venv.

To solve this, I took the advantage of `rez.egg-info` directory, which should be generated by `setuptools` under source `rez/src/` when `--edit` is on. Any changes made inside that directory will be ignored by Git, and install script could dump some breadcrumb there safely for Rez to read.

So I changed the install script to write out Rez's production binary tools' location into a file `.rez_production_entry` under `src/rez.egg-info` when `--edit` is on. And in production check, if it could not find Rez binary directory with venv layout, will change to look for `rez.egg-info` and try to match one from there.

