### PR TITLE
Fix pika connector

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -435,6 +435,7 @@ config_schema = Schema({
     "debug_package_exclusions":                     Bool,
     "debug_memcache":                               Bool,
     "debug_resolve_memcache":                       Bool,
+    "debug_context_tracking":                       Bool,
     "debug_all":                                    Bool,
     "debug_none":                                   Bool,
     "quiet":                                        Bool,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -715,6 +715,9 @@ debug_resolve_memcache = False
 # "memcached -vv" as the server)
 debug_memcache = False
 
+# Print debugging info when AMPQ is used in context tracking
+debug_context_tracking = False
+
 # Turn on all debugging messages
 debug_all = False
 

--- a/src/rez/utils/amqp.py
+++ b/src/rez/utils/amqp.py
@@ -2,6 +2,7 @@ import atexit
 import socket
 import time
 import threading
+import logging
 
 from rez.utils import json
 from rez.utils.logging_ import print_error
@@ -10,6 +11,7 @@ from rez.vendor.pika.adapters.blocking_connection import BlockingConnection
 from rez.vendor.pika.connection import ConnectionParameters
 from rez.vendor.pika.credentials import PlainCredentials
 from rez.vendor.pika.spec import BasicProperties
+from rez.config import config
 
 
 _lock = threading.Lock()
@@ -60,6 +62,8 @@ def _publish_message(host, amqp_settings, routing_key, data):
     if host == "stdout":
         print("Published to %s: %s" % (routing_key, data))
         return True
+
+    set_pika_log_level()
 
     host, port = parse_host_and_port(url=host)
 
@@ -139,3 +143,12 @@ def parse_host_and_port(url):
     port = _url.port
 
     return host, port
+
+
+def set_pika_log_level():
+    mod_name = "rez.vendor.pika"
+
+    if config.debug("context_tracking"):
+        logging.getLogger(mod_name).setLevel(logging.DEBUG)
+    else:
+        logging.getLogger(mod_name).setLevel(logging.WARNING)

--- a/src/rez/utils/amqp.py
+++ b/src/rez/utils/amqp.py
@@ -65,18 +65,22 @@ def _publish_message(host, amqp_settings, routing_key, data):
 
     set_pika_log_level()
 
-    host, port = parse_host_and_port(url=host)
+    conn_kwargs = dict()
 
-    creds = PlainCredentials(
-        username=amqp_settings.get("userid"),
-        password=amqp_settings.get("password")
-    )
+    host, port = parse_host_and_port(url=host)
+    conn_kwargs["host"] = host
+    if port is not None:
+        conn_kwargs["port"] = port
+
+    if amqp_settings.get("userid"):
+        conn_kwargs["credentials"] = PlainCredentials(
+            username=amqp_settings.get("userid"),
+            password=amqp_settings.get("password")
+        )
 
     params = ConnectionParameters(
-        host=host,
-        port=port,
-        credentials=creds,
-        socket_timeout=amqp_settings.get("connect_timeout")
+        socket_timeout=amqp_settings.get("connect_timeout"),
+        **conn_kwargs
     )
 
     props = BasicProperties(

--- a/src/rez/utils/amqp.py
+++ b/src/rez/utils/amqp.py
@@ -5,7 +5,7 @@ import threading
 
 from rez.utils import json
 from rez.utils.logging_ import print_error
-from rez.vendor.six.six.moves import queue
+from rez.vendor.six.six.moves import queue, urllib
 from rez.vendor.pika.adapters.blocking_connection import BlockingConnection
 from rez.vendor.pika.connection import ConnectionParameters
 from rez.vendor.pika.credentials import PlainCredentials
@@ -61,6 +61,8 @@ def _publish_message(host, amqp_settings, routing_key, data):
         print("Published to %s: %s" % (routing_key, data))
         return True
 
+    host, port = parse_host_and_port(url=host)
+
     creds = PlainCredentials(
         username=amqp_settings.get("userid"),
         password=amqp_settings.get("password")
@@ -68,6 +70,7 @@ def _publish_message(host, amqp_settings, routing_key, data):
 
     params = ConnectionParameters(
         host=host,
+        port=port,
         credentials=creds,
         socket_timeout=amqp_settings.get("connect_timeout")
     )
@@ -126,3 +129,13 @@ def on_exit():
 
     while _num_pending and (time.time() - t) < maxtime:
         time.sleep(timeinc)
+
+
+def parse_host_and_port(url):
+    _url = urllib.parse.urlsplit(url)
+    if not _url.scheme:
+        _url = urllib.parse.urlsplit("//" + url)
+    host = _url.hostname
+    port = _url.port
+
+    return host, port


### PR DESCRIPTION
This close #1144 .

## Changes
* supporting `{host}:{port}` formated `rezconfig.context_tracking_host`
* default credentials (guest/guest) can be used if `rezconfig.context_tracking_amqp.userid` remain as defulat
* adding `rezconfig.debug_context_tracking`, so the `pika` logging level is configable, between `DEBUG` and `WARNING`
