### PR TITLE
Fix rez-pip on Windows

### DIFF
--- a/src/rez/backport/shutilwhich.py
+++ b/src/rez/backport/shutilwhich.py
@@ -1,50 +1,67 @@
+# Modified version of whichcraft, a shim of `shutil.which`.
+# 'env' environ dict override has been added by Colin Kennedy.
+
+# Source: https://github.com/cookiecutter/whichcraft/blob/0.6.1/whichcraft.py
+# Copyright (c) 2015-2016, Daniel Roy Greenfeld
+# All rights reserved.
+
+__author__ = "Daniel Roy Greenfeld"
+__email__ = "pydanny@gmail.com"
+__version__ = "0.6.1"
+
 import os
-import os.path
 import sys
 
-
-# Modified version from Python-3.3. 'env' environ dict override has been added.
-
-def which(cmd, mode=os.F_OK | os.X_OK, env=None):
+def which(cmd, mode=os.F_OK | os.X_OK, path=None, env=None):
     """Given a command, mode, and a PATH string, return the path which
     conforms to the given mode on the PATH, or None if there is no such
     file.
-
-    `mode` defaults to os.F_OK | os.X_OK. `env` defaults to os.environ,
-    if not supplied.
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    Note: This function was backported from the Python 3 source code.
     """
     # Check that a given file can be accessed with the correct mode.
     # Additionally check that `file` is not a directory, as on Windows
     # directories pass the os.access check.
-    def _access_check(fn, mode):
-        return (os.path.exists(fn) and os.access(fn, mode)
-                and not os.path.isdir(fn))
 
-    # Short circuit. If we're given a full path which matches the mode
-    # and it exists, we're done here.
-    if _access_check(cmd, mode):
-        return cmd
+    def _access_check(fn, mode):
+        return os.path.exists(fn) and os.access(fn, mode) and not os.path.isdir(fn)
+
+    # If we're given a path with a directory part, look it up directly
+    # rather than referring to PATH directories. This includes checking
+    # relative to the current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+
+        return None
 
     if env is None:
         env = os.environ
 
-    path = env.get("PATH", os.defpath).split(os.pathsep)
+    if path is None:
+        path = env.get("PATH", os.defpath)
+    if not path:
+        return None
+
+    path = path.split(os.pathsep)
 
     if sys.platform == "win32":
         # The current directory takes precedence on Windows.
-        if not os.curdir in path:
+        if os.curdir not in path:
             path.insert(0, os.curdir)
 
         # PATHEXT is necessary to check on Windows.
-        default_pathext = \
-            '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC'
-        pathext = env.get("PATHEXT", default_pathext).split(os.pathsep)
-        # See if the given file matches any of the expected path extensions.
-        # This will allow us to short circuit when given "python.exe".
-        matches = [cmd for ext in pathext if cmd.lower().endswith(ext.lower())]
-        # If it does match, only test that one, otherwise we have to try
-        # others.
-        files = [cmd] if matches else [cmd + ext.lower() for ext in pathext]
+        pathext = env.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path
+        # extensions. This will allow us to short circuit when given
+        # "python.exe". If it does match, only test that one, otherwise we
+        # have to try others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
     else:
         # On other platforms you don't have things like PATHEXT to tell you
         # what file suffixes are executable, so just pass on cmd as-is.
@@ -52,13 +69,12 @@ def which(cmd, mode=os.F_OK | os.X_OK, env=None):
 
     seen = set()
     for dir in path:
-        dir = os.path.normcase(dir)
-        if not dir in seen:
-            seen.add(dir)
+        normdir = os.path.normcase(dir)
+        if normdir not in seen:
+            seen.add(normdir)
             for thefile in files:
                 name = os.path.join(dir, thefile)
-                # On windows the system paths might have %systemroot%
-                name = os.path.expandvars(name)
                 if _access_check(name, mode):
                     return name
+
     return None


### PR DESCRIPTION
Resolves #904 , #1024

This is my first PR here, please let me know if there's more to add. :)

# Intended change
This should now fix the issues with rez-pip on windows, which previously was not able to find python.

# Implementation
The implementation by @ColinKennedy is basically taken from [here](https://github.com/nerdvegas/rez/issues/904#issuecomment-766438613) and therefore based on another library called [whichcraft](https://github.com/cookiecutter/whichcraft). The library function is extended to also take an environment parameter.
The library is BSD licensed and I tried to include the relevant copyright notices.  

# Tested on
Windows 10
Rez 2.98
Python 3.9.7

___

Suggestions/feedback welcome!

Cheers,
Manuel