### PR TITLE
Uses Set-Item rather than $Env: to configure powershell environment variables.

### DIFF
--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -282,14 +282,15 @@ class PowerShellBase(Shell):
 
     def setenv(self, key, value):
         value = self.escape_string(value)
-        self._addline('$Env:{0} = "{1}"'.format(key, value))
+        self._addline('Set-Item -Path "env:{0}" -Value "{0}"'.format(key, value))
 
     def appendenv(self, key, value):
         value = self.escape_string(value)
         # Be careful about ambiguous case in pwsh on Linux where pathsep is :
         # so that the ${ENV:VAR} form has to be used to not collide.
         self._addline(
-            '$Env:{0} = "${{Env:{0}}}{1}{2}"'.format(key, os.path.pathsep, value)
+            'Set-Item -Path "env:{0}" -Value ((Get-ChildItem "env:{0}").Value + "{1}{2}")'.format(
+                key, os.path.pathsep, value)
         )
 
     def unsetenv(self, key):

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -282,14 +282,14 @@ class PowerShellBase(Shell):
 
     def setenv(self, key, value):
         value = self.escape_string(value)
-        self._addline('Set-Item -Path "env:{0}" -Value "{0}"'.format(key, value))
+        self._addline('Set-Item -Path "Env:{0}" -Value "{1}"'.format(key, value))
 
     def appendenv(self, key, value):
         value = self.escape_string(value)
         # Be careful about ambiguous case in pwsh on Linux where pathsep is :
         # so that the ${ENV:VAR} form has to be used to not collide.
         self._addline(
-            'Set-Item -Path "env:{0}" -Value ((Get-ChildItem "env:{0}").Value + "{1}{2}")'.format(
+            'Set-Item -Path "Env:{0}" -Value ((Get-ChildItem "Env:{0}").Value + "{1}{2}")'.format(
                 key, os.path.pathsep, value)
         )
 


### PR DESCRIPTION
Updates `powershell_base.py` to use `Set-Item` when setting environment variables to ensure environment variables with special characters such as `()` don't cause script failures.

Repro:

```
name = 'testpackage'
version = '1.0.0'

requires = [
    'platform-windows'
]

build_command = False

def commands():
    env['ENVVARWITH(x86)'] = 'This_breaks_powershell'
    env['ENVVARWITH(x86)'].append('Another value')
````

`rez build -i & rez-env testpackage --shell=powershell`

With this patch the above use case should work.