### PR TITLE
Whichcraft now cares about executable symlinks on windows that might not end with typical executable extensions

### DIFF
--- a/src/rez/vendor/whichcraft/whichcraft.py
+++ b/src/rez/vendor/whichcraft/whichcraft.py
@@ -62,6 +62,15 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None, env=None):
         # have to try others.
         if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
             files = [cmd]
+        # See if the file is a symlink. A symlink can be an executable on 
+        # windows without an extension. If it is, see if its target's extension
+        # matches any of the expted path extensions.
+        elif any(
+            os.path.realpath(os.path.join(p, cmd)).lower().endswith(ext.lower())
+            for ext in pathext
+            for p in path
+        ):
+            files = [cmd]
         else:
             files = [cmd + ext.lower() for ext in pathext]
     else:


### PR DESCRIPTION
Fixes #1178 

Hey,

in a previous commit we added whichcraft to care about rez pip for windows. 
In some cases however there might be executables in the packages that are just symlinks to executables. And these symlinks can have any kind of or no extension.

To deal with that I am checking if the checked files are a symlink to an executable with the [listed extensions](https://github.com/nerdvegas/rez/pull/1157/files#diff-364b6b1f7924a21c8cce24cd56ea6e8a077572f6faf5dfb249a92c5cac28e5bcR11).

Cheers,
Manuel