### PR TITLE
windows CI upgrade

### DIFF
--- a/.github/docker/rez-win-base/Dockerfile
+++ b/.github/docker/rez-win-base/Dockerfile
@@ -23,13 +23,13 @@ ARG PWSH_VERSION=6.2.2
 # - PowerShellCore
 #
 ENV chocolateyUseWindowsCompression false
-RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'));             `
-    choco feature disable --name showDownloadProgress;                                                 `
-    choco install git.install --yes --version=${ENV:GIT_VERSION};                                      `
+RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); `
+    choco feature disable --name showDownloadProgress; `
+    choco install git.install --yes --version=${ENV:GIT_VERSION}; `
     choco install cmake --yes --version=${ENV:CMAKE_VERSION} --installargs 'ADD_CMAKE_TO_PATH=System'; `
-    choco install pwsh --yes --version=${PWSH_VERSION};                                                `
-    choco install --yes choco-cleaner;                                                                 `
-    C:\ProgramData\chocolatey\bin\choco-cleaner.bat;                                                   `
+    choco install pwsh --yes --version=${PWSH_VERSION}; `
+    choco install --yes choco-cleaner; `
+    C:\ProgramData\chocolatey\bin\choco-cleaner.bat; `
     choco uninstall --yes choco-cleaner
 
 ENTRYPOINT ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "ByPass"]

--- a/.github/docker/rez-win-base/Dockerfile
+++ b/.github/docker/rez-win-base/Dockerfile
@@ -29,7 +29,7 @@ RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/insta
     choco install cmake --yes --version=${ENV:CMAKE_VERSION} --installargs 'ADD_CMAKE_TO_PATH=System'; `
     choco install pwsh --yes --version=${PWSH_VERSION};                                                `
     choco install --yes choco-cleaner;                                                                 `
-    C:\ProgramData\chocolatey\bin\choco-cleaner.ps1;                                                   `
+    C:\ProgramData\chocolatey\bin\choco-cleaner.bat;                                                   `
     choco uninstall --yes choco-cleaner
 
 ENTRYPOINT ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "ByPass"]

--- a/.github/docker/rez-win-py/Dockerfile
+++ b/.github/docker/rez-win-py/Dockerfile
@@ -27,14 +27,14 @@ ARG PYTHON_VERSION
 # Python 2.x uses msi while 3.x has an exe with separate arguments
 # Verifies the installation by running python explicitly and via `python`
 #
-RUN ${PYTHON_INSTALL_PATH} = 'C:\Python';                                                                                            `
-    ${PYTHON_MAJOR_VERSION} = ${ENV:PYTHON_VERSION}.Split('.')[0];                                                                   `
-    if (${PYTHON_MAJOR_VERSION} -eq "2") {                                                                                           `
-        ${INSTALLARGS} = \"'/qn /norestart ADDLOCAL=ALL ALLUSERS=1 TARGETDIR=`\"\" + ${PYTHON_INSTALL_PATH} + \"`\"'\";              `
-    } else {                                                                                                                         `
-        ${INSTALLARGS} = \"'/quiet InstallAllUsers=1 PrependPath=1 TargetDir=`\"\" + ${PYTHON_INSTALL_PATH} + \"`\"'\";              `
-    }                                                                                                                                `
-    choco install python${PYTHON_MAJOR_VERSION} --yes --version=\"${ENV:PYTHON_VERSION}\" --override --installargs=${INSTALLARGS};   `
+RUN ${PYTHON_INSTALL_PATH} = 'C:\Python'; `
+    ${PYTHON_MAJOR_VERSION} = ${ENV:PYTHON_VERSION}.Split('.')[0]; `
+    if (${PYTHON_MAJOR_VERSION} -eq "2") { `
+        ${INSTALLARGS} = \"'/qn /norestart ADDLOCAL=ALL ALLUSERS=1 TARGETDIR=`\"\" + ${PYTHON_INSTALL_PATH} + \"`\"'\"; `
+    } else { `
+        ${INSTALLARGS} = \"'/quiet InstallAllUsers=1 PrependPath=1 TargetDir=`\"\" + ${PYTHON_INSTALL_PATH} + \"`\"'\"; `
+    } `
+    choco install python${PYTHON_MAJOR_VERSION} --yes --version=\"${ENV:PYTHON_VERSION}\" --override --installargs=${INSTALLARGS}; `
     if (-not $?) {exit 1};
 
 # ------------------------------------------------------------------------------------------------------------

--- a/.github/docker/rez-win-py/Dockerfile
+++ b/.github/docker/rez-win-py/Dockerfile
@@ -3,12 +3,12 @@
 # Tag of base image to use
 ARG BASE_TAG
 
+# Base image windows version
+FROM rez-win-base:$BASE_TAG
+
 # Tag applied to this image
 ARG PY_TAG
 ENV _PY_TAG=$PY_TAG
-
-# Base image windows version
-FROM rez-win-base:$BASE_TAG
 
 # NOTE: Any " requires \" in the Dockerfile for windows.
 # NOTE: The order matters. ARG after the shell command will allow access via

--- a/.github/docker/rez-win-py/Dockerfile
+++ b/.github/docker/rez-win-py/Dockerfile
@@ -4,7 +4,8 @@
 ARG BASE_TAG
 
 # Tag applied to this image
-ENV PY_TAG
+ARG PY_TAG
+ENV _PY_TAG=$PY_TAG
 
 # Base image windows version
 FROM rez-win-base:$BASE_TAG

--- a/.github/docker/rez-win-py/Dockerfile
+++ b/.github/docker/rez-win-py/Dockerfile
@@ -36,14 +36,14 @@ RUN ${PYTHON_INSTALL_PATH} = 'C:\Python';                                       
 # ------------------------------------------------------------------------------------------------------------
 # Verify Python
 #
-RUN $python_relative_ver = (& python --version 2>&1).ToString().Trim().Split(" ")[1];                                       `
-    $python_explicit_ver = (& C:\python\python.exe --version 2>&1).ToString().Trim().Split(" ")[1];                         `
-    if (-not $?) {exit 1};                                                                                                  `
-    $python_relative_ver = (& python --version 2>&1).ToString().Trim().Split(" ")[1];                                       `
-    $python_explicit_ver = (& C:\python\python.exe --version 2>&1).ToString().Trim().Split(" ")[1];                         `
+RUN $python_relative_ver = (& python --version 2>&1).ToString().Trim().Split(" ")[1]; `
+    $python_explicit_ver = (& C:\python\python.exe --version 2>&1).ToString().Trim().Split(" ")[1]; `
+    if (-not $?) {exit 1}; `
+    $python_relative_ver = (& python --version 2>&1).ToString().Trim().Split(" ")[1]; `
+    $python_explicit_ver = (& C:\python\python.exe --version 2>&1).ToString().Trim().Split(" ")[1]; `
     if (-not ($python_explicit_ver -eq $python_relative_ver -and $python_explicit_ver -eq ${ENV:PYTHON_VERSION})) {exit 1}; `
-    choco install --yes choco-cleaner;                                                                                      `
-    C:\ProgramData\chocolatey\bin\choco-cleaner.ps1;                                                                        `
+    choco install --yes choco-cleaner; `
+    C:\ProgramData\chocolatey\bin\choco-cleaner.bat; `
     choco uninstall --yes choco-cleaner
 
 COPY entrypoint.ps1 /entrypoint.ps1

--- a/.github/docker/rez-win-py/Dockerfile
+++ b/.github/docker/rez-win-py/Dockerfile
@@ -3,6 +3,9 @@
 # Tag of base image to use
 ARG BASE_TAG
 
+# Tag applied to this image
+ENV PY_TAG
+
 # Base image windows version
 FROM rez-win-base:$BASE_TAG
 

--- a/.github/docker/rez-win-py/entrypoint.ps1
+++ b/.github/docker/rez-win-py/entrypoint.ps1
@@ -40,6 +40,9 @@ mkdir build
 python .\checkout\install.py build
 if (-not $?) {exit 1}
 
+# Install pytest for better rez-selftest output
+.\build\Scripts\rez\rez-python -m pip install pytest-cov
+
 # Run Rez Tests
 #
 .\build\Scripts\rez\rez-selftest.exe

--- a/.github/docker/rez-win-py/entrypoint.ps1
+++ b/.github/docker/rez-win-py/entrypoint.ps1
@@ -10,6 +10,12 @@ $ErrorActionPreference = "Stop"
 #
 ${ENV:PYTHONIOENCODING} = "UTF-8"
 
+# Print name of image being run, for debugging purposes. We can't show the
+# literal image name here, because it just uses 'latest' tagged image (see
+# explanation in windows-docker-image.yaml - on.push)
+#
+Write-Output "Running rez tests from docker image rez-win-py:${ENV:PY_TAG}"
+
 # Verify Python
 #
 python --version

--- a/.github/docker/rez-win-py/entrypoint.ps1
+++ b/.github/docker/rez-win-py/entrypoint.ps1
@@ -14,7 +14,7 @@ ${ENV:PYTHONIOENCODING} = "UTF-8"
 # literal image name here, because it just uses 'latest' tagged image (see
 # explanation in windows-docker-image.yaml - on.push)
 #
-Write-Output "Running rez tests from docker image rez-win-py:${ENV:PY_TAG}"
+Write-Output "Using docker image rez-win-py:${ENV:_PY_TAG}"
 
 # Verify Python
 #

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -6,20 +6,17 @@
 name: core
 on:
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/core.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
   push:
-    paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/core.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
 
 jobs:
   main:

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -7,8 +7,7 @@ name: core
 on:
   pull_request:
     paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
+      - '.github/**'
       - 'src/rez/utils/_version.py'
       - 'wiki/**'
       - 'metrics/**'

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -8,10 +8,13 @@ on:
       - '!src/rez/data/**'
   push:
     paths:
-      - 'src/**.py'
+      - 'src/rez/**.py'
+      - 'src/rezplugins/**.py'
       - '.github/workflows/flake8.yaml'
       - '!src/rez/utils/_version.py'
       - '!src/rez/data/**'
+      - '!src/rez/vendor/**'
+      - '!src/rez/backport/**'
 
 jobs:
   lint:
@@ -34,11 +37,11 @@ jobs:
       - name: Run flake8
         run: >-
           find -name '*.py'
-          -not -path './build_utils/*'
           -not -path './rez/vendor/*'
           -not -path './rez/data/*'
-          -not -path './support/*'
           -not -path './rez/backport/*'
+          -not -path './build_utils/*'
+          -not -path './support/*'
           -not -path './rezgui/*'
           | xargs flake8
         working-directory: src

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -5,11 +5,13 @@ on:
       - 'src/**.py'
       - '.github/workflows/flake8.yaml'
       - '!src/rez/utils/_version.py'
+      - '!src/rez/data/**'
   push:
     paths:
       - 'src/**.py'
       - '.github/workflows/flake8.yaml'
       - '!src/rez/utils/_version.py'
+      - '!src/rez/data/**'
 
 jobs:
   lint:

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -2,10 +2,13 @@ name: flake8
 on:
   pull_request:
     paths:
-      - 'src/**.py'
+      - 'src/rez/**.py'
+      - 'src/rezplugins/**.py'
       - '.github/workflows/flake8.yaml'
       - '!src/rez/utils/_version.py'
       - '!src/rez/data/**'
+      - '!src/rez/vendor/**'
+      - '!src/rez/backport/**'
   push:
     paths:
       - 'src/rez/**.py'

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,22 +1,15 @@
 name: flake8
 on:
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - 'data/**'
-      - '**.md'
+    paths:
+      - 'src/**.py'
+      - '.github/workflows/flake8.yaml'
+      - '!src/rez/utils/_version.py'
   push:
-    paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - 'data/**'
-      - '**.md'
+    paths:
+      - 'src/**.py'
+      - '.github/workflows/flake8.yaml'
+      - '!src/rez/utils/_version.py'
 
 jobs:
   lint:

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -2,8 +2,7 @@ name: flake8
 on:
   pull_request:
     paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
+      - '.github/**'
       - 'src/rez/utils/_version.py'
       - 'wiki/**'
       - 'metrics/**'

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -2,6 +2,8 @@ name: installation
 on:
   push:
     paths-ignore:
+      - '.github/docker/**'
+      - '.github/workflows/windows-docker-image.yaml'
       - 'src/rez/utils/_version.py'
       - 'wiki/**'
       - 'metrics/**'

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -2,8 +2,7 @@ name: installation
 on:
   push:
     paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
+      - '.github/**'
       - 'src/rez/utils/_version.py'
       - 'wiki/**'
       - 'metrics/**'

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -1,12 +1,11 @@
 name: installation
 on:
   push:
-    paths-ignore:
-      - '.github/**'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/installation.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
 
 jobs:
   main:

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -1,20 +1,17 @@
 name: mac
 on:
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/mac.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
   push:
-    paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/mac.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
 
 jobs:
   main:

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -2,8 +2,7 @@ name: mac
 on:
   pull_request:
     paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
+      - '.github/**'
       - 'src/rez/utils/_version.py'
       - 'wiki/**'
       - 'metrics/**'

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -2,8 +2,7 @@ name: ubuntu
 on:
   pull_request:
     paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
+      - '.github/**'
       - 'src/rez/utils/_version.py'
       - 'wiki/**'
       - 'metrics/**'

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -1,20 +1,17 @@
 name: ubuntu
 on:
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/ubuntu.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
   push:
-    paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/ubuntu.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
 
 jobs:
   main:

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -20,7 +20,24 @@ name: windows-docker-image
 
 on:
   push:
-    # Will only trigger building a docker image if any of these changed
+    # We only generate new images on master, because the 'windows' workflow uses
+    # latest image, and we don't want it to use latest from a different branch.
+    # We could get around this by qualifying the image name with user and branch,
+    # however that would create a new image on each new branch, and windows image
+    # builds are _very slow_ on github runners.
+    #
+    # It would be ideal to avoid use of latest tag in 'windows' workflow, however
+    # that doesn't work. If we use the commit hash tag (see ${last_docker_py_rev}
+    # below), this causes the windows workflow to fail if the image also needs to
+    # be updated, since _this_ workflow hasn't had a chance to build it yet. We
+    # can't use workflow dependencies either (see 'workflow_run' github actions
+    # event) because that causes a workflow to run _only when_ another workflow
+    # has completed - however we only want to rebuild the image when required,
+    # not every time. Github needs to add a way to "run workflow B _after_ workflow
+    # A, _if_ A was triggered, otherwise run B regardless."
+    #
+    branches:
+      - issue_1181-win-docker  # TEMP
     paths:
       - '.github/docker/rez-win-base/**'
       - '.github/docker/rez-win-py/**'
@@ -47,22 +64,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build docker image if needed
+      - name: Build base docker image if needed
         run: |
-          ${Env:LAST_DOCKER_BASE_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+          ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
+
           $ErrorActionPreference = "Continue"
-          docker manifest inspect ${gh_user}/rez-win-base:${ENV:LAST_DOCKER_BASE_REVISION} | Out-Null
+          docker pull ${gh_user}/rez-win-base:${last_docker_base_rev} | Out-Null
           $ErrorActionPreference = "Stop"
+
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-base
-            docker build --tag ${gh_user}/rez-win-base:${ENV:LAST_DOCKER_BASE_REVISION} .
-            docker push ${gh_user}/rez-win-base:${ENV:LAST_DOCKER_BASE_REVISION}
+            docker build --tag ${gh_user}/rez-win-base:${last_docker_base_rev} .
+            docker push ${gh_user}/rez-win-base:${last_docker_base_rev}
           }
-        env:
-          # By using dockers experimental CLI features we don't need to pull an
-          # image to check if it exists.
-          DOCKER_CLI_EXPERIMENTAL: enabled
 
   # ----------------------------------------------------------------------------
   # Create python images off base image
@@ -91,25 +106,26 @@ jobs:
 
       - name: Pull base docker image
         run: |
-          ${Env:LAST_DOCKER_BASE_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+          ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          docker pull ${gh_user}/rez-win-base:${ENV:LAST_DOCKER_BASE_REVISION}
-          docker tag ${gh_user}/rez-win-base:${ENV:LAST_DOCKER_BASE_REVISION} rez-win-base:${ENV:LAST_DOCKER_BASE_REVISION}
+          docker pull ${gh_user}/rez-win-base:${last_docker_base_rev}
 
-      - name: Build Docker image if needed
+          # so rez-win-py/Dockerfile can reference base image
+          docker tag ${gh_user}/rez-win-base:${last_docker_base_rev} rez-win-base:${last_docker_base_rev}
+
+      - name: Build py Docker image if needed
         run: |
-          ${Env:LAST_DOCKER_BASE_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          ${Env:LAST_DOCKER_PY_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          ${Env:DOCKER_TAG} = "${{ matrix.python-version }}-${ENV:LAST_DOCKER_PY_REVISION}"
+          ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+          ${last_docker_py_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
+          ${docker_image} = "${gh_user}/rez-win-py-${{ matrix.python-version }}"
+
           $ErrorActionPreference = "Continue"
-          docker manifest inspect ${gh_user}/rez-win-py:${ENV:DOCKER_TAG} | Out-Null
+          docker pull ${docker_image}:${last_docker_py_rev} | Out-Null
           $ErrorActionPreference = "Stop"
+
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-py
-            docker build --tag ${gh_user}/rez-win-py:${ENV:DOCKER_TAG} --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${ENV:LAST_DOCKER_BASE_REVISION} .
-            docker push ${gh_user}/rez-win-py:${ENV:DOCKER_TAG}
+            docker build --tag ${docker_image} --tag ${docker_image}:${last_docker_py_rev} --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${last_docker_base_rev} .
+            docker push ${docker_image}:${last_docker_py_rev}
           }
-          $ErrorActionPreference = "Stop"
-        env:
-          DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -71,8 +71,8 @@ jobs:
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
           Write-Output "Pulling DockerHub image ${docker_image}..."
-          $ErrorActionPreference = "Continue"
-          docker pull ${docker_image} 2>$null || Write-Output "(no such image)"
+          $ErrorActionPreference = "SilentlyContinue"
+          docker pull ${docker_image} || Write-Output "(no such image)"
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
@@ -145,8 +145,8 @@ jobs:
           ${docker_image} = "${docker_image_notag}:${last_docker_py_rev}"
 
           Write-Output "Pulling DockerHub image ${docker_image}..."
-          $ErrorActionPreference = "Continue"
-          docker pull ${docker_image} 2>$null || Write-Output "(no such image)"
+          $ErrorActionPreference = "SilentlyContinue"
+          docker pull ${docker_image} || Write-Output "(no such image)"
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -70,18 +70,18 @@ jobs:
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
-          Write-Output "Pulling DockerHub image ${docker_image}..."
+          echo "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
-          docker pull ${docker_image} 2>$null
+          docker pull ${docker_image} 2>$null || echo "(no such image)"
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-base
 
-            Write-Output "Building DockerHub image ${docker_image}..."
+            echo "Building DockerHub image ${docker_image}..."
             docker build --tag ${docker_image} .
 
-            Write-Output "Pushing DockerHub image ${docker_image}..."
+            echo "Pushing DockerHub image ${docker_image}..."
             docker push ${docker_image}
 
             # store inspection as artifact for ease of debugging
@@ -130,7 +130,7 @@ jobs:
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
-          Write-Output "Pulling DockerHub image ${docker_image}..."
+          echo "Pulling DockerHub image ${docker_image}..."
           docker pull ${docker_image}
 
           # so rez-win-py/Dockerfile can reference base image
@@ -144,18 +144,18 @@ jobs:
           ${docker_image_notag} = "${gh_user}/rez-win-py-${{ matrix.python-version }}"
           ${docker_image} = "${docker_image_notag}:${last_docker_py_rev}"
 
-          Write-Output "Pulling DockerHub image ${docker_image}..."
+          echo "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
-          docker pull ${docker_image} 2>$null
+          docker pull ${docker_image} 2>$null || echo "(no such image)"
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-py
 
-            Write-Output "Building DockerHub image ${docker_image}..."
+            echo "Building DockerHub image ${docker_image}..."
             docker build --tag ${docker_image} --tag ${docker_image_notag} --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${last_docker_base_rev} .
 
-            Write-Output "Pushing DockerHub image ${docker_image}..."
+            echo "Pushing DockerHub image ${docker_image}..."
             docker push ${docker_image}
 
             # store inspection as artifact for ease of debugging

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -70,9 +70,9 @@ jobs:
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
-          Write-Host -ForegroundColor Yellow "Pulling DockerHub image ${docker_image}..."
+          Write-Output "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
-          docker pull ${docker_image} | Out-Null
+          docker pull ${docker_image} 2>$null
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
@@ -146,7 +146,7 @@ jobs:
 
           Write-Output "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
-          docker pull ${docker_image} | Out-Null
+          docker pull ${docker_image} 2>$null
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -77,7 +77,21 @@ jobs:
             cd .github\docker\rez-win-base
             docker build --tag ${gh_user}/rez-win-base:${last_docker_base_rev} .
             docker push ${gh_user}/rez-win-base:${last_docker_base_rev}
+
+            # store inspection as artifact for ease of debugging
+            docker inspect ${gh_user}/rez-win-base:${last_docker_base_rev} > inspect.json
           }
+
+      - id: inspect_json
+        uses: andstor/file-existence-action@v1
+        with:
+          files: .github\docker\rez-win-base\inspect.json
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "rez-win-base.json"
+          path: .github\docker\rez-win-base\inspect.json
+        if: steps.inspect_json.outputs.files_exists == 'true'
 
   # ----------------------------------------------------------------------------
   # Create python images off base image

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -67,7 +67,12 @@ jobs:
       - name: Build base docker image if needed
         id: build_image
         run: |
-          ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+          ${last_docker_base_rev} = $( `
+            git log -n 1 --author-date-order --pretty=format:%H -- `
+            .\.github\docker\rez-win-base\ `
+            .\.github\workflows\windows-docker-image.yaml `
+          ).SubString(0, 8)
+
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
@@ -87,7 +92,7 @@ jobs:
 
             # store inspection as artifact for ease of debugging
             docker inspect ${docker_image} > inspect.json
-            Write-Output "::set-output base_rev=${last_docker_base_rev}"
+            Write-Output "::set-output name=base_rev::${last_docker_base_rev}"
           }
 
       - id: inspect_json
@@ -128,7 +133,12 @@ jobs:
 
       - name: Pull base docker image
         run: |
-          ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+          ${last_docker_base_rev} = $( `
+            git log -n 1 --author-date-order --pretty=format:%H -- `
+            .\.github\docker\rez-win-base\ `
+            .\.github\workflows\windows-docker-image.yaml `
+          ).SubString(0, 8)
+
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
@@ -140,8 +150,19 @@ jobs:
 
       - name: Build py Docker image if needed
         run: |
-          ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          ${last_docker_py_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
+          ${last_docker_base_rev} = $( `
+            git log -n 1 --author-date-order --pretty=format:%H -- `
+            .\.github\docker\rez-win-base\ `
+            .\.github\workflows\windows-docker-image.yaml `
+          ).SubString(0, 8)
+
+          ${last_docker_py_rev} = $( `
+            git log -n 1 --author-date-order --pretty=format:%H -- `
+            .\.github\docker\rez-win-py\ `
+            .\.github\docker\rez-win-base\ `
+            .\.github\workflows\windows-docker-image.yaml `
+          ).SubString(0, 8)
+
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image_notag} = "${gh_user}/rez-win-py-${{ matrix.python-version }}"
           ${docker_image} = "${docker_image_notag}:${last_docker_py_rev}"
@@ -155,10 +176,17 @@ jobs:
             cd .github\docker\rez-win-py
 
             Write-Output "Building DockerHub image ${docker_image}..."
-            docker build --tag ${docker_image} --tag ${docker_image_notag}:latest --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${last_docker_base_rev} .
+            docker build `
+              --tag ${docker_image} `
+              --build-arg PYTHON_VERSION="${{ matrix.python-version }}" `
+              --build-arg BASE_TAG=${last_docker_base_rev} .
 
             Write-Output "Pushing DockerHub image ${docker_image}..."
             docker push ${docker_image}
+
+            Write-Output "Tagging and pushing ${docker_image_notag}:latest..."
+            docker tag ${docker_image} ${docker_image_notag}:latest
+            docker push ${docker_image_notag}:latest
 
             # store inspection as artifact for ease of debugging
             docker inspect ${docker_image} > inspect.json

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -68,18 +68,24 @@ jobs:
         run: |
           ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
+          ${docker_image} = ${gh_user}/rez-win-base:${last_docker_base_rev}
 
+          Write-Output "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
-          docker pull ${gh_user}/rez-win-base:${last_docker_base_rev} | Out-Null
+          docker pull ${docker_image} | Out-Null
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-base
-            docker build --tag ${gh_user}/rez-win-base:${last_docker_base_rev} .
-            docker push ${gh_user}/rez-win-base:${last_docker_base_rev}
+
+            Write-Output "Building DockerHub image ${docker_image}..."
+            docker build --tag ${docker_image} .
+
+            Write-Output "Pushing DockerHub image ${docker_image}..."
+            docker push ${docker_image}
 
             # store inspection as artifact for ease of debugging
-            docker inspect ${gh_user}/rez-win-base:${last_docker_base_rev} > inspect.json
+            docker inspect ${docker_image} > inspect.json
           }
 
       - id: inspect_json
@@ -122,24 +128,47 @@ jobs:
         run: |
           ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          docker pull ${gh_user}/rez-win-base:${last_docker_base_rev}
+          ${docker_image} = ${gh_user}/rez-win-base:${last_docker_base_rev}
+
+          Write-Output "Pulling DockerHub image ${docker_image}..."
+          docker pull ${docker_image}
 
           # so rez-win-py/Dockerfile can reference base image
-          docker tag ${gh_user}/rez-win-base:${last_docker_base_rev} rez-win-base:${last_docker_base_rev}
+          docker tag ${docker_image} rez-win-base:${last_docker_base_rev}
 
       - name: Build py Docker image if needed
         run: |
           ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${last_docker_py_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          ${docker_image} = "${gh_user}/rez-win-py-${{ matrix.python-version }}"
+          ${docker_image_notag} = "${gh_user}/rez-win-py-${{ matrix.python-version }}"
+          ${docker_image} = ${docker_image_notag}:${last_docker_py_rev}
 
+          Write-Output "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
-          docker pull ${docker_image}:${last_docker_py_rev} | Out-Null
+          docker pull ${docker_image} | Out-Null
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-py
-            docker build --tag ${docker_image} --tag ${docker_image}:${last_docker_py_rev} --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${last_docker_base_rev} .
-            docker push ${docker_image}:${last_docker_py_rev}
+
+            Write-Output "Building DockerHub image ${docker_image}..."
+            docker build --tag ${docker_image} --tag ${docker_image_notag} --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${last_docker_base_rev} .
+
+            Write-Output "Pushing DockerHub image ${docker_image}..."
+            docker push ${docker_image}
+
+            # store inspection as artifact for ease of debugging
+            docker inspect ${docker_image} > inspect.json
           }
+
+      - id: inspect_json
+        uses: andstor/file-existence-action@v1
+        with:
+          files: .github\docker\rez-win-py\inspect.json
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "rez-win-py-${{ matrix.python-version }}.json"
+          path: .github\docker\rez-win-py\inspect.json
+        if: steps.inspect_json.outputs.files_exists == 'true'

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -70,18 +70,18 @@ jobs:
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
-          echo "Pulling DockerHub image ${docker_image}..."
+          Write-Output "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
-          docker pull ${docker_image} 2>$null || echo "(no such image)"
+          docker pull ${docker_image} 2>$null || Write-Output "(no such image)"
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-base
 
-            echo "Building DockerHub image ${docker_image}..."
+            Write-Output "Building DockerHub image ${docker_image}..."
             docker build --tag ${docker_image} .
 
-            echo "Pushing DockerHub image ${docker_image}..."
+            Write-Output "Pushing DockerHub image ${docker_image}..."
             docker push ${docker_image}
 
             # store inspection as artifact for ease of debugging
@@ -130,7 +130,7 @@ jobs:
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
-          echo "Pulling DockerHub image ${docker_image}..."
+          Write-Output "Pulling DockerHub image ${docker_image}..."
           docker pull ${docker_image}
 
           # so rez-win-py/Dockerfile can reference base image
@@ -144,18 +144,18 @@ jobs:
           ${docker_image_notag} = "${gh_user}/rez-win-py-${{ matrix.python-version }}"
           ${docker_image} = "${docker_image_notag}:${last_docker_py_rev}"
 
-          echo "Pulling DockerHub image ${docker_image}..."
+          Write-Output "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
-          docker pull ${docker_image} 2>$null || echo "(no such image)"
+          docker pull ${docker_image} 2>$null || Write-Output "(no such image)"
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-py
 
-            echo "Building DockerHub image ${docker_image}..."
+            Write-Output "Building DockerHub image ${docker_image}..."
             docker build --tag ${docker_image} --tag ${docker_image_notag} --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${last_docker_base_rev} .
 
-            echo "Pushing DockerHub image ${docker_image}..."
+            Write-Output "Pushing DockerHub image ${docker_image}..."
             docker push ${docker_image}
 
             # store inspection as artifact for ease of debugging

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -153,7 +153,7 @@ jobs:
             cd .github\docker\rez-win-py
 
             Write-Output "Building DockerHub image ${docker_image}..."
-            docker build --tag ${docker_image} --tag ${docker_image_notag} --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${last_docker_base_rev} .
+            docker build --tag ${docker_image} --tag ${docker_image_notag}:latest --build-arg PYTHON_VERSION="${{ matrix.python-version }}" --build-arg BASE_TAG=${last_docker_base_rev} .
 
             Write-Output "Pushing DockerHub image ${docker_image}..."
             docker push ${docker_image}

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -70,7 +70,7 @@ jobs:
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
-          Write-Output "Pulling DockerHub image ${docker_image}..."
+          Write-Host -ForegroundColor Yellow "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
           docker pull ${docker_image} | Out-Null
           $ErrorActionPreference = "Stop"

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          ${docker_image} = ${gh_user}/rez-win-base:${last_docker_base_rev}
+          ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
           Write-Output "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"
@@ -128,7 +128,7 @@ jobs:
         run: |
           ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
-          ${docker_image} = ${gh_user}/rez-win-base:${last_docker_base_rev}
+          ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
           Write-Output "Pulling DockerHub image ${docker_image}..."
           docker pull ${docker_image}
@@ -142,7 +142,7 @@ jobs:
           ${last_docker_py_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
           ${docker_image_notag} = "${gh_user}/rez-win-py-${{ matrix.python-version }}"
-          ${docker_image} = ${docker_image_notag}:${last_docker_py_rev}
+          ${docker_image} = "${docker_image_notag}:${last_docker_py_rev}"
 
           Write-Output "Pulling DockerHub image ${docker_image}..."
           $ErrorActionPreference = "Continue"

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -33,11 +33,12 @@ on:
     # can't use workflow dependencies either (see 'workflow_run' github actions
     # event) because that causes a workflow to run _only when_ another workflow
     # has completed - however we only want to rebuild the image when required,
-    # not every time. Github needs to add a way to "run workflow B _after_ workflow
-    # A, _if_ A was triggered, otherwise run B regardless."
+    # not every time the windows workflow runs. Github needs to add a way to
+    # "run workflow B _after_ workflow A, _if_ A was triggered, otherwise run B
+    # regardless."
     #
     branches:
-      - issue_1181-win-docker  # TEMP1
+      - master
     paths:
       - '.github/docker/rez-win-base/**'
       - '.github/docker/rez-win-py/**'

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -176,7 +176,7 @@ jobs:
           if ($LastExitCode -ne 0) {
             cd .github\docker\rez-win-py
 
-            Write-Output "Building DockerHub image ${docker_image}..."
+            Write-Output "Building DockerHub image ${docker_image} from rez-win-base:${last_docker_base_rev}..."
             docker build `
               --tag ${docker_image} `
               --build-arg PYTHON_VERSION="${{ matrix.python-version }}" `

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -180,8 +180,9 @@ jobs:
             docker build `
               --tag ${docker_image} `
               --build-arg PYTHON_VERSION="${{ matrix.python-version }}" `
-              --build-arg BASE_TAG=${last_docker_base_rev} . `
-              --build-arg PY_TAG=${last_docker_py_rev} .
+              --build-arg BASE_TAG=${last_docker_base_rev} `
+              --build-arg PY_TAG=${last_docker_py_rev} `
+              .
 
             Write-Output "Pushing DockerHub image ${docker_image}..."
             docker push ${docker_image}

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -180,7 +180,8 @@ jobs:
             docker build `
               --tag ${docker_image} `
               --build-arg PYTHON_VERSION="${{ matrix.python-version }}" `
-              --build-arg BASE_TAG=${last_docker_base_rev} .
+              --build-arg BASE_TAG=${last_docker_base_rev} . `
+              --build-arg PY_TAG=${last_docker_py_rev} .
 
             Write-Output "Pushing DockerHub image ${docker_image}..."
             docker push ${docker_image}

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -37,7 +37,7 @@ on:
     # A, _if_ A was triggered, otherwise run B regardless."
     #
     branches:
-      - issue_1181-win-docker  # TEMP
+      - issue_1181-win-docker  # TEMP1
     paths:
       - '.github/docker/rez-win-base/**'
       - '.github/docker/rez-win-py/**'

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build base docker image if needed
+        id: build_image
         run: |
           ${last_docker_base_rev} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-base\  .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
           ${gh_user} = ("${{ github.repository }}" -Split '/')[0]
@@ -86,6 +87,7 @@ jobs:
 
             # store inspection as artifact for ease of debugging
             docker inspect ${docker_image} > inspect.json
+            Write-Output "::set-output base_rev=${last_docker_base_rev}"
           }
 
       - id: inspect_json
@@ -95,7 +97,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: "rez-win-base.json"
+          name: "rez-win-base-${{ steps.build_image.outputs.base_rev }}.json"
           path: .github\docker\rez-win-base\inspect.json
         if: steps.inspect_json.outputs.files_exists == 'true'
 

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -71,8 +71,8 @@ jobs:
           ${docker_image} = "${gh_user}/rez-win-base:${last_docker_base_rev}"
 
           Write-Output "Pulling DockerHub image ${docker_image}..."
-          $ErrorActionPreference = "SilentlyContinue"
-          docker pull ${docker_image} || Write-Output "(no such image)"
+          $ErrorActionPreference = "Continue"
+          docker pull ${docker_image} 2>$null || Write-Output "(no such image)"
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {
@@ -145,8 +145,8 @@ jobs:
           ${docker_image} = "${docker_image_notag}:${last_docker_py_rev}"
 
           Write-Output "Pulling DockerHub image ${docker_image}..."
-          $ErrorActionPreference = "SilentlyContinue"
-          docker pull ${docker_image} || Write-Output "(no such image)"
+          $ErrorActionPreference = "Continue"
+          docker pull ${docker_image} 2>$null || Write-Output "(no such image)"
           $ErrorActionPreference = "Stop"
 
           if ($LastExitCode -ne 0) {

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -149,6 +149,7 @@ jobs:
           docker tag ${docker_image} rez-win-base:${last_docker_base_rev}
 
       - name: Build py Docker image if needed
+        id: build_image
         run: |
           ${last_docker_base_rev} = $( `
             git log -n 1 --author-date-order --pretty=format:%H -- `
@@ -190,6 +191,7 @@ jobs:
 
             # store inspection as artifact for ease of debugging
             docker inspect ${docker_image} > inspect.json
+            Write-Output "::set-output name=py_rev::${last_docker_py_rev}"
           }
 
       - id: inspect_json
@@ -199,6 +201,6 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: "rez-win-py-${{ matrix.python-version }}.json"
+          name: "rez-win-py-${{ matrix.python-version }}-${{ steps.build_image.outputs.py_rev }}.json"
           path: .github\docker\rez-win-py\inspect.json
         if: steps.inspect_json.outputs.files_exists == 'true'

--- a/.github/workflows/windows-docker-image.yaml
+++ b/.github/workflows/windows-docker-image.yaml
@@ -180,8 +180,8 @@ jobs:
             docker build `
               --tag ${docker_image} `
               --build-arg PYTHON_VERSION="${{ matrix.python-version }}" `
-              --build-arg BASE_TAG=${last_docker_base_rev} `
-              --build-arg PY_TAG=${last_docker_py_rev} `
+              --build-arg BASE_TAG="${last_docker_base_rev}" `
+              --build-arg PY_TAG="${last_docker_py_rev}" `
               .
 
             Write-Output "Pushing DockerHub image ${docker_image}..."

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -48,8 +48,8 @@ jobs:
         run: |
           ${docker_image} = "nerdvegas/rez-win-py-${{ matrix.python-version }}"
 
-          Write-Output "Pulling latest DockerHub image ${docker_image}..."
+          echo "Pulling latest DockerHub image ${docker_image}..."
           docker pull ${docker_image}
 
-          Write-Output "Running DockerHub image ${docker_image}..."
+          echo "Running DockerHub image ${docker_image}..."
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -51,9 +51,7 @@ jobs:
 
           # show tagged image name to help debugging
           ${docker_image_tagged} = $( `
-            docker inspect ${docker_image} --format "{{range .RepoTags}}{{println .}}{{end}}" `
-            | grep -vw latest `
-            | grep nerdvegas `
+            docker inspect ${docker_image} --format "{{.RepoTags}}" `
           )
           Write-Output "Running DockerHub image ${docker_image_tagged}..."
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -40,12 +40,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: "Pull Docker image nerdvegas/rez-win-py-${{ matrix.python-version }}:latest"
+        run: |
+          ${docker_image} = "nerdvegas/rez-win-py-${{ matrix.python-version }}"
+          docker pull ${docker_image}:latest
+
       - name: Run Docker image (installs and tests rez)
         run: |
           ${docker_image} = "nerdvegas/rez-win-py-${{ matrix.python-version }}"
 
-          Write-Output "Pulling latest DockerHub image ${docker_image}..."
-          docker pull ${docker_image}
+          # show tagged image name to help debugging
+          ${docker_image_tagged} = $( `
+            docker inspect ${docker_image} --format "{{range .RepoTags}}{{println .}}{{end}}" `
+            | grep -vw latest `
+            | grep nerdvegas `
+          )
+          Write-Output "Running DockerHub image ${docker_image_tagged}..."
 
-          Write-Output "Running DockerHub image ${docker_image}..."
-          docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}
+          docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}:latest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -49,3 +49,4 @@ jobs:
 
           Write-Output "Running DockerHub image ${docker_image}..."
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}
+

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -48,11 +48,4 @@ jobs:
       - name: Run Docker image (installs and tests rez)
         run: |
           ${docker_image} = "nerdvegas/rez-win-py-${{ matrix.python-version }}"
-
-          # show tagged image name to help debugging
-          ${docker_image_tagged} = $( `
-            docker inspect ${docker_image} --format "{{.RepoTags}}" `
-          )
-          Write-Output "Running DockerHub image ${docker_image_tagged}..."
-
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}:latest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,8 +11,7 @@ name: windows
 on:
   pull_request:
     paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
+      - '.github/**'
       - 'src/rez/utils/_version.py'
       - 'wiki/**'
       - 'metrics/**'

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -48,8 +48,8 @@ jobs:
         run: |
           ${docker_image} = "nerdvegas/rez-win-py-${{ matrix.python-version }}"
 
-          echo "Pulling latest DockerHub image ${docker_image}..."
+          Write-Output "Pulling latest DockerHub image ${docker_image}..."
           docker pull ${docker_image}
 
-          echo "Running DockerHub image ${docker_image}..."
+          Write-Output "Running DockerHub image ${docker_image}..."
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -49,3 +49,4 @@ jobs:
         run: |
           ${docker_image} = "nerdvegas/rez-win-py-${{ matrix.python-version }}"
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}:latest
+

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -49,4 +49,3 @@ jobs:
 
           Write-Output "Running DockerHub image ${docker_image}..."
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}
-

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -10,20 +10,17 @@ name: windows
 
 on:
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/windows.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
   push:
-    paths-ignore:
-      - '.github/docker/**'
-      - '.github/workflows/windows-docker-image.yaml'
-      - 'src/rez/utils/_version.py'
-      - 'wiki/**'
-      - 'metrics/**'
-      - '**.md'
+    paths:
+      - 'src/**'
+      - '.github/workflows/windows.yaml'
+      - '!src/rez/utils/_version.py'
+      - '!**.md'
 
 jobs:
   main:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -49,4 +49,3 @@ jobs:
         run: |
           ${docker_image} = "nerdvegas/rez-win-py-${{ matrix.python-version }}"
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}:latest
-

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -5,10 +5,6 @@
 # Requires username/repository to match the github repository.
 # For example: nerdvegas/rez -> User/Repository: nerdvegas
 #
-# Uses image tagged as **latest** commit revision of any file within:
-#  .github/docker/windows/**
-#  .github/workflows/windows-docker-image.yaml
-#
 
 name: windows
 
@@ -33,13 +29,8 @@ on:
 jobs:
   main:
     runs-on: windows-2019
-    env:
-      # DockerHub base image name. May switch to GitHub Docker Packages
-      # in the future. See GitHub Issue #789 and PR #830
-      BASE_IMAGE_NAME: "nerdvegas/rez-win-py:${{ matrix.python-version }}"
 
     strategy:
-
       matrix:
         # Needs to match python version of images (see windows-docker-image.yaml)
         python-version:
@@ -55,8 +46,10 @@ jobs:
 
       - name: Run Docker image (installs and tests rez)
         run: |
-          ${Env:LAST_DOCKER_REVISION} = $( git log -n 1 --author-date-order --pretty=format:%H -- .\.github\docker\rez-win-py\ .\.github\docker\rez-win-base\ .\.github\workflows\windows-docker-image.yaml ).SubString(0, 8)
-          ${docker_image} = "${{ Env.BASE_IMAGE_NAME }}-${Env:LAST_DOCKER_REVISION}"
+          ${docker_image} = "nerdvegas/rez-win-py-${{ matrix.python-version }}"
 
-          Write-Output "Running DockerHub ${docker_image}..."
+          Write-Output "Pulling latest DockerHub image ${docker_image}..."
+          docker pull ${docker_image}
+
+          Write-Output "Running DockerHub image ${docker_image}..."
           docker run --mount type=bind,src=$pwd,dst=C:\checkout,readonly ${docker_image}


### PR DESCRIPTION
Fixes #1181 

This PR introduces a bunch of changes to improve the situation wrt windows CI tests. Specifically:

* Previously, windows.yaml would use the tagged image generated by windows-docker-image.yaml (where tag is the latest commit hash of relevant workflow/docker files). This breaks when a change is made that triggers both an image rebuild, _and_ the windows workflow, since the new image isn't built yet. Now, windows.yaml just uses latest image instead.
* Updated windows-docker-image.yaml to generate artifacts that contain docker inspect info, for the images generated. This is for debugging purposes
* Updated windows.yaml to print the specific tag of the image it's using, to be able to verify that it is actually using the latest image as expected
* reworked path/path-ignore filters across all workflows - now uses combined include/exclude form to better target files to trigger workflow runs from
* fixed bug causing choco-cleanup to fail. It's reporting deletion of ~300Mb of files now, so images should be considerably smaller
* general cleanup of workflow run code to be cleaner and easier to follow
* avoid using env-vars when standard pwsh var will do
* run pytest-based selftest on windows to match other os workflows
* drop use of DOCKER_CLI_EXPERIMENTAL feature, not supposed to be used in production
* moved py version into the image name, required in order for windows.yaml to be able to pull latest image
