### PR TITLE
[Wiki] Package Def Guide: fix preprocessing examples

### DIFF
--- a/wiki/pages/Package-Definition-Guide.md
+++ b/wiki/pages/Package-Definition-Guide.md
@@ -405,7 +405,7 @@ this with a global preprocessing function like this:
         except KeyError:
             pass
 
-        data["config"] = data["config"] or {}
+        data["config"] = data.get("config", {})
         data["config"]["release_packages_path"] = "/software/packages/external"
 
 The *"with scope(...)"* statement is just a fancy way of defining a dict, so you can do the same

--- a/wiki/pages/Package-Definition-Guide.md
+++ b/wiki/pages/Package-Definition-Guide.md
@@ -361,7 +361,7 @@ preprocessing function, see the
 
 Consider the following preprocessing function, defined in a *package.py*:
 
-    def preprocess(package, data):
+    def preprocess(this, data):
         from rez.package_py_utils import InvalidPackageError
         import re
 
@@ -395,7 +395,7 @@ Let's say we have a scenario where we want to install third party packages to a 
 path, and that we set the arbitrary attribute *external* to True for these packages. We could do
 this with a global preprocessing function like this:
 
-    def preprocess(package, data):
+    def preprocess(this, data):
         if not data.get("external"):
             return
 


### PR DESCRIPTION
Hello! 🙂 
This is my first tiny contribution to this super cool project. I suggest this Pull Request since I noticed an error in the documentation, on the `Package Definition Guide` page. 

The first correction is based on what the code seems to do [on this line](https://github.com/nerdvegas/rez/blob/d392c65bf63b4bca8106f938cec49144ba54e770/src/rez/developer_package.py#L282) to avoid this error `TypeError: preprocess() got an unexpected keyword argument 'this'`.
The second one is just to avoid a `KeyError` raise.