### PR TITLE
Explicit fail when python executable is not found

### DIFF
--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -202,6 +202,9 @@ def find_pip_from_context(python_version, pip_version=None):
 
     py_exe = find_python_in_context(context)
 
+    if not py_exe:
+        raise RezSystemError("Failed to locate Python executable from context {}".format(context))
+    
     proc = context.execute_command(
         # -E and -s are used to isolate the environment as much as possible.
         # See python --help for more details. We absolutely don't want to get

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -203,8 +203,9 @@ def find_pip_from_context(python_version, pip_version=None):
     py_exe = find_python_in_context(context)
 
     if not py_exe:
-        raise RezSystemError("Failed to locate Python executable from context {}".format(context))
-    
+        print_debug("Failed to locate python executable from context")
+        return None, None, context
+
     proc = context.execute_command(
         # -E and -s are used to isolate the environment as much as possible.
         # See python --help for more details. We absolutely don't want to get

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -203,7 +203,6 @@ def find_pip_from_context(python_version, pip_version=None):
     py_exe = find_python_in_context(context)
 
     if not py_exe:
-        print_debug("Failed to locate python executable from context")
         return None, None, context
 
     proc = context.execute_command(


### PR DESCRIPTION
# Problem

We have found ourselves in a situation where during a call to `find_pip_from_context`,  `find_python_in_context(context)` returns `None`, resulting in the creation and execution of an invalid command (with `None` provided as an executable path). This ends up breaking downstream in `subprocess` with an obscure message.

# Solution

Raise an explicit error if the executable is not located, before we try to run it.