### PR TITLE
Another way to test packages in dev stage and make sure path set/append/prepend to PYTHONPATH is normalized.

### DIFF
--- a/src/rez/cli/env.py
+++ b/src/rez/cli/env.py
@@ -49,6 +49,10 @@ def setup_parser(parser, completions=False):
         "--paths", type=str, default=None,
         help="set package search path (use %r separator)" % os.pathsep)
     parser.add_argument(
+        "-d", "--dev-paths", type=str, default=None,
+        help="search packages from these dev paths if found, otherwise from formal search path,"
+             "normally for testing purpose, non-version packages (use %r separator)." % os.pathsep)
+    parser.add_argument(
         "-t", "--time", type=str,
         help="ignore packages released after the given time. Supported formats "
         "are: epoch time (eg 1393014494), or relative time (eg -10s, -5m, "
@@ -156,6 +160,13 @@ def command(opts, parser, extra_arg_groups=None):
     context = None
     request = opts.PKG
     t = get_epoch_time_from_str(opts.time) if opts.time else None
+
+    if opts.dev_paths:
+        for path in opts.dev_paths.split(os.pathsep):
+            path = os.path.abspath(path)
+            for idx, pkg in enumerate(request):
+                if pkg in os.listdir(path):
+                    request[idx] = '{}@{}'.format(pkg, os.path.join(path, pkg))
 
     if opts.paths is None:
         pkg_paths = (config.nonlocal_packages_path

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -620,7 +620,7 @@ class Python(ActionInterpreter):
         if self.update_session:
             if key == 'PYTHONPATH':
                 value = self.escape_string(value)
-                sys.path = value.split(os.pathsep)
+                sys.path = [os.path.normpath(v) for v in value.split(os.pathsep)]
 
     def unsetenv(self, key):
         pass
@@ -632,13 +632,13 @@ class Python(ActionInterpreter):
         if self.update_session:
             if key == 'PYTHONPATH':
                 value = self.escape_string(value)
-                sys.path.insert(0, value)
+                sys.path.insert(0, os.path.normpath(value))
 
     def appendenv(self, key, value):
         if self.update_session:
             if key == 'PYTHONPATH':
                 value = self.escape_string(value)
-                sys.path.append(value)
+                sys.path.append(os.path.normpath(value))
 
     def info(self, value):
         if not self.passive:

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -464,14 +464,20 @@ class _PackageVariantList(_Common):
         self.package_name = package_name
         self.solver = solver
 
+        self.entries = []
+
+        request_package = solver.request_list.get(package_name)
+        if request_package and request_package.request_path:
+            # it seems DeveloperPackage can't be used in this way
+            # self.entries.append([get_developer_package(request_package.request_path), False])
+            paths = [os.path.dirname(os.path.abspath(request_package.request_path))]
+        else:
+            paths = self.solver.package_paths
         # note: we do not apply package filters here, because doing so might
         # cause package loads (eg, timestamp rules). We only apply filters
         # during an intersection, which minimises the amount of filtering.
         #
-        self.entries = []
-
-        for package in iter_packages(self.package_name,
-                                     paths=self.solver.package_paths):
+        for package in iter_packages(self.package_name, paths=paths):
             package.set_context(solver.context)
             self.entries.append([package, False])
 
@@ -497,7 +503,7 @@ class _PackageVariantList(_Common):
             if value is None:
                 continue  # package was blocked by package filters
 
-            if package.version not in range_:
+            if not range_.is_a_folder() and package.version not in range_:
                 continue
 
             if isinstance(value, list):

--- a/src/rez/vendor/version/requirement.py
+++ b/src/rez/vendor/version/requirement.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Rez Project
-
+import os.path
 
 from rez.vendor.version.version import Version, VersionRange
 from rez.vendor.version.util import _Common
@@ -132,6 +132,7 @@ class Requirement(_Common):
         self.negate_ = False
         self.conflict_ = False
         self._str = None
+        self._request_path = None
         self.sep_ = '-'
         if s is None:
             return
@@ -152,6 +153,8 @@ class Requirement(_Common):
             if req_str[0] in ('-', '@', '#'):
                 self.sep_ = req_str[0]
                 req_str = req_str[1:]
+                if os.path.exists(os.path.abspath(req_str)):
+                    self._request_path = req_str
 
             self.range_ = VersionRange(
                 req_str, invalid_bound_error=invalid_bound_error)
@@ -183,6 +186,10 @@ class Requirement(_Common):
     def name(self):
         """Name of the required object."""
         return self.name_
+
+    @property
+    def request_path(self):
+        return self._request_path
 
     @property
     def range(self):

--- a/src/rez/vendor/version/version.py
+++ b/src/rez/vendor/version/version.py
@@ -28,6 +28,7 @@ from bisect import bisect_left
 import copy
 import string
 import re
+import os
 
 
 re_token = re.compile(r"[a-zA-Z0-9_]+")
@@ -859,8 +860,14 @@ class VersionRange(_Comparable):
                 impossible range is given, such as '3+<2'.
         """
         self._str = None
+        self._is_a_folder = False
         self.bounds = []  # note: kept in ascending order
         if range_str is None:
+            return
+
+        if os.path.isdir(range_str):
+            self._is_a_folder = True
+            self._str = range_str
             return
 
         try:
@@ -883,6 +890,9 @@ class VersionRange(_Comparable):
         """Returns True if this is the "any" range, ie the empty string range
         that contains all versions."""
         return (len(self.bounds) == 1) and (self.bounds[0] == _Bound.any)
+
+    def is_a_folder(self):
+        return self._is_a_folder
 
     def lower_bounded(self):
         """Returns True if the range has a lower bound (that is not the empty


### PR DESCRIPTION
Sorry I made 2 commits together here:
### Make sure path set/append/prepend to PYTHONPATH is normalized
87ee4e62e6172c3dafe615c8947be3cb1286cde0
PYTHONPATH in a package mostly set like this:
`env.PYTHONPATH.append('{root}/python')`
In windows sys,.path returns e.g.: c:\path\to\root/python, although it is ok, but prefer it is normalized.

### New Feat: Another way to test packages in dev stage
5f94b9c08eaaaf84ac5fec756bf99f3dc342fe4b
Let's say we have a package `helloworld` in d:\dev\helloworld(a pure python package, and no version specified) want to test, but don't want to move it to any package repository or package filters, instead call this package like this:
`rez-env helloworld pkg1 pkg2 ... -d d:\dev`, helloworld will be resolved to D:\dev\helloworld, but pkg1 and pkg2 resolved to a repository path in rez config. or if is also in D:\dev folder.
```
helloworld                d:\dev\helloworld
pkg1-3.3                   c:\users\frank\packages\pkg1\3.3\                                           (local)
pkg2-1.0.0                c:\users\frank\packages\pkg2\1.0.0                                          (local)
```