### PR TITLE
Add --favor-paths rez-env flag

### DIFF
--- a/src/rez/cli/env.py
+++ b/src/rez/cli/env.py
@@ -172,7 +172,7 @@ def setup_parser(parser, completions=False):
 
 
 def command(opts, parser, extra_arg_groups=None):
-    from rez.package_order import FavorPathsOrder
+    from rez.package_order import FavorPathsOrder, PackageOrderList
     from rez.resolved_context import ResolvedContext
     from rez.resolver import ResolverStatus
     from rez.package_filter import PackageFilterList, Rule
@@ -235,10 +235,10 @@ def command(opts, parser, extra_arg_groups=None):
             rule = Rule.parse_rule(rule_str)
             package_filter.add_inclusion(rule)
 
-        package_orderers = []
+        package_orderers = list(PackageOrderList.singleton)
 
         if opts.favor_paths:
-            package_orderers.append(FavorPathsOrder(opts.favor_paths))
+            package_orderers.insert(0, FavorPathsOrder(opts.favor_paths))
 
         # perform the resolve
         context = ResolvedContext(

--- a/src/rez/data/tests/solver/favor_paths_first/pyfoo/2.0.0/package.py
+++ b/src/rez/data/tests/solver/favor_paths_first/pyfoo/2.0.0/package.py
@@ -1,0 +1,3 @@
+name = "pyfoo"
+
+version = "2.0.0"

--- a/src/rez/data/tests/solver/favor_paths_second/pyfoo/1.0.0/package.py
+++ b/src/rez/data/tests/solver/favor_paths_second/pyfoo/1.0.0/package.py
@@ -1,0 +1,3 @@
+name = "pyfoo"
+
+version = "1.0.0"

--- a/src/rez/data/tests/solver/favor_paths_second/pyfoo/1.1.0/package.py
+++ b/src/rez/data/tests/solver/favor_paths_second/pyfoo/1.1.0/package.py
@@ -1,0 +1,3 @@
+name = "pyfoo"
+
+version = "1.1.0"

--- a/src/rez/data/tests/solver/favor_paths_second/pyfoo/1.1.1/package.py
+++ b/src/rez/data/tests/solver/favor_paths_second/pyfoo/1.1.1/package.py
@@ -1,0 +1,3 @@
+name = "pyfoo"
+
+version = "1.1.1"

--- a/src/rez/data/tests/solver/favor_paths_third/pyfoo/3.0.0/package.py
+++ b/src/rez/data/tests/solver/favor_paths_third/pyfoo/3.0.0/package.py
@@ -1,0 +1,3 @@
+name = "pyfoo"
+
+version = "3.0.0"

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -85,7 +85,7 @@ class FavorPathsOrder(PackageOrder):
 
         from rez.resolved_context import ResolvedContext
 
-        orderer = FavorPathsOrder(["/some/packages/path/"])
+        orderer = FavorPathsOrder(["/some/packages/path"])
         context = ResolvedContext(
             "foo",
             package_orderers=[orderer],
@@ -96,14 +96,14 @@ class FavorPathsOrder(PackageOrder):
     The resolved package will be **foo version 2.0.0**, from
     ``/some/packages/path``. Normally, foo version 3.0.0 would be chosen from
     ``/another/root/path`` but, because the orderer is tracking
-    "/some/packages/path/", foo version 2.0.0 is used instead.
+    "/some/packages/path", foo version 2.0.0 is used instead.
 
     .. code-block:: python
 
-        orderer = FavorPathsOrder(["/some/packages/path/", "/extra/place/here"])
+        orderer = FavorPathsOrder(["/some/packages/path", "/extra/place/here"])
 
     An orderer with multiple paths like the one above means "use the packages
-    found from ``/some/packages/path/``. If the package isn't found there, try
+    found from ``/some/packages/path``. If the package isn't found there, try
     ``/extra/place/here`` next". Once all paths are exhausted, we check
     packages_path like normal.
 

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -2,6 +2,7 @@
 # Copyright Contributors to the Rez Project
 
 
+import collections
 from inspect import isclass
 from hashlib import sha1
 
@@ -57,6 +58,133 @@ class PackageOrder(object):
 
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, str(self))
+
+
+class FavorPathsOrder(PackageOrder):
+    """Order installed Rez packages depending on where they exist on-disk.
+
+    If you have a package installed to two or more directories:
+
+    (package name: foo)
+
+    ::
+
+        /some/packages/path/
+            foo/
+                2.0.0/
+        /another/root/path/
+            foo/
+                1.0.0/
+                2.0.1/
+                2.1.0/
+                3.0.0/
+
+    and then you create an orderer like so:
+
+    .. code-block:: python
+
+        from rez.resolved_context import ResolvedContext
+
+        orderer = FavorPathsOrder(["/some/packages/path/"])
+        context = ResolvedContext(
+            "foo",
+            package_orderers=[orderer],
+            package_paths=["/another/root/path", "/some/packages/path"],
+        )
+        str(context.get_resolved_package("foo").version)  # "2.0.0"
+
+    The resolved package will be **foo version 2.0.0**, from
+    ``/some/packages/path``. Normally, foo version 3.0.0 would be chosen from
+    ``/another/root/path`` but, because the orderer is tracking
+    "/some/packages/path/", foo version 2.0.0 is used instead.
+
+    .. code-block:: python
+
+        orderer = FavorPathsOrder(["/some/packages/path/", "/extra/place/here"])
+
+    An orderer with multiple paths like the one above means "use the packages
+    found from ``/some/packages/path/``. If the package isn't found there, try
+    ``/extra/place/here`` next". Once all paths are exhausted, we check
+    packages_path like normal.
+
+    """
+
+    name = "favor_paths"
+    _paths_key = "paths"
+
+    def __init__(self, paths):
+        """Keep track of some root directories containing Rez packages.
+
+        Args:
+            paths (list[str]):
+                Each path, usually an installed path like ``"~/packages"``, to
+                reference while ordering packages.
+
+        """
+        super(FavorPathsOrder, self).__init__()
+
+        self._paths = paths
+
+    @classmethod
+    def from_pod(cls, data):
+        """Create a package from data.
+
+        See Also:
+            :meth:`FavorPathsOrder.to_pod`
+
+        Args:
+            data (dict[str, list[str]]):
+                The serialized content to make an instance from. e.g.
+                ``{"paths": ["~/packages"]}``.
+
+        Returns:
+            FavorPathsOrder: The generated instance.
+
+        """
+        return cls(data[cls._paths_key])
+
+    def reorder(self, iterable, key=None):
+        """Sort ``iterable`` depending on if the come from known paths.
+
+        Args:
+            iterable (list[Package] or list[object]):
+                If ``key`` is not provided, ``iterable`` must be a list of
+                packages.  If ``key`` is provided, it will be used to "find"
+                the package within each enty from ``iterable``.
+            key (callable[object] -> Package, optional):
+                A function which queries each entry in ``iterable`` for a Rez package.
+
+        Returns:
+            list[Package] or list[object]:
+                The sorted packages (if ``key`` is None) or the sorted objects.
+
+        """
+        key = key or (lambda package: package)
+        buckets = collections.OrderedDict([(path, []) for path in self._paths])
+        unordered = []
+
+        for entry in iterable:
+            package = key(entry)
+            location = package.resource.location
+
+            if location in buckets:
+                buckets[location].append(entry)
+            else:
+                unordered.append(entry)
+
+        return [entry for entries in buckets.values() for entry in entries] + unordered
+
+    def to_pod(self):
+        """dict[str, list[str]]: A JSON-friendly representation of this instance."""
+        return {self._paths_key: self._paths}
+
+    def __str__(self):
+        """str: The paths which make up this instance."""
+        return str(self._paths)
+
+    def __eq__(self, other):
+        """bool: Check if ``other`` matches this instance."""
+        return type(self) == type(other) and self._paths == other._paths
 
 
 class NullPackageOrder(PackageOrder):

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -159,6 +159,10 @@ class FavorPathsOrder(PackageOrder):
                 The sorted packages (if ``key`` is None) or the sorted objects.
 
         """
+
+        def _sort(key, entries):
+            return sorted(entries, key=lambda entry: key(entry).version, reverse=True)
+
         key = key or (lambda package: package)
         buckets = collections.OrderedDict([(path, []) for path in self._paths])
         unordered = []
@@ -172,7 +176,14 @@ class FavorPathsOrder(PackageOrder):
             else:
                 unordered.append(entry)
 
-        return [entry for entries in buckets.values() for entry in entries] + unordered
+        known_paths = [
+            entry
+            for entries in buckets.values()
+            for entry in _sort(key, entries)
+        ]
+        all_others = _sort(key, unordered)
+
+        return known_paths + all_others
 
     def to_pod(self):
         """dict[str, list[str]]: A JSON-friendly representation of this instance."""

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -8,7 +8,7 @@ Test cases for package_order.py (package ordering)
 import json
 
 from rez.config import config
-from rez.package_order import NullPackageOrder, PackageOrder, PerFamilyOrder, VersionSplitPackageOrder, \
+from rez.package_order import FavorPathsOrder, NullPackageOrder, PackageOrder, PerFamilyOrder, VersionSplitPackageOrder, \
     TimestampPackageOrder, SortedOrder, PackageOrderList, from_pod
 from rez.packages import iter_packages
 from rez.tests.util import TestBase, TempdirMixin
@@ -71,6 +71,90 @@ class TestAbstractPackageOrder(TestBase):
         """Validate __eq__ is not implemented"""
         with self.assertRaises(NotImplementedError):
             PackageOrder() == PackageOrder()
+
+
+class TestFavorPathsOrder(_BaseTestPackagesOrder):
+    """Make sure :class:`.FavorPathsOrder` works as expected."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Add extra packages_path for tests in this class."""
+        super(TestFavorPathsOrder, cls).setUpClass()
+
+        cls.first_packages_path = cls.data_path("solver", "favor_paths_first")
+        cls.second_packages_path = cls.data_path("solver", "favor_paths_second")
+        cls.third_packages_path = cls.data_path("solver", "favor_paths_third")
+
+        cls.settings = {
+            "packages_path": [
+                cls.first_packages_path,
+                cls.second_packages_path,
+                cls.third_packages_path,
+            ],
+        }
+
+    def test_comparison(self):
+        """Validate we can compare :class:`.FavorPathsOrder` together."""
+        one = FavorPathsOrder([self.solver_packages_path])
+        two = FavorPathsOrder([self.solver_packages_path])
+        three = FavorPathsOrder([self.py_packages_path])
+        four = FavorPathsOrder([])
+        five = FavorPathsOrder([])
+
+        self.assertEqual(one, two)
+        self.assertEqual(four, five)
+        self.assertEqual(three, three)
+        self.assertNotEqual(two, three)
+        self.assertNotEqual(one, three)
+        self.assertNotEqual(one, four)
+        self.assertNotEqual(one, five)
+        self.assertNotEqual(two, four)
+        self.assertNotEqual(three, four)
+
+    def test_multi_paths(self):
+        """Prefer favored paths in the exact, preferred order."""
+        self._test_reorder(
+            FavorPathsOrder(
+                [
+                    self.second_packages_path,
+                    self.third_packages_path,
+                ],
+            ),
+            "pyfoo",
+            ["1.1.1", "1.1.0", "1.0.0", "3.0.0", "2.0.0"],
+        )
+
+    def test_newer_package(self):
+        """Prefer favored paths, even if packages in non-favored are newer."""
+        self._test_reorder(
+            FavorPathsOrder([self.second_packages_path]),
+            "pyfoo",
+            ["1.1.1", "1.1.0", "1.0.0", "3.0.0", "2.0.0"],
+        )
+
+    def test_non_existent(self):
+        """Use packages_path if the favored paths don't exist or don't have packages."""
+        self._test_reorder(
+            FavorPathsOrder(["/does/not/exist"]),
+            "pyfoo",
+            ["3.0.0", "2.0.0", "1.1.1", "1.1.0", "1.0.0"],
+        )
+
+    def test_pod_empty(self):
+        """Ensure :meth:`.FavorPathsOrder.to_pod` works."""
+        self._test_pod(FavorPathsOrder([]))
+
+    def test_pod_normal(self):
+        """Ensure :meth:`.FavorPathsOrder.to_pod` works."""
+        self._test_pod(FavorPathsOrder([self.py_packages_path]))
+
+    def test_repr(self):
+        """Validate we can represent a :class:`.FavorPathsOrder` as a string."""
+        orderer = FavorPathsOrder([self.solver_packages_path])
+        self.assertEqual(
+            "FavorPathsOrder([{path!r}])".format(path=self.solver_packages_path),
+            repr(orderer),
+        )
 
 
 class TestNullPackageOrder(_BaseTestPackagesOrder):

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -111,6 +111,25 @@ class TestFavorPathsOrder(_BaseTestPackagesOrder):
         self.assertNotEqual(two, four)
         self.assertNotEqual(three, four)
 
+    def test_conflicting_versions(self):
+        """Use the favored path if 2 of the same version are found."""
+        package_name = "pyfoo"
+        orderer = FavorPathsOrder([self.second_packages_path])
+        descending = sorted(
+            iter_packages(package_name),
+            key=lambda x: x.version,
+            reverse=True,
+        )
+        package = orderer.reorder(descending)[0]
+
+        expected_version = "2.0.0"
+        self.assertEqual(
+            self.data_path("solver", "favor_paths_second"),
+            package.resource.location,
+        )
+        self.assertEqual(package.name, package_name)
+        self.assertEqual(str(package.version), expected_version)
+
     def test_multi_paths(self):
         """Prefer favored paths in the exact, preferred order."""
         self._test_reorder(

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -111,25 +111,6 @@ class TestFavorPathsOrder(_BaseTestPackagesOrder):
         self.assertNotEqual(two, four)
         self.assertNotEqual(three, four)
 
-    def test_conflicting_versions(self):
-        """Use the favored path if 2 of the same version are found."""
-        package_name = "pyfoo"
-        orderer = FavorPathsOrder([self.second_packages_path])
-        descending = sorted(
-            iter_packages(package_name),
-            key=lambda x: x.version,
-            reverse=True,
-        )
-        package = orderer.reorder(descending)[0]
-
-        expected_version = "2.0.0"
-        self.assertEqual(
-            self.data_path("solver", "favor_paths_second"),
-            package.resource.location,
-        )
-        self.assertEqual(package.name, package_name)
-        self.assertEqual(str(package.version), expected_version)
-
     def test_multi_paths(self):
         """Prefer favored paths in the exact, preferred order."""
         self._test_reorder(


### PR DESCRIPTION
Closes: https://github.com/nerdvegas/rez/issues/1263

## Added rez-env cli option, `--favor-paths`
- If not provided, does nothing
- If provided and 1+ path specified, `--favor-paths /foo:/bar`
	- All packages found within /foo are preferred over packages found in /bar
	- All packages found in /bar are preferred over packages found within packages_path
- If provided but no paths specified, `--favor-paths`, `[config.local_packages_path]` is used. All other logic applies.
- In all cases, the usual package path rules still apply. e.g. any path provided in --favor-paths must be in `packages_path` or it won't be used during ordering
 
## Miscellaneous
Introduced `SplitPaths` to show an alternative way we can be parsing our arguments. If you like that approach, I can add it to `--paths` as well, which is currently being described in `setup_parser` but then parsed again, in env.py `command`.

## What's not in this PR, currently
> And now I recall - the problem we ran into when discussing this ages ago, is that orderers can't be stacked. So that could interfere with orderers already in place.

In the original ticket thread, https://github.com/nerdvegas/rez/issues/1263#issuecomment-1086347517, @nerdvegas mentions that we may need a kind of "stacked orderer". However I didn't encounter any limitations in practice. `ResolvedContext` takes a list of package orderers so it should be fine. However please let me know if not and I'll make necessary adjustments.