### PR TITLE
Force change permissions before deleting directory

### DIFF
--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -208,13 +208,11 @@ def forceful_rmtree(path):
                 path = windows_long_path(path)
 
             parent_path = os.path.dirname(path)
-            if not os.access(parent_path, os.W_OK):
-                st = os.stat(parent_path)
-                os.chmod(parent_path, st.st_mode | stat.S_IWUSR)
+            st = os.stat(parent_path)
+            os.chmod(parent_path, st.st_mode | stat.S_IWUSR)
 
-            if not os.access(path, os.W_OK):
-                st = os.stat(path)
-                os.chmod(path, st.st_mode | stat.S_IWUSR)
+            st = os.stat(path)
+            os.chmod(path, st.st_mode | stat.S_IWUSR)
 
         except:
             # avoid confusion by ensuring original exception is reraised


### PR DESCRIPTION
Fixes #1493

This will skip the permission checks before deleting a directory since they don't seem to work on Windows.
Also, if we're deleting a folder the permissions aren't really that important.