### PR TITLE
Fix rez-pkg-cache to preserve symlinks instead of following them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- start-here-sphinx-start-after -->
 
+## Unreleased
+
+### Fixes
+- Fix `rez-pkg-cache` to preserve symlinks instead of following them [\#2047](https://github.com/AcademySoftwareFoundation/rez/issues/2047)
+
 ## v3.3.0 (2025-10-17)
 [Source](https://github.com/AcademySoftwareFoundation/rez/tree/3.3.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/v3.2.1...3.3.0)
 

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -405,7 +405,7 @@ class PackageCache(object):
         th.start()
 
         try:
-            shutil.copytree(variant_root, rootpath)
+            shutil.copytree(variant_root, rootpath, symlinks=True)
         finally:
             still_copying = False
 


### PR DESCRIPTION
## Summary
This PR fixes issue #2047 where `rez-pkg-cache` follows symlinks during package caching, which can cause failures when symlink targets are inaccessible.

## Problem
The `PackageCache.add_variant()` method uses `shutil.copytree()` without the `symlinks` parameter, which defaults to following symlinks. This causes failures when:
- Symlinks point to inaccessible locations
- Symlink targets don't exist
- Permission issues with symlink targets

## Solution
Added `symlinks=True` parameter to `shutil.copytree()` call in `package_cache.py` line 408. This preserves symlinks instead of following them, matching the default behavior of `rez-cp`.

## Changes
- Modified `src/rez/package_cache.py`: Added `symlinks=True` to `shutil.copytree()` call
- Updated `CHANGELOG.md`: Added entry for this fix

## Testing
The fix aligns with how `rez-cp` handles symlinks (which has a `--follow-symlinks` flag that defaults to False). The `replacing_copy()` function in `filesystem.py` already uses this pattern correctly.

Fixes #2047
