### PR TITLE
Fix resetenv() by just using setenv()

### DIFF
--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -332,7 +332,7 @@ class ActionManager(object):
             key, value = expanded_key, expanded_value
         else:
             key, value = unexpanded_key, unexpanded_value
-        self.interpreter.resetenv(key, value)
+        self.interpreter.resetenv(key, value, friends)
 
     def _pendenv(self, key, value, action, interpfunc, addfunc):
         unexpanded_key, expanded_key = self._key(key)

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -512,7 +512,7 @@ class UnixShell(Shell):
         return p
 
     def resetenv(self, key, value, friends=None):
-        self._addline(self.setenv(key, value))
+        self.setenv(key, value)
 
     def info(self, value):
         for line in value.split('\n'):

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -277,7 +277,7 @@ class PowerShellBase(Shell):
         )
 
     def resetenv(self, key, value, friends=None):
-        self._addline(self.setenv(key, value))
+        self.setenv(key, value)
 
     def alias(self, key, value):
         value = EscapedString.disallow(value)

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -257,7 +257,7 @@ class CMD(Shell):
         self._addline("set %s=" % key)
 
     def resetenv(self, key, value, friends=None):
-        self._addline(self.setenv(key, value))
+        self.setenv(key, value)
 
     def alias(self, key, value):
         # find doskey, falling back to system paths if not in $PATH. Fall back


### PR DESCRIPTION
While trying to document `resetenv()` (which had a TODO in the docs) I noticed that Rez would always generate a python traceback when `resetenv()` was called. 

The reason for this turns out to be that it is creating a "command" that is None because it is adding a line that is the return value of setenv. But that is always None. In any case, it doesn't do what `rezconfig.py` suggests it might. And it has a "friends" parameter that isn't used and whose purpose I couldn't guess at.

This PR "fixes" that by just having calls to `resetenv()` defer to `setenv()` since that is all that would currently happen even if it worked. As an aside, I think that `resetenv` should either be removed, or implemented as `rezconfig.py` implies.