### PR TITLE
Ensure additional key versions are prioritised over number of additional keys in version_priority solving

### DIFF
--- a/src/rez/data/tests/solver/packages/missing_variant_requires/1/package.py
+++ b/src/rez/data/tests/solver/packages/missing_variant_requires/1/package.py
@@ -5,6 +5,6 @@ def commands():
     pass
 
 variants = [
-    ["noexist"],
-    ["nada"]
+    ["nada"],
+    ["noexist"]
 ]

--- a/src/rez/data/tests/solver/packages/test_prio_both_base/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_both_base/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_both_base"
+version = "1.0"
+
+variants = [["python-2.6.0"], ["python-2.7.0"]]

--- a/src/rez/data/tests/solver/packages/test_prio_both_base_reverse/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_both_base_reverse/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_both_base_reverse"
+version = "1.0"
+
+variants = [["python-2.7.0"], ["python-2.6.0"]]

--- a/src/rez/data/tests/solver/packages/test_prio_both_extra_package/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_both_extra_package/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_both_extra_package"
+version = "1.0"
+
+variants = [["python-2.6.0", "nada"], ["python-2.7.0", "nada"]]

--- a/src/rez/data/tests/solver/packages/test_prio_both_extra_package_reverse/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_both_extra_package_reverse/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_both_extra_package_reverse"
+version = "1.0"
+
+variants = [["python-2.7.0", "nada"], ["python-2.6.0", "nada"]]

--- a/src/rez/data/tests/solver/packages/test_prio_both_versions_equal_extra_package/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_both_versions_equal_extra_package/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_both_versions_equal_extra_package"
+version = "1.0"
+
+variants = [["python-2.6.0", "nada"], ["python-2.6.0"]]

--- a/src/rez/data/tests/solver/packages/test_prio_higher_extra_package/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_higher_extra_package/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_higher_extra_package"
+version = "1.0"
+
+variants = [["python-2.6.0"], ["python-2.7.0", "nada"]]

--- a/src/rez/data/tests/solver/packages/test_prio_higher_extra_package_reverse/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_higher_extra_package_reverse/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_higher_extra_package_reverse"
+version = "1.0"
+
+variants = [["python-2.7.0", "nada"], ["python-2.6.0"]]

--- a/src/rez/data/tests/solver/packages/test_prio_lower_extra_package/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_lower_extra_package/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_lower_extra_package"
+version = "1.0"
+
+variants = [["python-2.6.0", "nada"], ["python-2.7.0"]]

--- a/src/rez/data/tests/solver/packages/test_prio_lower_extra_package_reverse/1.0/package.py
+++ b/src/rez/data/tests/solver/packages/test_prio_lower_extra_package_reverse/1.0/package.py
@@ -1,0 +1,4 @@
+name = "test_prio_lower_extra_package_reverse"
+version = "1.0"
+
+variants = [["python-2.7.0"], ["python-2.6.0", "nada"]]

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -442,8 +442,8 @@ class _PackageEntry(object):
 
             if (VariantSelectMode[config.variant_select_mode] == VariantSelectMode.version_priority):
                 k = (requested_key,
-                     -len(additional_key),
                      additional_key,
+                     -len(additional_key),
                      variant.index)
             else:  # VariantSelectMode.intersection_priority
                 k = (len(requested_key),

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -443,7 +443,6 @@ class _PackageEntry(object):
             if (VariantSelectMode[config.variant_select_mode] == VariantSelectMode.version_priority):
                 k = (requested_key,
                      additional_key,
-                     -len(additional_key),
                      variant.index)
             else:  # VariantSelectMode.intersection_priority
                 k = (len(requested_key),

--- a/src/rez/tests/test_completion.py
+++ b/src/rez/tests/test_completion.py
@@ -53,7 +53,8 @@ class TestCompletion(TestBase):
                  "pyodd", "pyson", "pysplit", "python", "pyvariants",
                  "test_variant_split_start", "test_variant_split_mid1",
                  "test_variant_split_mid2", "test_variant_split_end", "missing_variant_requires",
-                 "test_weakly_reference_requires", "test_weakly_reference_variant"])
+                 "test_weakly_reference_requires", "test_weakly_reference_variant", 
+                 "test_prio_both_base", "test_prio_both_extra_package", "test_prio_lower_extra_package", "test_prio_higher_extra_package", "test_prio_both_base_reverse", "test_prio_both_extra_package_reverse", "test_prio_lower_extra_package_reverse", "test_prio_higher_extra_package_reverse"])
         _eq("py", ["pybah", "pydad", "pyfoo", "pymum", "pyodd", "pyson",
             "pysplit", "python", "pyvariants"])
         _eq("pys", ["pyson", "pysplit"])

--- a/src/rez/tests/test_completion.py
+++ b/src/rez/tests/test_completion.py
@@ -54,7 +54,7 @@ class TestCompletion(TestBase):
                  "test_variant_split_start", "test_variant_split_mid1",
                  "test_variant_split_mid2", "test_variant_split_end", "missing_variant_requires",
                  "test_weakly_reference_requires", "test_weakly_reference_variant", 
-                 "test_prio_both_base", "test_prio_both_extra_package", "test_prio_lower_extra_package", "test_prio_higher_extra_package", "test_prio_both_base_reverse", "test_prio_both_extra_package_reverse", "test_prio_lower_extra_package_reverse", "test_prio_higher_extra_package_reverse"])
+                 "test_prio_both_base", "test_prio_both_extra_package", "test_prio_lower_extra_package", "test_prio_higher_extra_package", "test_prio_both_base_reverse", "test_prio_both_extra_package_reverse", "test_prio_lower_extra_package_reverse", "test_prio_higher_extra_package_reverse", "test_prio_both_versions_equal_extra_package"])
         _eq("py", ["pybah", "pydad", "pyfoo", "pymum", "pyodd", "pyson",
             "pysplit", "python", "pyvariants"])
         _eq("pys", ["pyson", "pysplit"])

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -63,6 +63,7 @@ ALL_PACKAGES = set([
     'test_weakly_reference_variant-2.0',
     'test_prio_both_extra_package-1.0',
     'test_prio_both_base-1.0',
+    'test_prio_both_versions_equal_extra_package-1.0',
     'test_prio_lower_extra_package-1.0',
     'test_prio_higher_extra_package-1.0',
     'test_prio_both_extra_package_reverse-1.0',

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -61,6 +61,14 @@ ALL_PACKAGES = set([
     'missing_variant_requires-1',
     'test_weakly_reference_requires-2.0',
     'test_weakly_reference_variant-2.0',
+    'test_prio_both_extra_package-1.0',
+    'test_prio_both_base-1.0',
+    'test_prio_lower_extra_package-1.0',
+    'test_prio_higher_extra_package-1.0',
+    'test_prio_both_extra_package_reverse-1.0',
+    'test_prio_both_base_reverse-1.0',
+    'test_prio_lower_extra_package_reverse-1.0',
+    'test_prio_higher_extra_package_reverse-1.0',
 ])
 
 

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -291,6 +291,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]","test_prio_lower_extra_package-1.0[1]", "nada[]"], )
         self._solve(["test_prio_lower_extra_package", "nada", "python"],
                     ["nada[]", "python-2.6.0[]","test_prio_lower_extra_package-1.0[0]"], )
+        self._solve(["test_prio_lower_extra_package", "nada"],
+                    ["nada[]", "python-2.6.0[]","test_prio_lower_extra_package-1.0[0]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_higher_extra_package"],
                     ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package-1.0[1]"], 
@@ -300,6 +303,9 @@ class TestSolver(TestBase):
                     perms_same_packages=True)
         self._solve(["test_prio_higher_extra_package", "python", "nada"],
                     ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
+        self._solve(["test_prio_higher_extra_package", "nada"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package-1.0[1]"], 
                     perms_same_packages=True)
         
         self._solve(["test_prio_both_extra_package"],
@@ -311,6 +317,9 @@ class TestSolver(TestBase):
         self._solve(["test_prio_both_extra_package", "python", "nada"],
                     ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package-1.0[1]"], 
                     perms_same_packages=True)
+        self._solve(["test_prio_both_extra_package", "nada"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_base"],
                     ["python-2.7.0[]", "test_prio_both_base-1.0[1]"], 
@@ -319,6 +328,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "test_prio_both_base-1.0[1]"], 
                     perms_same_packages=True)
         self._solve(["test_prio_both_base", "python", "nada"],
+                    ["python-2.7.0[]", "test_prio_both_base-1.0[1]", "nada[]"], 
+                    perms_same_packages=True)
+        self._solve(["test_prio_both_base", "nada"],
                     ["python-2.7.0[]", "test_prio_both_base-1.0[1]", "nada[]"], 
                     perms_same_packages=True)
         
@@ -332,6 +344,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]","test_prio_lower_extra_package_reverse-1.0[0]", "nada[]"], )
         self._solve(["test_prio_lower_extra_package_reverse", "nada", "python"],
                     ["nada[]", "python-2.6.0[]","test_prio_lower_extra_package_reverse-1.0[1]"], )
+        self._solve(["test_prio_lower_extra_package_reverse", "nada"],
+                    ["nada[]", "python-2.6.0[]","test_prio_lower_extra_package_reverse-1.0[1]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_higher_extra_package_reverse"],
                     ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package_reverse-1.0[0]"], 
@@ -341,6 +356,9 @@ class TestSolver(TestBase):
                     perms_same_packages=True)
         self._solve(["test_prio_higher_extra_package_reverse", "python", "nada"],
                     ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
+        self._solve(["test_prio_higher_extra_package_reverse", "nada"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package_reverse-1.0[0]"], 
                     perms_same_packages=True)
         
         self._solve(["test_prio_both_extra_package_reverse"],
@@ -352,6 +370,9 @@ class TestSolver(TestBase):
         self._solve(["test_prio_both_extra_package_reverse", "python", "nada"],
                     ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package_reverse-1.0[0]"], 
                     perms_same_packages=True)
+        self._solve(["test_prio_both_extra_package_reverse", "nada"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_base_reverse"],
                     ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]"], 
@@ -360,6 +381,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]"], 
                     perms_same_packages=True)
         self._solve(["test_prio_both_base_reverse", "python", "nada"],
+                    ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]", "nada[]"], 
+                    perms_same_packages=True)
+        self._solve(["test_prio_both_base_reverse", "nada"],
                     ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]", "nada[]"], 
                     perms_same_packages=True)
 
@@ -376,6 +400,9 @@ class TestSolver(TestBase):
                     ["python-2.6.0[]", "nada[]", "test_prio_lower_extra_package-1.0[0]"])
         self._solve(["python", "test_prio_lower_extra_package", "nada"],
                     ["python-2.7.0[]", "test_prio_lower_extra_package-1.0[1]", "nada[]"])
+        self._solve(["test_prio_lower_extra_package", "nada"],
+                    ["nada[]", "python-2.6.0[]", "test_prio_lower_extra_package-1.0[0]"],
+                    perms_same_packages=True)
         
         self._solve(["test_prio_higher_extra_package"],
                     ["python-2.6.0[]", "test_prio_higher_extra_package-1.0[0]"],
@@ -388,6 +415,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package-1.0[1]"])
         self._solve(["python", "test_prio_higher_extra_package", "nada"],
                     ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package-1.0[1]"])
+        self._solve(["test_prio_higher_extra_package", "nada"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package-1.0[1]"],
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_extra_package"],
                     ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package-1.0[1]"],
@@ -400,6 +430,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package-1.0[1]"])
         self._solve(["test_prio_both_extra_package", "nada", "python"],
                     ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package-1.0[1]"])
+        self._solve(["test_prio_both_extra_package", "nada"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package-1.0[1]"],
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_base"],
                     ["python-2.7.0[]", "test_prio_both_base-1.0[1]"],
@@ -412,6 +445,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "test_prio_both_base-1.0[1]", "nada[]"])
         self._solve(["python", "test_prio_both_base", "nada"],
                     ["python-2.7.0[]", "test_prio_both_base-1.0[1]", "nada[]"])
+        self._solve(["test_prio_both_base", "nada"],
+                    ["python-2.7.0[]", "test_prio_both_base-1.0[1]", "nada[]"],
+                    perms_same_packages=True)
         
         self._solve(["test_prio_lower_extra_package_reverse"],
                     ["python-2.7.0[]", "test_prio_lower_extra_package_reverse-1.0[0]"],
@@ -424,6 +460,9 @@ class TestSolver(TestBase):
                     ["python-2.6.0[]", "nada[]", "test_prio_lower_extra_package_reverse-1.0[1]"])
         self._solve(["python", "test_prio_lower_extra_package_reverse", "nada"],
                     ["python-2.7.0[]", "test_prio_lower_extra_package_reverse-1.0[0]", "nada[]"])
+        self._solve(["test_prio_lower_extra_package_reverse", "nada"],
+                    ["nada[]", "python-2.6.0[]", "test_prio_lower_extra_package_reverse-1.0[1]"],
+                    perms_same_packages=True)
         
         self._solve(["test_prio_higher_extra_package_reverse"],
                     ["python-2.6.0[]", "test_prio_higher_extra_package_reverse-1.0[1]"],
@@ -436,6 +475,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package_reverse-1.0[0]"])
         self._solve(["python", "test_prio_higher_extra_package_reverse", "nada"],
                     ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package_reverse-1.0[0]"])
+        self._solve(["test_prio_higher_extra_package_reverse", "nada"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package_reverse-1.0[0]"],
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_extra_package_reverse"],
                     ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package_reverse-1.0[0]"],
@@ -448,6 +490,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package_reverse-1.0[0]"])
         self._solve(["test_prio_both_extra_package_reverse", "nada", "python"],
                     ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package_reverse-1.0[0]"])
+        self._solve(["test_prio_both_extra_package_reverse", "nada"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package_reverse-1.0[0]"],
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_base_reverse"],
                     ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]"],
@@ -460,6 +505,9 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]", "nada[]"])
         self._solve(["python", "test_prio_both_base_reverse", "nada"],
                     ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]", "nada[]"])
+        self._solve(["test_prio_both_base_reverse", "nada"],
+                    ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]", "nada[]"],
+                    perms_same_packages=True)
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -43,7 +43,7 @@ class TestSolver(TestBase):
                        self.packages_path,
                        optimised=True,
                        verbosity=solver_verbosity)
-            s_perms.append(s)
+            s_perms.append((s, reqs_))
 
         return (s1, s2, s_perms)
 
@@ -77,7 +77,7 @@ class TestSolver(TestBase):
         self.assertEqual(resolve2, resolve)
 
         print("checking that permutations also succeed...")
-        for s in s_perms:
+        for s, s_reqs in s_perms:
             s.solve()
             self.assertEqual(s.status, SolverStatus.solved)
             if perms_same_packages:
@@ -85,7 +85,7 @@ class TestSolver(TestBase):
                     [str(x) for x in s.resolved_packages]
                     + sorted(str(x) for x in s.resolved_ephemerals)
                 )
-                self.assertEqual(set(resolve_perm), set(expected_resolve))
+                self.assertEqual(set(resolve_perm), set(expected_resolve), msg="Differing packages in resolve for request \"{}\" - {} not equal to {}".format([x.name for x in s_reqs], resolve_perm, expected_resolve))
 
         return s1
 
@@ -107,7 +107,7 @@ class TestSolver(TestBase):
         self.assertEqual(s1.failure_reason(), s2.failure_reason())
 
         print("checking that permutations also fail...")
-        for s in s_perms:
+        for s, s_reqs in s_perms:
             s.solve()
             self.assertEqual(s.status, SolverStatus.failed)
 
@@ -282,60 +282,86 @@ class TestSolver(TestBase):
     def test_15_version_priority_extra_packages(self):
         config.override("variant_select_mode", "version_priority")
         self._solve(["test_prio_lower_extra_package"],
-                    ["python-2.7.0[]", "test_prio_lower_extra_package-1.0[1]"])
+                    ["python-2.7.0[]", "test_prio_lower_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_lower_extra_package", "python"],
-                    ["python-2.7.0[]","test_prio_lower_extra_package-1.0[1]"])
+                    ["python-2.7.0[]","test_prio_lower_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_lower_extra_package", "python", "nada"],
-                    ["python-2.7.0[]","test_prio_lower_extra_package-1.0[1]", "nada[]"])
+                    ["python-2.7.0[]","test_prio_lower_extra_package-1.0[1]", "nada[]"], )
+        self._solve(["test_prio_lower_extra_package", "nada", "python"],
+                    ["nada[]", "python-2.6.0[]","test_prio_lower_extra_package-1.0[0]"], )
         
         self._solve(["test_prio_higher_extra_package"],
-                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package-1.0[1]"])
+                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_higher_extra_package", "python"],
-                    ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package-1.0[1]"])
+                    ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_higher_extra_package", "python", "nada"],
-                    ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package-1.0[1]"])
+                    ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_extra_package"],
-                    ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package-1.0[1]"])
+                    ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_both_extra_package", "python"],
-                    ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package-1.0[1]",])
+                    ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package-1.0[1]",], 
+                    perms_same_packages=True)
         self._solve(["test_prio_both_extra_package", "python", "nada"],
-                    ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package-1.0[1]"])
+                    ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_base"],
-                    ["python-2.7.0[]", "test_prio_both_base-1.0[1]"])
+                    ["python-2.7.0[]", "test_prio_both_base-1.0[1]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_both_base", "python"],
-                    ["python-2.7.0[]", "test_prio_both_base-1.0[1]"])
+                    ["python-2.7.0[]", "test_prio_both_base-1.0[1]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_both_base", "python", "nada"],
-                    ["python-2.7.0[]", "test_prio_both_base-1.0[1]", "nada[]"])
+                    ["python-2.7.0[]", "test_prio_both_base-1.0[1]", "nada[]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_lower_extra_package_reverse"],
-                    ["python-2.7.0[]", "test_prio_lower_extra_package_reverse-1.0[0]"])
+                    ["python-2.7.0[]", "test_prio_lower_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_lower_extra_package_reverse", "python"],
-                    ["python-2.7.0[]","test_prio_lower_extra_package_reverse-1.0[0]"])
+                    ["python-2.7.0[]","test_prio_lower_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_lower_extra_package_reverse", "python", "nada"],
-                    ["python-2.7.0[]","test_prio_lower_extra_package_reverse-1.0[0]", "nada[]"])
+                    ["python-2.7.0[]","test_prio_lower_extra_package_reverse-1.0[0]", "nada[]"], )
+        self._solve(["test_prio_lower_extra_package_reverse", "nada", "python"],
+                    ["nada[]", "python-2.6.0[]","test_prio_lower_extra_package_reverse-1.0[1]"], )
         
         self._solve(["test_prio_higher_extra_package_reverse"],
-                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package_reverse-1.0[0]"])
+                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_higher_extra_package_reverse", "python"],
-                    ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package_reverse-1.0[0]"])
+                    ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_higher_extra_package_reverse", "python", "nada"],
-                    ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package_reverse-1.0[0]"])
+                    ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_extra_package_reverse"],
-                    ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package_reverse-1.0[0]"])
+                    ["nada[]", "python-2.7.0[]", "test_prio_both_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_both_extra_package_reverse", "python"],
-                    ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package_reverse-1.0[0]",])
+                    ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package_reverse-1.0[0]",], 
+                    perms_same_packages=True)
         self._solve(["test_prio_both_extra_package_reverse", "python", "nada"],
-                    ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package_reverse-1.0[0]"])
+                    ["python-2.7.0[]", "nada[]", "test_prio_both_extra_package_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         
         self._solve(["test_prio_both_base_reverse"],
-                    ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]"])
+                    ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_both_base_reverse", "python"],
-                    ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]"])
+                    ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]"], 
+                    perms_same_packages=True)
         self._solve(["test_prio_both_base_reverse", "python", "nada"],
-                    ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]", "nada[]"])
+                    ["python-2.7.0[]", "test_prio_both_base_reverse-1.0[0]", "nada[]"], 
+                    perms_same_packages=True)
 
     def test_16_intersection_priority_extra_packages(self):
         config.override("variant_select_mode", "intersection_priority")

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -260,7 +260,7 @@ class TestSolver(TestBase):
             self._solve(["missing_variant_requires"], [])
 
         config.override("error_on_missing_variant_requires", False)
-        self._solve(["missing_variant_requires"], ["nada[]", "missing_variant_requires-1[1]"])
+        self._solve(["missing_variant_requires"], ["nada[]", "missing_variant_requires-1[0]"])
 
     def test_13_resolve_weakly_reference_requires(self):
         """Test resolving a package with a weakly referenced requirement."""
@@ -334,6 +334,19 @@ class TestSolver(TestBase):
                     ["python-2.7.0[]", "test_prio_both_base-1.0[1]", "nada[]"], 
                     perms_same_packages=True)
         
+        self._solve(["test_prio_both_versions_equal_extra_package"],
+                    ["python-2.6.0[]", "test_prio_both_versions_equal_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
+        self._solve(["test_prio_both_versions_equal_extra_package", "python"],
+                    ["python-2.6.0[]", "test_prio_both_versions_equal_extra_package-1.0[1]"], 
+                    perms_same_packages=True)
+        self._solve(["test_prio_both_versions_equal_extra_package", "python", "nada"],
+                    ["python-2.6.0[]", "nada[]", "test_prio_both_versions_equal_extra_package-1.0[0]"],
+                    perms_same_packages=True)
+        self._solve(["test_prio_both_versions_equal_extra_package", "nada"],
+                    ["nada[]", "python-2.6.0[]", "test_prio_both_versions_equal_extra_package-1.0[0]"], 
+                    perms_same_packages=True)
+        
         self._solve(["test_prio_lower_extra_package_reverse"],
                     ["python-2.7.0[]", "test_prio_lower_extra_package_reverse-1.0[0]"], 
                     perms_same_packages=True)
@@ -405,7 +418,7 @@ class TestSolver(TestBase):
                     perms_same_packages=True)
         
         self._solve(["test_prio_higher_extra_package"],
-                    ["python-2.6.0[]", "test_prio_higher_extra_package-1.0[0]"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package-1.0[1]"],
                     perms_same_packages=True)
         self._solve(["test_prio_higher_extra_package", "python"],
                     ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package-1.0[1]"])
@@ -465,7 +478,7 @@ class TestSolver(TestBase):
                     perms_same_packages=True)
         
         self._solve(["test_prio_higher_extra_package_reverse"],
-                    ["python-2.6.0[]", "test_prio_higher_extra_package_reverse-1.0[1]"],
+                    ["nada[]", "python-2.7.0[]", "test_prio_higher_extra_package_reverse-1.0[0]"],
                     perms_same_packages=True)
         self._solve(["test_prio_higher_extra_package_reverse", "python"],
                     ["python-2.7.0[]", "nada[]", "test_prio_higher_extra_package_reverse-1.0[0]"])


### PR DESCRIPTION
When resolving with version_priority solving, the number of additional keys is prioritised over the version number of additional keys.

This causes unexpected behaviour, especially when using package orderers.

Take the following example orderer from the docs: https://rez.readthedocs.io/en/stable/package_orderers.html#version-split
```
package_orderers = [
    {
       "type": "version_split",
       "first_version": "2.7.16",
       "packages": ["python"],
    }
]
```

If I have a package named `pipeline` with two variants, `[["python-2.7.16"], ["python-3.7.4"]]`, and I run `rez-env pipeline`, then it will correctly resolve the `python-2.7.16` variant based on the package orderer.

However, if I add another package to the variants, then we get unexepected behaviour.

1. If I change the variants to `[["python-2.7.16", "other_package"], ["python-3.7.4"]]`, and run `rez-env pipeline` then the larger number of additional keys in variant 0 causes it to be pushed down in priority, and the `python-3.7.4` variant is resolved (even though we specify that `python-2` should be prioritised). If we run `rez-env pipeline python`, then `python` is recognised as a requested key rather than an additional key, and the `python-2.7.16` variant is resolved.

2. More unexpectedly, if I change the variants to `[["python-2.7.16"], ["python-3.7.4", "other_package"]]`, and run `rez-env pipeline` then the smaller number of additional keys in variant 0 brings it back up in the priority, causing the `python-2.7.16` variant to be resolved again. 
* Even more unexpectedly, even without the custom package orderer, this same logic occurs with the above variant setup, since the smaller number of additional keys causes the `python-2.7.16` variant to be resolved over the `python-3.7.4` variant.

To continue to ensure that unnecessary extra keys are not included, but the versioning of common additional keys is correctly respected, my solution is to separate common from non-common keys across all variants, and rework the sort ordering to ensure the correct version always takes priority, then prioritise based on non-common additional keys which were identified in the request, then the lowest number of additional keys. I believe this results in more robust and deterministic logic in which we make sure we are always getting the variants that make sense and are most correct.